### PR TITLE
Remove unused forgerock-eidas-psd2-sdk-cert dependencies

### DIFF
--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -95,10 +95,6 @@
             <artifactId>brave</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.forgerock</groupId>
-            <artifactId>forgerock-eidas-psd2-cert-sdk</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
         </dependency>


### PR DESCRIPTION
- These need to be removed before the latest parent pom can be used as
the eidas-psd2 library has moved and it's groupId and artifactId have
changed, meaning this library would fail to build when dependabot
tried to update to the lastest parent pom