### PR TITLE
Fix update dynamic registration bug

### DIFF
--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApiController.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApiController.java
@@ -50,11 +50,6 @@ import dev.openbanking4.spring.security.multiauth.model.authentication.X509Authe
 import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
-import org.bouncycastle.asn1.x500.RDN;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x500.style.BCStyle;
-import org.bouncycastle.asn1.x500.style.IETFUtils;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -219,7 +214,7 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
             log.debug("SSA json payload {}", ssaJwsJson.toJSONString());
 
             verifyRegistrationRequest(registrationRequestJwtSerialised,
-                    ssaSerialised, ssaClaims, oidcRegistrationRequest, tpp.getCertificateCn());
+                    ssaClaims, oidcRegistrationRequest, tpp.getCertificateCn());
 
             Set<SoftwareStatementRole> types = tppRegistrationService.prepareRegistrationRequestWithSSA(ssaClaims, oidcRegistrationRequest, currentUser);
 
@@ -301,7 +296,7 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
                     log.debug("SSA json payload {}", ssaJwsJson.toJSONString());
 
                     verifyRegistrationRequest(registrationRequestJwtSerialised,
-                            ssaSerialised, ssaClaims, oidcRegistrationRequest, authentication.getCertificateChain());
+                            ssaClaims, oidcRegistrationRequest, getCn(authentication.getCertificateChain()[0]));
 
                     Set<SoftwareStatementRole> types = tppRegistrationService.prepareRegistrationRequestWithSSA(ssaClaims, oidcRegistrationRequest, authentication);
 
@@ -376,38 +371,11 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
 
     private void verifyRegistrationRequest(
             String registrationRequestJwtSerialised,
-            String ssaSerialised, JWTClaimsSet ssaClaims,
+            JWTClaimsSet ssaClaims,
             OIDCRegistrationRequest oidcRegistrationRequest,
-            String subject
-    ) throws OBErrorException, ParseException {
-        X500Name x500name = new X500Name(subject);
-        RDN cnRDN = x500name.getRDNs(BCStyle.CN)[0];
-        verifyRegistrationRequest(registrationRequestJwtSerialised, ssaSerialised, ssaClaims, oidcRegistrationRequest, cnRDN);
-
-    }
-
-    private void verifyRegistrationRequest(
-            String registrationRequestJwtSerialised,
-            String ssaSerialised, JWTClaimsSet ssaClaims,
-            OIDCRegistrationRequest oidcRegistrationRequest,
-            X509Certificate[] chain
-    ) throws OBErrorException, ParseException, CertificateEncodingException {
-        //Verify request
-        X500Name x500name = new JcaX509CertificateHolder(chain[0]).getSubject();
-        RDN cnRDN = x500name.getRDNs(BCStyle.CN)[0];
-
-        verifyRegistrationRequest(registrationRequestJwtSerialised, ssaSerialised, ssaClaims, oidcRegistrationRequest, cnRDN);
-    }
-
-    private void verifyRegistrationRequest(
-            String registrationRequestJwtSerialised,
-            String ssaSerialised, JWTClaimsSet ssaClaims,
-            OIDCRegistrationRequest oidcRegistrationRequest,
-            RDN cnRDN
+            String cn
     ) throws OBErrorException, ParseException {
         //Verify request
-
-        String cn = IETFUtils.valueToString(cnRDN.getFirst().getValue());
         String softwareId = ssaClaims.getStringClaim(SSAClaims.SOFTWARE_ID);
 
         tppRegistrationService.verifySSASoftwareIDAgainstTransportCert(softwareId, cn);


### PR DESCRIPTION
A parsing bug of the CN causes update of OIDC client to fail with a 500
with the stacktrace

```
java.lang.IllegalArgumentException: badly formatted directory string
	at org.bouncycastle.asn1.x500.style.IETFUtils.rDNsFromString(Unknown Source)
	at org.bouncycastle.asn1.x500.style.BCStyle.fromString(Unknown Source)
	at org.bouncycastle.asn1.x500.X500Name.<init>(Unknown Source)
	at org.bouncycastle.asn1.x500.X500Name.<init>(Unknown Source)
	at com.forgerock.openbanking.aspsp.as.api.registration.dynamic.DynamicRegistrationApiController.verifyRegistrationRequest(DynamicRegistrationApiController.java:383)
	at com.forgerock.openbanking.aspsp.as.api.registration.dynamic.DynamicRegistrationApiController.updateClient(DynamicRegistrationApiController.java:221)
```

This change fixes the parsing