### PR TITLE
Create OpenAPI specs of rs store

### DIFF
--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/README.md
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/README.md
@@ -1,0 +1,11 @@
+# RS Mock Store
+The RS mock store is an example bank integration. It's a demonstration of how to integrate the RS gateway with a bank.
+
+In our example we store and retrieve bank data from mongo. In an existing ASPSP or bank environment it's likely the RS store
+will act as a integration between the OpenBanking Toolkit and the internal bank APIs.
+
+## Getting started
+To satisfy the contract RS gateway expects you'll need to implement the integration to your bank. To make this easier
+we have a set of OpenAPI specifications that forms the contract between RS gateway and your bank integration service. We
+recommend that you use swagger-codegen to generate the server code. [generate-bank-resource-server.sh](./generate-bank-resource-server.sh) is an
+example of how you can do this using spring MVC.

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/generate-bank-resource-server.sh
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/generate-bank-resource-server.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+generate() {
+local output_dir=$1
+local spec=$2
+local language=$3
+local library=$4
+local config="${@:5}"
+  swagger-codegen generate -o ${output_dir} -i ${spec} -l ${language} --library ${library} $config
+}
+
+base_path=forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store
+output_dir=$1
+language=$2
+library=$3
+config="${@:4}"
+
+if [[ -z ${output_dir+x} || -z ${language+x} || -z ${library+x} || -z ${config+x} ]]; then
+  echo "Missing arguments"
+  echo
+  echo "output: ${output_dir}"
+  echo "language: ${language}"
+  echo "library: ${library}"
+  echo "config: ${config}"
+  echo
+  echo "Example usage:"
+  echo "    generate-bank-resource-server.sh bank-rs-store spring spring-mvc --group-id com.forgerock.openbanking -DuseBeanValidation=true -DinterfaceOnly=true"
+  exit 1
+fi
+
+generate ${output_dir} ${base_path}/internal.json ${language} ${library} "--model-package com.forgerock.rs.store.models.internal --api-package=com.forgerock.rs.store.apis.internal ${config}"
+generate ${output_dir} ${base_path}/openbanking-v1.1.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v1_0 --api-package=com.forgerock.rs.store.apis.v1_0 ${config}"
+generate ${output_dir} ${base_path}/openbanking-v2.0.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v2_0 --api-package=com.forgerock.rs.store.apis.v2_0 ${config}"
+generate ${output_dir} ${base_path}/openbanking-v3.0.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v3_0 --api-package=com.forgerock.rs.store.apis.v3_0 ${config}"
+generate ${output_dir} ${base_path}/openbanking-v3.1.1.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v3.1.1 --api-package=com.forgerock.rs.store.apis.v3_1_1 ${config}"
+generate ${output_dir} ${base_path}/openbanking-v3.1.2.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v3_1_2 --api-package=com.forgerock.rs.store.apis.v3_1_2 ${config}"
+generate ${output_dir} ${base_path}/openbanking-v3.1.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v3_1 --api-package=com.forgerock.rs.store.apis.v3_1 ${config}"

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/generate-bank-resource-server.sh
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/generate-bank-resource-server.sh
@@ -30,6 +30,7 @@ if [[ -z ${output_dir+x} || -z ${language+x} || -z ${library+x} || -z ${config+x
 fi
 
 generate ${output_dir} ${base_path}/internal.json ${language} ${library} "--model-package com.forgerock.rs.store.models.internal --api-package=com.forgerock.rs.store.apis.internal ${config}"
+generate ${output_dir} ${base_path}/internal-account-payments.json ${language} ${library} "--model-package com.forgerock.rs.store.models.internal --api-package=com.forgerock.rs.store.apis.internal ${config}"
 generate ${output_dir} ${base_path}/openbanking-v1.1.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v1_0 --api-package=com.forgerock.rs.store.apis.v1_0 ${config}"
 generate ${output_dir} ${base_path}/openbanking-v2.0.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v2_0 --api-package=com.forgerock.rs.store.apis.v2_0 ${config}"
 generate ${output_dir} ${base_path}/openbanking-v3.0.json ${language} ${library} "--model-package com.forgerock.rs.store.models.v3_0 --api-package=com.forgerock.rs.store.apis.v3_0 ${config}"

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/internal-account-payments.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/internal-account-payments.json
@@ -1,0 +1,16723 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/api/accounts",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/scheduled-payments/": {
+      "post": {
+        "tags": [
+          "scheduled-payment-api-controller"
+        ],
+        "summary": "create",
+        "operationId": "createUsingPOST_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "scheduledPayment",
+            "description": "scheduledPayment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRScheduledPayment2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRScheduledPayment2"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/scheduled-payments/search/find": {
+      "get": {
+        "tags": [
+          "scheduled-payment-api-controller"
+        ],
+        "summary": "getAll",
+        "operationId": "getAllUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "COMPLETED",
+              "REJECTED"
+            ]
+          },
+          {
+            "name": "toDateTime",
+            "in": "query",
+            "description": "toDateTime",
+            "required": true,
+            "type": "string",
+            "format": "date-time"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRScheduledPayment2"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/scheduled-payments/{id}": {
+      "put": {
+        "tags": [
+          "scheduled-payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_9",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "scheduledPayment",
+            "description": "scheduledPayment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRScheduledPayment2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/standing-orders/": {
+      "post": {
+        "tags": [
+          "standing-order-api-controller"
+        ],
+        "summary": "create",
+        "operationId": "createUsingPOST_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "standingOrder",
+            "description": "standingOrder",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRStandingOrder5"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRStandingOrder5"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/standing-orders/search/active": {
+      "get": {
+        "tags": [
+          "standing-order-api-controller"
+        ],
+        "summary": "getActive",
+        "operationId": "getActiveUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRStandingOrder5"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/standing-orders/{id}": {
+      "put": {
+        "tags": [
+          "standing-order-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_10",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "standingOrder",
+            "description": "standingOrder",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRStandingOrder5"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/internal.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/internal.json
@@ -1,0 +1,18982 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/api",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/account-access-consents/": {
+      "put": {
+        "tags": [
+          "account-access-consent-api-controller"
+        ],
+        "summary": "save",
+        "operationId": "saveUsingPUT",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "accountAccessConsent1",
+            "description": "accountAccessConsent1",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRAccountAccessConsent1"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRAccountAccessConsent1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/account-access-consents/{consentId}": {
+      "get": {
+        "tags": [
+          "account-access-consent-api-controller"
+        ],
+        "summary": "read",
+        "operationId": "readUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "consentId",
+            "in": "path",
+            "description": "consentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/account-requests/": {
+      "put": {
+        "tags": [
+          "account-request-api-controller"
+        ],
+        "summary": "save",
+        "operationId": "saveUsingPUT_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "accountRequest1",
+            "description": "accountRequest1",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRAccountRequest1"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRAccountRequest1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/account-requests/{accountRequestId}": {
+      "get": {
+        "tags": [
+          "account-request-api-controller"
+        ],
+        "summary": "read",
+        "operationId": "readUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "accountRequestId",
+            "in": "path",
+            "description": "accountRequestId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/permissions/{accountId}": {
+      "get": {
+        "tags": [
+          "accounts-api-controller"
+        ],
+        "summary": "findByAccountId",
+        "operationId": "findByAccountIdUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "description": "accountId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "permissions",
+            "in": "query",
+            "description": "permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRAccount3"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/scheduled-payments/": {
+      "post": {
+        "tags": [
+          "scheduled-payment-api-controller"
+        ],
+        "summary": "create",
+        "operationId": "createUsingPOST_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "scheduledPayment",
+            "description": "scheduledPayment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRScheduledPayment2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRScheduledPayment2"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/scheduled-payments/search/find": {
+      "get": {
+        "tags": [
+          "scheduled-payment-api-controller"
+        ],
+        "summary": "getAll",
+        "operationId": "getAllUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "COMPLETED",
+              "REJECTED"
+            ]
+          },
+          {
+            "name": "toDateTime",
+            "in": "query",
+            "description": "toDateTime",
+            "required": true,
+            "type": "string",
+            "format": "date-time"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRScheduledPayment2"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/scheduled-payments/{id}": {
+      "put": {
+        "tags": [
+          "scheduled-payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_9",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "scheduledPayment",
+            "description": "scheduledPayment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRScheduledPayment2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/search/findByIdentification": {
+      "get": {
+        "tags": [
+          "accounts-api-controller"
+        ],
+        "summary": "findByIdentification",
+        "operationId": "findByIdentificationUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "identification",
+            "in": "query",
+            "description": "identification",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Optional«FRAccount3»"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/search/findByUserId": {
+      "get": {
+        "tags": [
+          "accounts-api-controller"
+        ],
+        "summary": "getAccounts",
+        "operationId": "getAccountsUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "userId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "withBalance",
+            "in": "query",
+            "description": "withBalance",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRAccountWithBalance"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/standing-orders/": {
+      "post": {
+        "tags": [
+          "standing-order-api-controller"
+        ],
+        "summary": "create",
+        "operationId": "createUsingPOST_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "standingOrder",
+            "description": "standingOrder",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRStandingOrder5"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRStandingOrder5"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/standing-orders/search/active": {
+      "get": {
+        "tags": [
+          "standing-order-api-controller"
+        ],
+        "summary": "getActive",
+        "operationId": "getActiveUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRStandingOrder5"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/standing-orders/{id}": {
+      "put": {
+        "tags": [
+          "standing-order-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_10",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "standingOrder",
+            "description": "standingOrder",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRStandingOrder5"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/accounts/{accountId}": {
+      "get": {
+        "tags": [
+          "accounts-api-controller"
+        ],
+        "summary": "getAccount",
+        "operationId": "getAccountUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "description": "accountId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRAccount3"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/aggregated-polling": {
+      "post": {
+        "tags": [
+          "internal-aggregated-polling-api-controller"
+        ],
+        "summary": "create",
+        "operationId": "createUsingPOST",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "eventNotification",
+            "description": "eventNotification",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FREventNotification"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FREventNotification"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/balances/": {
+      "put": {
+        "tags": [
+          "balance-api-controller"
+        ],
+        "summary": "save",
+        "operationId": "saveUsingPUT_2",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "balance1",
+            "description": "balance1",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRBalance1"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/balances/search/findByAccountId": {
+      "get": {
+        "tags": [
+          "balance-api-controller"
+        ],
+        "summary": "findByAcountId",
+        "operationId": "findByAcountIdUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "query",
+            "description": "accountId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "type",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "ClosingAvailable",
+              "ClosingBooked",
+              "ClosingCleared",
+              "Expected",
+              "ForwardAvailable",
+              "Information",
+              "InterimAvailable",
+              "InterimBooked",
+              "InterimCleared",
+              "OpeningAvailable",
+              "OpeningBooked",
+              "OpeningCleared",
+              "PreviouslyClosedBooked"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Optional«FRBalance1»"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/callback-urls/search/findByTppId": {
+      "get": {
+        "tags": [
+          "callback-url-api-controller"
+        ],
+        "summary": "findByTppId",
+        "operationId": "findByTppIdUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "tppId",
+            "in": "query",
+            "description": "tppId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRCallbackUrl1"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/data/account": {
+      "get": {
+        "tags": [
+          "data-api-controller"
+        ],
+        "summary": "exportAccountData",
+        "operationId": "exportAccountDataUsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "paged",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "sort.sorted",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "sort.unsorted",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "unpaged",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Page«FRAccountData4»"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/data/user": {
+      "get": {
+        "tags": [
+          "data-api-controller"
+        ],
+        "summary": "exportUserData",
+        "operationId": "exportUserDataUsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "userId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRUserData4"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "data-api-controller"
+        ],
+        "summary": "importUserData",
+        "operationId": "importUserDataUsingPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "userData",
+            "description": "userData",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRUserData4"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "data-api-controller"
+        ],
+        "summary": "updateUserData",
+        "operationId": "updateUserDataUsingPUT",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "userData",
+            "description": "userData",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRUserData4"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "data-api-controller"
+        ],
+        "summary": "deleteUserData",
+        "operationId": "deleteUserDataUsingDELETE",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "userId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/data/user/has-data": {
+      "get": {
+        "tags": [
+          "data-api-controller"
+        ],
+        "summary": "hasData",
+        "operationId": "hasDataUsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "userId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-payments/": {
+      "put": {
+        "tags": [
+          "domestic-payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRDomesticConsent2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRDomesticConsent2"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-payments/search/findByStatus": {
+      "get": {
+        "tags": [
+          "domestic-payment-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "AUTHORISED",
+              "AWAITINGAUTHORISATION",
+              "CONSUMED",
+              "REJECTED",
+              "ACCEPTEDCUSTOMERPROFILE",
+              "ACCEPTEDSETTLEMENTCOMPLETED",
+              "ACCEPTEDSETTLEMENTINPROCESS",
+              "ACCEPTEDTECHNICALVALIDATION",
+              "PENDING",
+              "REVOKED",
+              "AWAITINGUPLOAD"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRDomesticConsent2"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-payments/{paymentId}": {
+      "get": {
+        "tags": [
+          "domestic-payment-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-scheduled-payments/": {
+      "put": {
+        "tags": [
+          "domestic-scheduled-payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRDomesticScheduledConsent2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRDomesticScheduledConsent2"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-scheduled-payments/search/findByStatus": {
+      "get": {
+        "tags": [
+          "domestic-scheduled-payment-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "AUTHORISED",
+              "AWAITINGAUTHORISATION",
+              "CONSUMED",
+              "REJECTED",
+              "ACCEPTEDCUSTOMERPROFILE",
+              "ACCEPTEDSETTLEMENTCOMPLETED",
+              "ACCEPTEDSETTLEMENTINPROCESS",
+              "ACCEPTEDTECHNICALVALIDATION",
+              "PENDING",
+              "REVOKED",
+              "AWAITINGUPLOAD"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRDomesticScheduledConsent2"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-scheduled-payments/{paymentId}": {
+      "get": {
+        "tags": [
+          "domestic-scheduled-payment-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-standing-orders/": {
+      "put": {
+        "tags": [
+          "domestic-standing-order-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_2",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRDomesticStandingOrderConsent3"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRDomesticStandingOrderConsent3"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-standing-orders/search/findByStatus": {
+      "get": {
+        "tags": [
+          "domestic-standing-order-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "AUTHORISED",
+              "AWAITINGAUTHORISATION",
+              "CONSUMED",
+              "REJECTED",
+              "ACCEPTEDCUSTOMERPROFILE",
+              "ACCEPTEDSETTLEMENTCOMPLETED",
+              "ACCEPTEDSETTLEMENTINPROCESS",
+              "ACCEPTEDTECHNICALVALIDATION",
+              "PENDING",
+              "REVOKED",
+              "AWAITINGUPLOAD"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRDomesticStandingOrderConsent3"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/domestic-standing-orders/{paymentId}": {
+      "get": {
+        "tags": [
+          "domestic-standing-order-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/event-subscriptions/search/findByTppId": {
+      "get": {
+        "tags": [
+          "event-subscription-api-controller"
+        ],
+        "summary": "findByTppId",
+        "operationId": "findByTppIdUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "tppId",
+            "in": "query",
+            "description": "tppId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FREventSubscription1"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/fake-data/generate": {
+      "post": {
+        "tags": [
+          "fake-data-api-controller"
+        ],
+        "summary": "generateFakeData",
+        "operationId": "generateFakeDataUsingPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "profile",
+            "in": "query",
+            "description": "profile",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "userId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "username",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/file-payments/": {
+      "put": {
+        "tags": [
+          "file-payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_3",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRFileConsent2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRFileConsent2"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/file-payments/search/findByStatus": {
+      "get": {
+        "tags": [
+          "file-payment-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "AUTHORISED",
+              "AWAITINGAUTHORISATION",
+              "CONSUMED",
+              "REJECTED",
+              "ACCEPTEDCUSTOMERPROFILE",
+              "ACCEPTEDSETTLEMENTCOMPLETED",
+              "ACCEPTEDSETTLEMENTINPROCESS",
+              "ACCEPTEDTECHNICALVALIDATION",
+              "PENDING",
+              "REVOKED",
+              "AWAITINGUPLOAD"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRFileConsent2"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/file-payments/{paymentId}": {
+      "get": {
+        "tags": [
+          "file-payment-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/funds-confirmations/": {
+      "put": {
+        "tags": [
+          "funds-confirmation-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_4",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "consent",
+            "description": "consent",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRFundsConfirmationConsent1"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRFundsConfirmationConsent1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/funds-confirmations/search/findByStatus": {
+      "get": {
+        "tags": [
+          "funds-confirmation-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRFundsConfirmationConsent1"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/funds-confirmations/{id}": {
+      "get": {
+        "tags": [
+          "funds-confirmation-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-payments/": {
+      "put": {
+        "tags": [
+          "international-payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_5",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRInternationalConsent2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRInternationalConsent2"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-payments/search/findByStatus": {
+      "get": {
+        "tags": [
+          "international-payment-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "AUTHORISED",
+              "AWAITINGAUTHORISATION",
+              "CONSUMED",
+              "REJECTED",
+              "ACCEPTEDCUSTOMERPROFILE",
+              "ACCEPTEDSETTLEMENTCOMPLETED",
+              "ACCEPTEDSETTLEMENTINPROCESS",
+              "ACCEPTEDTECHNICALVALIDATION",
+              "PENDING",
+              "REVOKED",
+              "AWAITINGUPLOAD"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRInternationalConsent2"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-payments/{paymentId}": {
+      "get": {
+        "tags": [
+          "international-payment-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-scheduled-payments/": {
+      "put": {
+        "tags": [
+          "international-scheduled-payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_6",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRInternationalScheduledConsent2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRInternationalScheduledConsent2"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-scheduled-payments/search/findByStatus": {
+      "get": {
+        "tags": [
+          "international-scheduled-payment-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_6",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRInternationalScheduledConsent2"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-scheduled-payments/{paymentId}": {
+      "get": {
+        "tags": [
+          "international-scheduled-payment-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_6",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-standing-orders/": {
+      "put": {
+        "tags": [
+          "international-standing-order-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_7",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRInternationalStandingOrderConsent3"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRInternationalStandingOrderConsent3"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-standing-orders/search/findByStatus": {
+      "get": {
+        "tags": [
+          "international-standing-order-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_7",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "AUTHORISED",
+              "AWAITINGAUTHORISATION",
+              "CONSUMED",
+              "REJECTED",
+              "ACCEPTEDCUSTOMERPROFILE",
+              "ACCEPTEDSETTLEMENTCOMPLETED",
+              "ACCEPTEDSETTLEMENTINPROCESS",
+              "ACCEPTEDTECHNICALVALIDATION",
+              "PENDING",
+              "REVOKED",
+              "AWAITINGUPLOAD"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRInternationalStandingOrderConsent3"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/international-standing-orders/{paymentId}": {
+      "get": {
+        "tags": [
+          "international-standing-order-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_7",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/payments/": {
+      "put": {
+        "tags": [
+          "payment-api-controller"
+        ],
+        "summary": "update",
+        "operationId": "updateUsingPUT_8",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "paymentSetup",
+            "description": "paymentSetup",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRPaymentSetup1"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRPaymentSetup1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/payments/search/findByStatus": {
+      "get": {
+        "tags": [
+          "payment-api-controller"
+        ],
+        "summary": "findByStatus",
+        "operationId": "findByStatusUsingGET_8",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "status",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "AUTHORISED",
+              "AWAITINGAUTHORISATION",
+              "CONSUMED",
+              "REJECTED",
+              "ACCEPTEDCUSTOMERPROFILE",
+              "ACCEPTEDSETTLEMENTCOMPLETED",
+              "ACCEPTEDSETTLEMENTINPROCESS",
+              "ACCEPTEDTECHNICALVALIDATION",
+              "PENDING",
+              "REVOKED",
+              "AWAITINGUPLOAD"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FRPaymentSetup1"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/payments/{paymentId}": {
+      "get": {
+        "tags": [
+          "payment-api-controller"
+        ],
+        "summary": "get",
+        "operationId": "getUsingGET_8",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "paymentId",
+            "in": "path",
+            "description": "paymentId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/statements/{statementId}": {
+      "get": {
+        "tags": [
+          "statement-api-controller"
+        ],
+        "summary": "getStatement",
+        "operationId": "getStatementUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "statementId",
+            "in": "path",
+            "description": "statementId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/transactions/": {
+      "post": {
+        "tags": [
+          "transaction-api-controller"
+        ],
+        "summary": "create",
+        "operationId": "createUsingPOST_3",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "transaction",
+            "description": "transaction",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FRTransaction5"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FRTransaction5"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v1.1.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v1.1.json
@@ -1,0 +1,19810 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/open-banking/v1.1",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/account-requests": {
+      "post": {
+        "tags": [
+          "v1.1-AccountRequests"
+        ],
+        "summary": "Create an account request",
+        "description": "Create an account request",
+        "operationId": "createAccountRequestUsingPOST",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Create an Account Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBReadRequest1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-aisp_id",
+            "in": "header",
+            "description": "The AISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "201": {
+            "description": "FRAccount1 Request resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/account-requests/{AccountRequestId}": {
+      "get": {
+        "tags": [
+          "v1.1-AccountRequests"
+        ],
+        "summary": "Get an account request",
+        "description": "Get an account request",
+        "operationId": "getAccountRequestUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountRequestId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Request resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "v1.1-AccountRequests"
+        ],
+        "summary": "Delete an account request",
+        "description": "Delete an account request",
+        "operationId": "deleteAccountRequestUsingDELETE",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountRequestId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "Account Request resource successfully deleted",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts": {
+      "get": {
+        "tags": [
+          "v1.1-Accounts"
+        ],
+        "summary": "Get Accounts",
+        "description": "Get a list of accounts",
+        "operationId": "getAccountsUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accounts successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}": {
+      "get": {
+        "tags": [
+          "v1.1-Accounts"
+        ],
+        "summary": "Get Account",
+        "description": "Get an account",
+        "operationId": "getAccountUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/balances": {
+      "get": {
+        "tags": [
+          "v1.1-Balances"
+        ],
+        "summary": "Get Account Balances",
+        "description": "Get Balances related to an account",
+        "operationId": "getAccountBalancesUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/beneficiaries": {
+      "get": {
+        "tags": [
+          "v1.1-Beneficiaries"
+        ],
+        "summary": "Get Account Beneficiaries",
+        "description": "Get Beneficiaries related to an account",
+        "operationId": "getAccountBeneficiariesUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries  successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/direct-debits": {
+      "get": {
+        "tags": [
+          "v1.1-Direct-Debits"
+        ],
+        "summary": "Get Account Direct Debits",
+        "description": "Get Direct Debits related to an account",
+        "operationId": "getAccountDirectDebitsUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/product": {
+      "get": {
+        "tags": [
+          "v1.1-Products"
+        ],
+        "summary": "Get Account Product",
+        "description": "Get Product related to an account",
+        "operationId": "getAccountProductUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Product successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/standing-orders": {
+      "get": {
+        "tags": [
+          "v1.1-Standing-Orders"
+        ],
+        "summary": "Get Account Standing Orders",
+        "description": "Get Standing Orders related to an account",
+        "operationId": "getAccountStandingOrdersUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/transactions": {
+      "get": {
+        "tags": [
+          "v1.1-Transactions"
+        ],
+        "summary": "Get Account Transactions",
+        "description": "Get transactions related to an account",
+        "operationId": "getAccountTransactionsUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/balances": {
+      "get": {
+        "tags": [
+          "v1.1-Balances"
+        ],
+        "summary": "Get Balances",
+        "description": "Get Balances",
+        "operationId": "getBalancesUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balances successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/beneficiaries": {
+      "get": {
+        "tags": [
+          "v1.1-Beneficiaries"
+        ],
+        "summary": "Get Beneficiaries",
+        "description": "Get Beneficiaries",
+        "operationId": "getBeneficiariesUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/direct-debits": {
+      "get": {
+        "tags": [
+          "v1.1-Direct-Debits"
+        ],
+        "summary": "Get Direct Debits",
+        "description": "Get Direct Debits",
+        "operationId": "getDirectDebitsUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payment-submissions": {
+      "post": {
+        "tags": [
+          "v1.1-Payments"
+        ],
+        "summary": "Create a payment submission",
+        "description": "Submit a previously setup payment",
+        "operationId": "createPaymentSubmissionUsingPOST_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "paymentSubmission",
+            "description": "Setup a single immediate payment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmission1"
+            }
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key. The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-payment-id",
+            "in": "header",
+            "description": "The payment ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmissionResponse1"
+            }
+          },
+          "201": {
+            "description": "Payment submit resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmissionResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payment-submissions/{PaymentSubmissionId}": {
+      "get": {
+        "tags": [
+          "v1.1-Payments"
+        ],
+        "summary": "Get a payment submission",
+        "description": "Get payment submission",
+        "operationId": "getPaymentSubmissionUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "PaymentSubmissionId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmissionResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          },
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payments": {
+      "post": {
+        "tags": [
+          "v1.1-Payments"
+        ],
+        "summary": "Create a single immediate payment",
+        "description": "Create a single immediate payment",
+        "operationId": "createSingleImmediatePaymentUsingPOST_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "paymentSetupPOSTRequest",
+            "description": "Setup a single immediate payment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetup1"
+            }
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetupResponse1"
+            }
+          },
+          "201": {
+            "description": "Payment setup resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetupResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payments/{PaymentId}": {
+      "get": {
+        "tags": [
+          "v1.1-Payments"
+        ],
+        "summary": "Get a single immediate payment",
+        "description": "Get a single immediate payment",
+        "operationId": "getSingleImmediatePaymentUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "PaymentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetupResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          },
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/products": {
+      "get": {
+        "tags": [
+          "v1.1-Products"
+        ],
+        "summary": "Get Products",
+        "description": "Get Products",
+        "operationId": "getProductsUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Products successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/standing-orders": {
+      "get": {
+        "tags": [
+          "v1.1-Standing-Orders"
+        ],
+        "summary": "Get Standing Orders",
+        "description": "Get Standing Orders",
+        "operationId": "getStandingOrdersUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/transactions": {
+      "get": {
+        "tags": [
+          "v1.1-Transactions"
+        ],
+        "summary": "Get Transactions",
+        "description": "Get Transactions",
+        "operationId": "getTransactionsUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v2.0.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v2.0.json
@@ -1,0 +1,21793 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/open-banking/v2.0",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/account-requests": {
+      "post": {
+        "tags": [
+          "v2.0-Account-Requests"
+        ],
+        "summary": "Create an account request",
+        "description": "Create an account request",
+        "operationId": "createAccountRequestUsingPOST_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Create an Account Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBReadRequest1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-aisp_id",
+            "in": "header",
+            "description": "The AISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "201": {
+            "description": "FRAccount1 Request resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/account-requests/{AccountRequestId}": {
+      "get": {
+        "tags": [
+          "v2.0-Account-Requests"
+        ],
+        "summary": "Get an account request",
+        "description": "Get an account request",
+        "operationId": "getAccountRequestUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountRequestId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Request resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "v2.0-Account-Requests"
+        ],
+        "summary": "Delete an account request",
+        "description": "Delete an account request",
+        "operationId": "deleteAccountRequestUsingDELETE_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountRequestId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "Account Request resource successfully deleted"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts": {
+      "get": {
+        "tags": [
+          "v2.0-Accounts"
+        ],
+        "summary": "Get Accounts",
+        "description": "Get a list of accounts",
+        "operationId": "getAccountsUsingGET_6",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "string",
+            "default": "0",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accounts successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}": {
+      "get": {
+        "tags": [
+          "v2.0-Accounts"
+        ],
+        "summary": "Get Account",
+        "description": "Get an account",
+        "operationId": "getAccountUsingGET_6",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/balances": {
+      "get": {
+        "tags": [
+          "v1.1-Balances",
+          "v2.0-Balances"
+        ],
+        "summary": "Get Account Balances",
+        "description": "Get Balances related to an account",
+        "operationId": "getAccountBalancesUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/beneficiaries": {
+      "get": {
+        "tags": [
+          "v2.0-Beneficiaries"
+        ],
+        "summary": "Get Account Beneficiaries",
+        "description": "Get Beneficiaries related to an account",
+        "operationId": "getAccountBeneficiariesUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries  successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/direct-debits": {
+      "get": {
+        "tags": [
+          "v1.1-Direct-Debits",
+          "v2.0-Direct-Debits"
+        ],
+        "summary": "Get Account Direct Debits",
+        "description": "Get Direct Debits related to an account",
+        "operationId": "getAccountDirectDebitsUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/offers": {
+      "get": {
+        "tags": [
+          "v2.0-Offers"
+        ],
+        "summary": "Get Account Offers",
+        "description": "Get Offers related to an account",
+        "operationId": "getAccountOffers_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/party": {
+      "get": {
+        "tags": [
+          "v2.0-Party"
+        ],
+        "summary": "Get Account Party",
+        "description": "Get Party related to an account",
+        "operationId": "getAccountParty_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/product": {
+      "get": {
+        "tags": [
+          "v2.0-Products"
+        ],
+        "summary": "Get Account Product",
+        "description": "Get Product related to an account",
+        "operationId": "getAccountProductUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Product successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v2.0-Scheduled-Payments"
+        ],
+        "summary": "Get Account Scheduled Payments",
+        "description": "Get Scheduled Payments related to an account",
+        "operationId": "getAccountScheduledPayments_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/standing-orders": {
+      "get": {
+        "tags": [
+          "v2.0-Standing-Orders"
+        ],
+        "summary": "Get Account Standing Orders",
+        "description": "Get Standing Orders related to an account",
+        "operationId": "getAccountStandingOrdersUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/statements": {
+      "get": {
+        "tags": [
+          "v2.0-Statements"
+        ],
+        "summary": "Get Account Statements",
+        "description": "Get Statements related to an account",
+        "operationId": "getAccountStatements",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/statements/{StatementId}": {
+      "get": {
+        "tags": [
+          "v2.0-Statements"
+        ],
+        "summary": "Get Statement",
+        "description": "Get Statement related to an account",
+        "operationId": "getAccountStatement",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/statements/{StatementId}/file": {
+      "get": {
+        "tags": [
+          "v2.0-Statements"
+        ],
+        "summary": "Get Statement File",
+        "description": "Get Statement File related to an account",
+        "operationId": "getAccountStatementFile",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP accept header. Statements only implemented for certain media types.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement File successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/statements/{StatementId}/transactions": {
+      "get": {
+        "tags": [
+          "v2.0-Transactions"
+        ],
+        "summary": "Get Statement Transactions",
+        "description": "Get Statement Transactions related to an account",
+        "operationId": "getAccountStatementTransactions_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/accounts/{AccountId}/transactions": {
+      "get": {
+        "tags": [
+          "v2.0-Transactions"
+        ],
+        "summary": "Get Account Transactions",
+        "description": "Get transactions related to an account",
+        "operationId": "getAccountTransactionsUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/balances": {
+      "get": {
+        "tags": [
+          "v2.0-Balances"
+        ],
+        "summary": "Get Balances",
+        "description": "Get Balances",
+        "operationId": "getBalancesUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balances successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/beneficiaries": {
+      "get": {
+        "tags": [
+          "v2.0-Beneficiaries"
+        ],
+        "summary": "Get Beneficiaries",
+        "description": "Get Beneficiaries",
+        "operationId": "getBeneficiariesUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/direct-debits": {
+      "get": {
+        "tags": [
+          "v2.0-Direct-Debits"
+        ],
+        "summary": "Get Direct Debits",
+        "description": "Get Direct Debits",
+        "operationId": "getDirectDebitsUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/offers": {
+      "get": {
+        "tags": [
+          "v2.0-Offers"
+        ],
+        "summary": "Get Offers",
+        "description": "Get Offers",
+        "operationId": "getOffers_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/party": {
+      "get": {
+        "tags": [
+          "v2.0-Party"
+        ],
+        "summary": "Get Party",
+        "description": "Get Party",
+        "operationId": "getParty_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-user-id",
+            "in": "header",
+            "description": "The OB user ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payment-submissions": {
+      "post": {
+        "tags": [
+          "v2.0-Payments"
+        ],
+        "summary": "Create a payment submission",
+        "description": "Submit a previously setup payment",
+        "operationId": "createPaymentSubmissionUsingPOST",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "paymentSubmission",
+            "description": "Setup a single immediate payment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmission1"
+            }
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key. The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-payment-id",
+            "in": "header",
+            "description": "The payment ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmissionResponse1"
+            }
+          },
+          "201": {
+            "description": "Payment submit resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmissionResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payment-submissions/{PaymentSubmissionId}": {
+      "get": {
+        "tags": [
+          "v2.0-Payments"
+        ],
+        "summary": "Get a payment submission",
+        "description": "Get payment submission",
+        "operationId": "getPaymentSubmissionUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "PaymentSubmissionId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSubmissionResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          },
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payments": {
+      "post": {
+        "tags": [
+          "v2.0-Payments"
+        ],
+        "summary": "Create a single immediate payment",
+        "description": "Create a single immediate payment",
+        "operationId": "createSingleImmediatePaymentUsingPOST",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "paymentSetupPOSTRequest",
+            "description": "Setup a single immediate payment",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetup1"
+            }
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetupResponse1"
+            }
+          },
+          "201": {
+            "description": "Payment setup resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetupResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/payments/{PaymentId}": {
+      "get": {
+        "tags": [
+          "v2.0-Payments"
+        ],
+        "summary": "Get a single immediate payment",
+        "description": "Get a single immediate payment",
+        "operationId": "getSingleImmediatePaymentUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "PaymentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBPaymentSetupResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          },
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/products": {
+      "get": {
+        "tags": [
+          "v2.0-Products"
+        ],
+        "summary": "Get Products",
+        "description": "Get Products",
+        "operationId": "getProductsUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Products successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v2.0-Scheduled-Payments"
+        ],
+        "summary": "Get Scheduled Payments",
+        "description": "Get Scheduled Payments",
+        "operationId": "getScheduledPayments_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/standing-orders": {
+      "get": {
+        "tags": [
+          "v2.0-Standing-Orders"
+        ],
+        "summary": "Get Standing Orders",
+        "description": "Get Standing Orders",
+        "operationId": "getStandingOrdersUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/statements": {
+      "get": {
+        "tags": [
+          "v2.0-Statements"
+        ],
+        "summary": "Get Statements",
+        "description": "Get Statements",
+        "operationId": "getStatements",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/transactions": {
+      "get": {
+        "tags": [
+          "v2.0-Transactions"
+        ],
+        "summary": "Get Transactions",
+        "description": "Get Transactions",
+        "operationId": "getTransactionsUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.0.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.0.json
@@ -1,0 +1,26480 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/open-banking/v3.0",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/aisp/account-access-consents": {
+      "post": {
+        "tags": [
+          "v3.0-AccountRequests"
+        ],
+        "summary": "Create an account access consent",
+        "description": "Create an account access consent",
+        "operationId": "createAccountAccessConsentUsingPOST_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Create an Account Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBReadRequest1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-aisp_id",
+            "in": "header",
+            "description": "The AISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "201": {
+            "description": "FRAccount1 Request resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/account-access-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "v3.0-AccountRequests"
+        ],
+        "summary": "Get an account access consent",
+        "description": "Get an account access consent",
+        "operationId": "getAccountConsentUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the Account access consent resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Access Consent resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "v3.0-AccountRequests"
+        ],
+        "summary": "Delete an account access consent",
+        "description": "Delete an account access consent",
+        "operationId": "deleteAccountConsentUsingDELETE_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "Account Access Consent resource successfully deleted",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts": {
+      "get": {
+        "tags": [
+          "v3.0-Accounts"
+        ],
+        "summary": "Get Accounts",
+        "description": "Get a list of accounts",
+        "operationId": "getAccountsUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "string",
+            "default": "0",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accounts successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}": {
+      "get": {
+        "tags": [
+          "v3.0-Accounts"
+        ],
+        "summary": "Get Account",
+        "description": "Get an account",
+        "operationId": "getAccountUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/balances": {
+      "get": {
+        "tags": [
+          "v1.1-Balances",
+          "v3.0-Balances"
+        ],
+        "summary": "Get Account Balances",
+        "description": "Get Balances related to an account",
+        "operationId": "getAccountBalancesUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.0-Beneficiaries"
+        ],
+        "summary": "Get Account Beneficiaries",
+        "description": "Get Beneficiaries related to an account",
+        "operationId": "getAccountBeneficiariesUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries  successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/direct-debits": {
+      "get": {
+        "tags": [
+          "v1.1-Direct-Debits",
+          "v3.0-Direct-Debits"
+        ],
+        "summary": "Get Account Direct Debits",
+        "description": "Get Direct Debits related to an account",
+        "operationId": "getAccountDirectDebitsUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/offers": {
+      "get": {
+        "tags": [
+          "v3.0-Offers"
+        ],
+        "summary": "Get Account Offers",
+        "description": "Get Offers related to an account",
+        "operationId": "getAccountOffers_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/party": {
+      "get": {
+        "tags": [
+          "v3.0-Party"
+        ],
+        "summary": "Get Account Party",
+        "description": "Get Party related to an account",
+        "operationId": "getAccountParty_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/product": {
+      "get": {
+        "tags": [
+          "v3.0-Products"
+        ],
+        "summary": "Get Account Product",
+        "description": "Get Product related to an account",
+        "operationId": "getAccountProductUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Product successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.0-Scheduled-Payments"
+        ],
+        "summary": "Get Account Scheduled Payments",
+        "description": "Get Scheduled Payments related to an account",
+        "operationId": "getAccountScheduledPayments_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.0-Standing-Orders"
+        ],
+        "summary": "Get Account Standing Orders",
+        "description": "Get Standing Orders related to an account",
+        "operationId": "getAccountStandingOrdersUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements": {
+      "get": {
+        "tags": [
+          "v3.0-Statements"
+        ],
+        "summary": "Get Account Statements",
+        "description": "Get Statements related to an account",
+        "operationId": "getAccountStatements_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}": {
+      "get": {
+        "tags": [
+          "v3.0-Statements"
+        ],
+        "summary": "Get Statement",
+        "description": "Get Statement related to an account",
+        "operationId": "getAccountStatement_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/file": {
+      "get": {
+        "tags": [
+          "v3.0-Statements"
+        ],
+        "summary": "Get Statement File",
+        "description": "Get Statement File related to an account",
+        "operationId": "getAccountStatementFile_3",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP accept header. Statements only implemented for certain media types.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement File successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.0-Transactions"
+        ],
+        "summary": "Get Statement Transactions",
+        "description": "Get Statement Transactions related to an account",
+        "operationId": "getAccountStatementTransactions_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.0-Transactions"
+        ],
+        "summary": "Get Account Transactions",
+        "description": "Get transactions related to an account",
+        "operationId": "getAccountTransactionsUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/balances": {
+      "get": {
+        "tags": [
+          "v3.0-Balances"
+        ],
+        "summary": "Get Balances",
+        "description": "Get Balances",
+        "operationId": "getBalancesUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balances successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.0-Beneficiaries"
+        ],
+        "summary": "Get Beneficiaries",
+        "description": "Get Beneficiaries",
+        "operationId": "getBeneficiariesUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/direct-debits": {
+      "get": {
+        "tags": [
+          "v3.0-Direct-Debits"
+        ],
+        "summary": "Get Direct Debits",
+        "description": "Get Direct Debits",
+        "operationId": "getDirectDebitsUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/offers": {
+      "get": {
+        "tags": [
+          "v3.0-Offers"
+        ],
+        "summary": "Get Offers",
+        "description": "Get Offers",
+        "operationId": "getOffers_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/party": {
+      "get": {
+        "tags": [
+          "v3.0-Party"
+        ],
+        "summary": "Get Party",
+        "description": "Get Party",
+        "operationId": "getParty_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-user-id",
+            "in": "header",
+            "description": "The OB user ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/products": {
+      "get": {
+        "tags": [
+          "v3.0-Products"
+        ],
+        "summary": "Get Products",
+        "description": "Get Products",
+        "operationId": "getProductsUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Products successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.0-Scheduled-Payments"
+        ],
+        "summary": "Get Scheduled Payments",
+        "description": "Get Scheduled Payments",
+        "operationId": "getScheduledPayments_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.0-Standing-Orders"
+        ],
+        "summary": "Get Standing Orders",
+        "description": "Get Standing Orders",
+        "operationId": "getStandingOrdersUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/statements": {
+      "get": {
+        "tags": [
+          "v3.0-Statements"
+        ],
+        "summary": "Get Statements",
+        "description": "Get Statements",
+        "operationId": "getStatements_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/transactions": {
+      "get": {
+        "tags": [
+          "v3.0-Transactions"
+        ],
+        "summary": "Get Transactions",
+        "description": "Get Transactions",
+        "operationId": "getTransactionsUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls": {
+      "get": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Read all callback URLs",
+        "operationId": "readCallbackUrls_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Read",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Create a callback URL",
+        "operationId": "createCallbackURL_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Callback URLs Created",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "409": {
+            "description": "Conflict"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls/{CallbackUrlId}": {
+      "put": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Amend a callback URI",
+        "operationId": "amendCallbackURL_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Amended",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Delete a callback URI",
+        "operationId": "deleteCallbackURL_1",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "Callback URLs Deleted",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation Consents",
+        "operationId": "createFundsConfirmationConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmationConsent",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation  Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation Consents",
+        "operationId": "getFundsConfirmationConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Delete Funds Confirmation Consents",
+        "operationId": "deleteFundsConfirmationConsentsConsentId_2",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Deleted",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation",
+        "operationId": "createFundsConfirmation",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmation",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmation1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations/{FundsConfirmationId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation",
+        "operationId": "getFundsConfirmationId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FundsConfirmationId",
+            "in": "path",
+            "description": "FundsConfirmationId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payment Consents",
+        "operationId": "createDomesticPaymentConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticConsent1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "Domestic Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payment Consents",
+        "operationId": "getDomesticPaymentConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payments",
+        "operationId": "createDomesticPayments_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomestic1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomestic1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse1"
+            }
+          },
+          "201": {
+            "description": "Domestic Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments/{DomesticPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payments",
+        "operationId": "getDomesticPaymentsDomesticPaymentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticPaymentId",
+            "in": "path",
+            "description": "DomesticPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payment Consents",
+        "operationId": "createDomesticScheduledPaymentConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduledConsent1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payment Consents",
+        "operationId": "getDomesticScheduledPaymentConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payments",
+        "operationId": "createDomesticScheduledPayments_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduled1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduled1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse1"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payments",
+        "operationId": "getDomesticScheduledPaymentsDomesticScheduledPaymentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticScheduledPaymentId",
+            "in": "path",
+            "description": "DomesticScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Order Consents",
+        "operationId": "createDomesticStandingOrderConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticStandingOrderConsent1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Order Consents",
+        "operationId": "getDomesticStandingOrderConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Orders",
+        "operationId": "createDomesticStandingOrders_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticStandingOrder1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrder1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse1"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders/{DomesticStandingOrderId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Orders",
+        "operationId": "getDomesticStandingOrdersDomesticStandingOrderId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticStandingOrderId",
+            "in": "path",
+            "description": "DomesticStandingOrderId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFileConsent1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "File Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents",
+        "operationId": "getFilePaymentConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}/file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents File",
+        "operationId": "getFilePaymentConsentsConsentIdFile_2",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsentsConsentIdFile_2",
+        "consumes": [
+          "*/*"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "fileParam",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payments",
+        "operationId": "createFilePayments",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFile1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFile1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse1"
+            }
+          },
+          "201": {
+            "description": "File Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}/report-file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentIdReportFile",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payment Consents",
+        "operationId": "createInternationalPaymentConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalConsent1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "International Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payment Consents",
+        "operationId": "getInternationalPaymentConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payments",
+        "operationId": "createInternationalPayments",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternational1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternational1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse1"
+            }
+          },
+          "201": {
+            "description": "International Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments/{InternationalPaymentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payments",
+        "operationId": "getInternationalPaymentsInternationalPaymentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalPaymentId",
+            "in": "path",
+            "description": "InternationalPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payment Consents",
+        "operationId": "createInternationalScheduledPaymentConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduledConsent1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payment Consents",
+        "operationId": "getInternationalScheduledPaymentConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payments",
+        "operationId": "createInternationalScheduledPayments_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduled1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduled1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse1"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payments",
+        "operationId": "getInternationalScheduledPaymentsInternationalScheduledPaymentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalScheduledPaymentId",
+            "in": "path",
+            "description": "InternationalScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Order Consents",
+        "operationId": "createInternationalStandingOrderConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalStandingOrderConsent1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "International Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Order Consents",
+        "operationId": "getInternationalStandingOrderConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Orders",
+        "operationId": "createInternationalStandingOrders_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalStandingOrder1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrder1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse1"
+            }
+          },
+          "201": {
+            "description": "International Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Orders",
+        "operationId": "getInternationalStandingOrdersInternationalStandingOrderPaymentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalStandingOrderPaymentId",
+            "in": "path",
+            "description": "InternationalStandingOrderPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.1.1.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.1.1.json
@@ -1,0 +1,27011 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/open-banking/v3.1.1",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/aisp/account-access-consents": {
+      "post": {
+        "tags": [
+          "v3.1.1-AccountRequests"
+        ],
+        "summary": "Create an account access consent",
+        "description": "Create an account access consent",
+        "operationId": "createAccountAccessConsentUsingPOST_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Create an Account Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBReadRequest1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-aisp_id",
+            "in": "header",
+            "description": "The AISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "201": {
+            "description": "FRAccount1 Request resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/account-access-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "v3.1.1-AccountRequests"
+        ],
+        "summary": "Get an account access consent",
+        "description": "Get an account access consent",
+        "operationId": "getAccountConsentUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the Account access consent resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Access Consent resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "v3.1.1-AccountRequests"
+        ],
+        "summary": "Delete an account access consent",
+        "description": "Delete an account access consent",
+        "operationId": "deleteAccountConsentUsingDELETE_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "Account Access Consent resource successfully deleted"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts": {
+      "get": {
+        "tags": [
+          "v3.1.1-Accounts"
+        ],
+        "summary": "Get Accounts",
+        "description": "Get a list of accounts",
+        "operationId": "getAccountsUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "string",
+            "default": "0",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accounts successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}": {
+      "get": {
+        "tags": [
+          "v3.1.1-Accounts"
+        ],
+        "summary": "Get Account",
+        "description": "Get an account",
+        "operationId": "getAccountUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/balances": {
+      "get": {
+        "tags": [
+          "v1.1-Balances",
+          "v3.1.1-Balances"
+        ],
+        "summary": "Get Account Balances",
+        "description": "Get Balances related to an account",
+        "operationId": "getAccountBalancesUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.1.1-Beneficiaries"
+        ],
+        "summary": "Get Account Beneficiaries",
+        "description": "Get Beneficiaries related to an account",
+        "operationId": "getAccountBeneficiariesUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries  successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/direct-debits": {
+      "get": {
+        "tags": [
+          "v1.1-Direct-Debits",
+          "v3.1.1-Direct-Debits"
+        ],
+        "summary": "Get Account Direct Debits",
+        "description": "Get Direct Debits related to an account",
+        "operationId": "getAccountDirectDebitsUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/offers": {
+      "get": {
+        "tags": [
+          "v3.1.1-Offers"
+        ],
+        "summary": "Get Account Offers",
+        "description": "Get Offers related to an account",
+        "operationId": "getAccountOffers",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/parties": {
+      "get": {
+        "tags": [
+          "v3.1.1-Party"
+        ],
+        "summary": "Get All Account Parties",
+        "description": "Get Parties related to an account",
+        "operationId": "getAccountParties",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-user-id",
+            "in": "header",
+            "description": "The OB user ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/party": {
+      "get": {
+        "tags": [
+          "v3.1.1-Party"
+        ],
+        "summary": "Get Account Party",
+        "description": "Get Party related to an account",
+        "operationId": "getAccountParty",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/product": {
+      "get": {
+        "tags": [
+          "v3.1.1-Products"
+        ],
+        "summary": "Get Account Product",
+        "description": "Get Product related to an account",
+        "operationId": "getAccountProductUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Product successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.1.1-Scheduled-Payments"
+        ],
+        "summary": "Get Account Scheduled Payments",
+        "description": "Get Scheduled Payments related to an account",
+        "operationId": "getAccountScheduledPayments_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.1.1-Standing-Orders"
+        ],
+        "summary": "Get Account Standing Orders",
+        "description": "Get Standing Orders related to an account",
+        "operationId": "getAccountStandingOrdersUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements": {
+      "get": {
+        "tags": [
+          "v3.1.1-Statements"
+        ],
+        "summary": "Get Account Statements",
+        "description": "Get Statements related to an account",
+        "operationId": "getAccountStatements_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}": {
+      "get": {
+        "tags": [
+          "v3.1.1-Statements"
+        ],
+        "summary": "Get Statement",
+        "description": "Get Statement related to an account",
+        "operationId": "getAccountStatement_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/file": {
+      "get": {
+        "tags": [
+          "v3.1.1-Statements"
+        ],
+        "summary": "Get Statement File",
+        "description": "Get Statement File related to an account",
+        "operationId": "getAccountStatementFile_4",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP accept header. Statements only implemented for certain media types.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement File successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.1-Transactions",
+          "v3.1.1-Transactions"
+        ],
+        "summary": "Get Statement Transactions",
+        "description": "Get Statement Transactions related to an account",
+        "operationId": "getAccountStatementTransactions",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.1.1-Transactions"
+        ],
+        "summary": "Get Account Transactions",
+        "description": "Get transactions related to an account",
+        "operationId": "getAccountTransactionsUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/balances": {
+      "get": {
+        "tags": [
+          "v3.1.1-Balances"
+        ],
+        "summary": "Get Balances",
+        "description": "Get Balances",
+        "operationId": "getBalancesUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balances successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.1.1-Beneficiaries"
+        ],
+        "summary": "Get Beneficiaries",
+        "description": "Get Beneficiaries",
+        "operationId": "getBeneficiariesUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/direct-debits": {
+      "get": {
+        "tags": [
+          "v3.1.1-Direct-Debits"
+        ],
+        "summary": "Get Direct Debits",
+        "description": "Get Direct Debits",
+        "operationId": "getDirectDebitsUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/offers": {
+      "get": {
+        "tags": [
+          "v3.1.1-Offers"
+        ],
+        "summary": "Get Offers",
+        "description": "Get Offers",
+        "operationId": "getOffers",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/party": {
+      "get": {
+        "tags": [
+          "v3.1.1-Party"
+        ],
+        "summary": "Get Party",
+        "description": "Get Party",
+        "operationId": "getParty",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-user-id",
+            "in": "header",
+            "description": "The OB user ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/products": {
+      "get": {
+        "tags": [
+          "v3.1.1-Products"
+        ],
+        "summary": "Get Products",
+        "description": "Get Products",
+        "operationId": "getProductsUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Products successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.1.1-Scheduled-Payments"
+        ],
+        "summary": "Get Scheduled Payments",
+        "description": "Get Scheduled Payments",
+        "operationId": "getScheduledPayments_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.1.1-Standing-Orders"
+        ],
+        "summary": "Get Standing Orders",
+        "description": "Get Standing Orders",
+        "operationId": "getStandingOrdersUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/statements": {
+      "get": {
+        "tags": [
+          "v3.1.1-Statements"
+        ],
+        "summary": "Get Statements",
+        "description": "Get Statements",
+        "operationId": "getStatements_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/transactions": {
+      "get": {
+        "tags": [
+          "v3.1.1-Transactions"
+        ],
+        "summary": "Get Transactions",
+        "description": "Get Transactions",
+        "operationId": "getTransactionsUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls": {
+      "get": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Read all callback URLs",
+        "operationId": "readCallbackUrls_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Read",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Create a callback URL",
+        "operationId": "createCallbackURL_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Callback URLs Created",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "409": {
+            "description": "Conflict"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls/{CallbackUrlId}": {
+      "put": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Amend a callback URI",
+        "operationId": "amendCallbackURL_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Amended",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Delete a callback URI",
+        "operationId": "deleteCallbackURL_3",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "Callback URLs Deleted",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation Consents",
+        "operationId": "createFundsConfirmationConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmationConsent",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation  Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation Consents",
+        "operationId": "getFundsConfirmationConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Delete Funds Confirmation Consents",
+        "operationId": "deleteFundsConfirmationConsentsConsentId_1",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Deleted",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation",
+        "operationId": "createFundsConfirmation_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmation",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmation1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations/{FundsConfirmationId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation",
+        "operationId": "getFundsConfirmationId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FundsConfirmationId",
+            "in": "path",
+            "description": "FundsConfirmationId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payment Consents",
+        "operationId": "createDomesticPaymentConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payment Consents",
+        "operationId": "getDomesticPaymentConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "domestic-payment-consents-api-controller"
+        ],
+        "summary": "Get Domestic Payment Consents Funds Confirmation",
+        "operationId": "getDomesticPaymentConsentsConsentIdFundsConfirmation",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payment Consents Funds Confirmation Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payments",
+        "operationId": "createDomesticPayments_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomestic2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomestic2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments/{DomesticPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payments",
+        "operationId": "getDomesticPaymentsDomesticPaymentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticPaymentId",
+            "in": "path",
+            "description": "DomesticPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payment Consents",
+        "operationId": "createDomesticScheduledPaymentConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduledConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payment Consents",
+        "operationId": "getDomesticScheduledPaymentConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payments",
+        "operationId": "createDomesticScheduledPayments_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduled2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduled2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payments",
+        "operationId": "getDomesticScheduledPaymentsDomesticScheduledPaymentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticScheduledPaymentId",
+            "in": "path",
+            "description": "DomesticScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Order Consents",
+        "operationId": "createDomesticStandingOrderConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "OBWriteDomesticStandingOrderConsent3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse3"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Order Consents",
+        "operationId": "getDomesticStandingOrderConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Orders",
+        "operationId": "createDomesticStandingOrders_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticStandingOrder3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrder3"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse3"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders/{DomesticStandingOrderId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Orders",
+        "operationId": "getDomesticStandingOrdersDomesticStandingOrderId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticStandingOrderId",
+            "in": "path",
+            "description": "DomesticStandingOrderId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFileConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "File Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents",
+        "operationId": "getFilePaymentConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}/file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents File",
+        "operationId": "getFilePaymentConsentsConsentIdFile_3",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsentsConsentIdFile_3",
+        "consumes": [
+          "*/*"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "fileParam",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Created"
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payments",
+        "operationId": "createFilePayments_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFile2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFile2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "201": {
+            "description": "File Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}/report-file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentIdReportFile_2",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payment Consents",
+        "operationId": "createInternationalPaymentConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "International Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payment Consents",
+        "operationId": "getInternationalPaymentConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "international-payment-consents-api-controller"
+        ],
+        "summary": "Get International Payment Consents Funds Confirmation",
+        "operationId": "getInternationalPaymentConsentsConsentIdFundsConfirmation",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payments",
+        "operationId": "createInternationalPayments_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternational2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternational2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "201": {
+            "description": "International Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments/{InternationalPaymentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payments",
+        "operationId": "getInternationalPaymentsInternationalPaymentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalPaymentId",
+            "in": "path",
+            "description": "InternationalPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payment Consents",
+        "operationId": "createInternationalScheduledPaymentConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduledConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payment Consents",
+        "operationId": "getInternationalScheduledPaymentConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "international-scheduled-payment-consents-api-controller"
+        ],
+        "summary": "Get International Scheduled Payment Consents Funds Confirmation",
+        "operationId": "getInternationalScheduledPaymentConsentsConsentIdFundsConfirmation_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payments",
+        "operationId": "createInternationalScheduledPayments_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduled2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduled2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payments",
+        "operationId": "getInternationalScheduledPaymentsInternationalScheduledPaymentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalScheduledPaymentId",
+            "in": "path",
+            "description": "InternationalScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Order Consents",
+        "operationId": "createInternationalStandingOrderConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "OBWriteInternationalStandingOrderConsent3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse3"
+            }
+          },
+          "201": {
+            "description": "International Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Order Consents",
+        "operationId": "getInternationalStandingOrderConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Orders",
+        "operationId": "createInternationalStandingOrders_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "OBWriteInternationalStandingOrder3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrder3"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse3"
+            }
+          },
+          "201": {
+            "description": "International Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Orders",
+        "operationId": "getInternationalStandingOrdersInternationalStandingOrderPaymentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalStandingOrderPaymentId",
+            "in": "path",
+            "description": "InternationalStandingOrderPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.1.2.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.1.2.json
@@ -1,0 +1,27524 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/open-banking/v3.1.2",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/aisp/account-access-consents": {
+      "post": {
+        "tags": [
+          "v3.1.2-AccountRequests"
+        ],
+        "summary": "Create an account access consent",
+        "description": "Create an account access consent",
+        "operationId": "createAccountAccessConsentUsingPOST",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Create an Account Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBReadRequest1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-aisp_id",
+            "in": "header",
+            "description": "The AISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "201": {
+            "description": "FRAccount1 Request resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/account-access-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "v3.1.2-AccountRequests"
+        ],
+        "summary": "Get an account access consent",
+        "description": "Get an account access consent",
+        "operationId": "getAccountConsentUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the Account access consent resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Access Consent resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "v3.1.2-AccountRequests"
+        ],
+        "summary": "Delete an account access consent",
+        "description": "Delete an account access consent",
+        "operationId": "deleteAccountConsentUsingDELETE",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "Account Access Consent resource successfully deleted"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts": {
+      "get": {
+        "tags": [
+          "v3.1.2-Accounts"
+        ],
+        "summary": "Get Accounts",
+        "description": "Get a list of accounts",
+        "operationId": "getAccountsUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "string",
+            "default": "0",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accounts successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}": {
+      "get": {
+        "tags": [
+          "v3.1.2-Accounts"
+        ],
+        "summary": "Get Account",
+        "description": "Get an account",
+        "operationId": "getAccountUsingGET",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/balances": {
+      "get": {
+        "tags": [
+          "v1.1-Balances",
+          "v3.1.2-Balances"
+        ],
+        "summary": "Get Account Balances",
+        "description": "Get Balances related to an account",
+        "operationId": "getAccountBalancesUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.1.2-Beneficiaries"
+        ],
+        "summary": "Get Account Beneficiaries",
+        "description": "Get Beneficiaries related to an account",
+        "operationId": "getAccountBeneficiariesUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries  successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/direct-debits": {
+      "get": {
+        "tags": [
+          "v1.1-Direct-Debits",
+          "v3.1.2-Direct-Debits"
+        ],
+        "summary": "Get Account Direct Debits",
+        "description": "Get Direct Debits related to an account",
+        "operationId": "getAccountDirectDebitsUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/offers": {
+      "get": {
+        "tags": [
+          "v3.1.2-Offers"
+        ],
+        "summary": "Get Account Offers",
+        "description": "Get Offers related to an account",
+        "operationId": "getAccountOffers_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/parties": {
+      "get": {
+        "tags": [
+          "v3.1.2-Party"
+        ],
+        "summary": "Get All Account Parties",
+        "description": "Get Parties related to an account",
+        "operationId": "getAccountParties_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-user-id",
+            "in": "header",
+            "description": "The OB user ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/party": {
+      "get": {
+        "tags": [
+          "v3.1.2-Party"
+        ],
+        "summary": "Get Account Party",
+        "description": "Get Party related to an account",
+        "operationId": "getAccountParty_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/product": {
+      "get": {
+        "tags": [
+          "v3.1.2-Products"
+        ],
+        "summary": "Get Account Product",
+        "description": "Get Product related to an account",
+        "operationId": "getAccountProductUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Product successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.1.2-Scheduled-Payments"
+        ],
+        "summary": "Get Account Scheduled Payments",
+        "description": "Get Scheduled Payments related to an account",
+        "operationId": "getAccountScheduledPayments",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.1.2-Standing-Orders"
+        ],
+        "summary": "Get Account Standing Orders",
+        "description": "Get Standing Orders related to an account",
+        "operationId": "getAccountStandingOrdersUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements": {
+      "get": {
+        "tags": [
+          "v3.1.2-Statements"
+        ],
+        "summary": "Get Account Statements",
+        "description": "Get Statements related to an account",
+        "operationId": "getAccountStatements_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}": {
+      "get": {
+        "tags": [
+          "v3.1.2-Statements"
+        ],
+        "summary": "Get Statement",
+        "description": "Get Statement related to an account",
+        "operationId": "getAccountStatement_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/file": {
+      "get": {
+        "tags": [
+          "v3.1.2-Statements"
+        ],
+        "summary": "Get Statement File",
+        "description": "Get Statement File related to an account",
+        "operationId": "getAccountStatementFile_2",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP accept header. Statements only implemented for certain media types.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement File successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.1-Transactions",
+          "v3.1.2-Transactions"
+        ],
+        "summary": "Get Statement Transactions",
+        "description": "Get Statement Transactions related to an account",
+        "operationId": "getAccountStatementTransactions_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.1.2-Transactions"
+        ],
+        "summary": "Get Account Transactions",
+        "description": "Get transactions related to an account",
+        "operationId": "getAccountTransactionsUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/balances": {
+      "get": {
+        "tags": [
+          "v3.1.2-Balances"
+        ],
+        "summary": "Get Balances",
+        "description": "Get Balances",
+        "operationId": "getBalancesUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balances successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.1.2-Beneficiaries"
+        ],
+        "summary": "Get Beneficiaries",
+        "description": "Get Beneficiaries",
+        "operationId": "getBeneficiariesUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary3"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/direct-debits": {
+      "get": {
+        "tags": [
+          "v3.1.2-Direct-Debits"
+        ],
+        "summary": "Get Direct Debits",
+        "description": "Get Direct Debits",
+        "operationId": "getDirectDebitsUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/offers": {
+      "get": {
+        "tags": [
+          "v3.1.2-Offers"
+        ],
+        "summary": "Get Offers",
+        "description": "Get Offers",
+        "operationId": "getOffers_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/party": {
+      "get": {
+        "tags": [
+          "v3.1.2-Party"
+        ],
+        "summary": "Get Party",
+        "description": "Get Party",
+        "operationId": "getParty_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-user-id",
+            "in": "header",
+            "description": "The OB user ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/products": {
+      "get": {
+        "tags": [
+          "v3.1.2-Products"
+        ],
+        "summary": "Get Products",
+        "description": "Get Products",
+        "operationId": "getProductsUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Products successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.1.2-Scheduled-Payments"
+        ],
+        "summary": "Get Scheduled Payments",
+        "description": "Get Scheduled Payments",
+        "operationId": "getScheduledPayments",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.1.2-Standing-Orders"
+        ],
+        "summary": "Get Standing Orders",
+        "description": "Get Standing Orders",
+        "operationId": "getStandingOrdersUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/statements": {
+      "get": {
+        "tags": [
+          "v3.1.2-Statements"
+        ],
+        "summary": "Get Statements",
+        "description": "Get Statements",
+        "operationId": "getStatements_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/transactions": {
+      "get": {
+        "tags": [
+          "v3.1.2-Transactions"
+        ],
+        "summary": "Get Transactions",
+        "description": "Get Transactions",
+        "operationId": "getTransactionsUsingGET_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction5"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls": {
+      "get": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Read all callback URLs",
+        "operationId": "readCallbackUrls_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Read",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Create a callback URL",
+        "operationId": "createCallbackURL_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Callback URLs Created",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "409": {
+            "description": "Conflict"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls/{CallbackUrlId}": {
+      "put": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Amend a callback URI",
+        "operationId": "amendCallbackURL_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Amended",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Delete a callback URI",
+        "operationId": "deleteCallbackURL_2",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "Callback URLs Deleted",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation Consents",
+        "operationId": "createFundsConfirmationConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmationConsent",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation  Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation Consents",
+        "operationId": "getFundsConfirmationConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Delete Funds Confirmation Consents",
+        "operationId": "deleteFundsConfirmationConsentsConsentId",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Deleted",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation",
+        "operationId": "createFundsConfirmation_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmation",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmation1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations/{FundsConfirmationId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation",
+        "operationId": "getFundsConfirmationId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FundsConfirmationId",
+            "in": "path",
+            "description": "FundsConfirmationId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/event": {
+      "post": {
+        "tags": [
+          "event polling"
+        ],
+        "summary": "Poll events",
+        "operationId": "pollEvents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obEventPolling",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBEventPolling1"
+            }
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Events successfully polled",
+            "schema": {
+              "$ref": "#/definitions/OBEventPollingResponse1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "409": {
+            "description": "Conflict"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/event-subscriptions": {
+      "get": {
+        "tags": [
+          "Event Subscription"
+        ],
+        "summary": "Read Event Subscription",
+        "operationId": "read",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Event Subscriptiopn Read",
+            "schema": {
+              "$ref": "#/definitions/OBEventSubscriptionsResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Event Subscription"
+        ],
+        "summary": "Create an event subscription",
+        "operationId": "createEventSubscription",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obEventSubscription",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBEventSubscription1"
+            }
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBEventSubscriptionResponse1"
+            }
+          },
+          "201": {
+            "description": "Event subscriptions Created",
+            "schema": {
+              "$ref": "#/definitions/OBEventSubscriptionResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "409": {
+            "description": "Conflict"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/event-subscriptions/{EventSubscriptionId}": {
+      "put": {
+        "tags": [
+          "Event Subscription"
+        ],
+        "summary": "Amend an event subscription",
+        "operationId": "amend",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "EventSubscriptionId",
+            "in": "path",
+            "description": "EventSubscriptionId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obEventSubscriptionParam",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBEventSubscriptionResponse1"
+            }
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBEventSubscriptionsResponse1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "204": {
+            "description": "Event Subscription Amended",
+            "schema": {
+              "$ref": "#/definitions/OBEventSubscriptionResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Event Subscription"
+        ],
+        "summary": "Delete an event subscription",
+        "operationId": "delete",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "EventSubscriptionId",
+            "in": "path",
+            "description": "EventSubscriptionId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "Event Subscription Deleted",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payment Consents",
+        "operationId": "createDomesticPaymentConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payment Consents",
+        "operationId": "getDomesticPaymentConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "domestic-payment-consents-api-controller"
+        ],
+        "summary": "Get Domestic Payment Consents Funds Confirmation",
+        "operationId": "getDomesticPaymentConsentsConsentIdFundsConfirmation_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payment Consents Funds Confirmation Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payments",
+        "operationId": "createDomesticPayments",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomestic2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomestic2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments/{DomesticPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payments",
+        "operationId": "getDomesticPaymentsDomesticPaymentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticPaymentId",
+            "in": "path",
+            "description": "DomesticPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payment Consents",
+        "operationId": "createDomesticScheduledPaymentConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduledConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payment Consents",
+        "operationId": "getDomesticScheduledPaymentConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payments",
+        "operationId": "createDomesticScheduledPayments_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduled2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduled2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payments",
+        "operationId": "getDomesticScheduledPaymentsDomesticScheduledPaymentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticScheduledPaymentId",
+            "in": "path",
+            "description": "DomesticScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Order Consents",
+        "operationId": "createDomesticStandingOrderConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "OBWriteDomesticStandingOrderConsent3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse3"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Order Consents",
+        "operationId": "getDomesticStandingOrderConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Orders",
+        "operationId": "createDomesticStandingOrders_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticStandingOrder3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrder3"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse3"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders/{DomesticStandingOrderId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Orders",
+        "operationId": "getDomesticStandingOrdersDomesticStandingOrderId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticStandingOrderId",
+            "in": "path",
+            "description": "DomesticStandingOrderId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFileConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "File Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents",
+        "operationId": "getFilePaymentConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}/file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents File",
+        "operationId": "getFilePaymentConsentsConsentIdFile",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsentsConsentIdFile",
+        "consumes": [
+          "*/*"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "fileParam",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Created"
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payments",
+        "operationId": "createFilePayments_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFile2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFile2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "201": {
+            "description": "File Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}/report-file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentIdReportFile_1",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payment Consents",
+        "operationId": "createInternationalPaymentConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "International Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payment Consents",
+        "operationId": "getInternationalPaymentConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "international-payment-consents-api-controller"
+        ],
+        "summary": "Get International Payment Consents Funds Confirmation",
+        "operationId": "getInternationalPaymentConsentsConsentIdFundsConfirmation_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payments",
+        "operationId": "createInternationalPayments_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternational2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternational2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "201": {
+            "description": "International Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments/{InternationalPaymentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payments",
+        "operationId": "getInternationalPaymentsInternationalPaymentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalPaymentId",
+            "in": "path",
+            "description": "InternationalPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payment Consents",
+        "operationId": "createInternationalScheduledPaymentConsents_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduledConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payment Consents",
+        "operationId": "getInternationalScheduledPaymentConsentsConsentId_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "international-scheduled-payment-consents-api-controller"
+        ],
+        "summary": "Get International Scheduled Payment Consents Funds Confirmation",
+        "operationId": "getInternationalScheduledPaymentConsentsConsentIdFundsConfirmation_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payments",
+        "operationId": "createInternationalScheduledPayments_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduled2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduled2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payments",
+        "operationId": "getInternationalScheduledPaymentsInternationalScheduledPaymentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalScheduledPaymentId",
+            "in": "path",
+            "description": "InternationalScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Order Consents",
+        "operationId": "createInternationalStandingOrderConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "OBWriteInternationalStandingOrderConsent3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse3"
+            }
+          },
+          "201": {
+            "description": "International Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Order Consents",
+        "operationId": "getInternationalStandingOrderConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Orders",
+        "operationId": "createInternationalStandingOrders_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "OBWriteInternationalStandingOrder3Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrder3"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse3"
+            }
+          },
+          "201": {
+            "description": "International Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Orders",
+        "operationId": "getInternationalStandingOrdersInternationalStandingOrderPaymentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalStandingOrderPaymentId",
+            "in": "path",
+            "description": "InternationalStandingOrderPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse3"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.1.json
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/openbanking-v3.1.json
@@ -1,0 +1,26837 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "rs-store:8086",
+  "basePath": "/open-banking/v3.1",
+  "tags": [
+    {
+      "name": "account-access-consent-api-controller",
+      "description": "Account Access Consent Api Controller"
+    },
+    {
+      "name": "account-request-api-controller",
+      "description": "Account Request Api Controller"
+    },
+    {
+      "name": "accounts-api-controller",
+      "description": "Accounts Api Controller"
+    },
+    {
+      "name": "aggregated-polling-api-controller",
+      "description": "the event notification aggregated polling API"
+    },
+    {
+      "name": "balance-api-controller",
+      "description": "Balance Api Controller"
+    },
+    {
+      "name": "basic-error-controller",
+      "description": "Basic Error Controller"
+    },
+    {
+      "name": "callback-url-api-controller",
+      "description": "Callback Url Api Controller"
+    },
+    {
+      "name": "callback-urls-api-controller",
+      "description": "the event notification callback urls API"
+    },
+    {
+      "name": "data-api-controller",
+      "description": "Data Api Controller"
+    },
+    {
+      "name": "domestic-payment-api-controller",
+      "description": "Domestic Payment Api Controller"
+    },
+    {
+      "name": "domestic-payment-consents-api-controller",
+      "description": "the domestic-payment-consents API"
+    },
+    {
+      "name": "domestic-payments-api-controller",
+      "description": "the domestic-payments API"
+    },
+    {
+      "name": "domestic-scheduled-payment-api-controller",
+      "description": "Domestic Scheduled Payment Api Controller"
+    },
+    {
+      "name": "domestic-scheduled-payment-consents-api-controller",
+      "description": "the domestic-scheduled-payment-consents API"
+    },
+    {
+      "name": "domestic-scheduled-payments-api-controller",
+      "description": "the domestic-scheduled-payments API"
+    },
+    {
+      "name": "domestic-standing-order-api-controller",
+      "description": "Domestic Standing Order Api Controller"
+    },
+    {
+      "name": "domestic-standing-order-consents-api-controller",
+      "description": "the domestic-standing-order-consents API"
+    },
+    {
+      "name": "domestic-standing-orders-api-controller",
+      "description": "the domestic-standing-orders API"
+    },
+    {
+      "name": "event-subscription-api-controller",
+      "description": "the event subscriptions API"
+    },
+    {
+      "name": "fake-data-api-controller",
+      "description": "Fake Data Api Controller"
+    },
+    {
+      "name": "file-payment-api-controller",
+      "description": "File Payment Api Controller"
+    },
+    {
+      "name": "file-payment-consents-api-controller",
+      "description": "the file-payment-consents API"
+    },
+    {
+      "name": "file-payments-api-controller",
+      "description": "the file-payments API"
+    },
+    {
+      "name": "funds-confirmation-api-controller",
+      "description": "Funds Confirmation Api Controller"
+    },
+    {
+      "name": "funds-confirmation-consents-api-controller",
+      "description": "the funds-confirmation-consents API"
+    },
+    {
+      "name": "funds-confirmations-api-controller",
+      "description": "the funds-confirmation API"
+    },
+    {
+      "name": "internal-aggregated-polling-api-controller",
+      "description": "Internal Aggregated Polling Api Controller"
+    },
+    {
+      "name": "international-payment-api-controller",
+      "description": "International Payment Api Controller"
+    },
+    {
+      "name": "international-payment-consents-api-controller",
+      "description": "the international-payment-consents API"
+    },
+    {
+      "name": "international-payments-api-controller",
+      "description": "the international-payments API"
+    },
+    {
+      "name": "international-scheduled-payment-api-controller",
+      "description": "International Scheduled Payment Api Controller"
+    },
+    {
+      "name": "international-scheduled-payment-consents-api-controller",
+      "description": "the international-scheduled-payment-consents API"
+    },
+    {
+      "name": "international-scheduled-payments-api-controller",
+      "description": "the international-scheduled-payments API"
+    },
+    {
+      "name": "international-standing-order-api-controller",
+      "description": "International Standing Order Api Controller"
+    },
+    {
+      "name": "international-standing-order-consents-api-controller",
+      "description": "the international-standing-order-consents API"
+    },
+    {
+      "name": "international-standing-orders-api-controller",
+      "description": "the international-standing-orders API"
+    },
+    {
+      "name": "operation-handler",
+      "description": "Operation Handler"
+    },
+    {
+      "name": "payment-api-controller",
+      "description": "Payment Api Controller"
+    },
+    {
+      "name": "scheduled-payment-api-controller",
+      "description": "Scheduled Payment Api Controller"
+    },
+    {
+      "name": "standing-order-api-controller",
+      "description": "Standing Order Api Controller"
+    },
+    {
+      "name": "statement-api-controller",
+      "description": "Statement Api Controller"
+    },
+    {
+      "name": "transaction-api-controller",
+      "description": "Transaction Api Controller"
+    },
+    {
+      "name": "v1.1-AccountRequests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v1.1-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v2.0-Account-Requests",
+      "description": "the account-requests API"
+    },
+    {
+      "name": "v2.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v2.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v2.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v2.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v2.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v2.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v2.0-Payments",
+      "description": "the payment-submissions API"
+    },
+    {
+      "name": "v2.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v2.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v2.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v2.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v2.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.0-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.0-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.0-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.0-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.0-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.0-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.0-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.0-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.0-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.0-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.0-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.0-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.1-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.1-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.1-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.1-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.1-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.1-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.1-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.1-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.1-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.1-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.1-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.1-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "v3.1.2-AccountRequests",
+      "description": "the account-access-consents API"
+    },
+    {
+      "name": "v3.1.2-Accounts",
+      "description": "the accounts API"
+    },
+    {
+      "name": "v3.1.2-Balances",
+      "description": "the balances API"
+    },
+    {
+      "name": "v3.1.2-Beneficiaries",
+      "description": "the beneficiaries API"
+    },
+    {
+      "name": "v3.1.2-Direct-Debits",
+      "description": "the direct-debits API"
+    },
+    {
+      "name": "v3.1.2-Offers",
+      "description": "the offers API"
+    },
+    {
+      "name": "v3.1.2-Party",
+      "description": "the party API"
+    },
+    {
+      "name": "v3.1.2-Products",
+      "description": "the products API"
+    },
+    {
+      "name": "v3.1.2-Scheduled-Payments",
+      "description": "the scheduled-payments API"
+    },
+    {
+      "name": "v3.1.2-Standing-Orders",
+      "description": "the standing-orders API"
+    },
+    {
+      "name": "v3.1.2-Statements",
+      "description": "the statements API"
+    },
+    {
+      "name": "v3.1.2-Transactions",
+      "description": "the transactions API"
+    },
+    {
+      "name": "web-mvc-links-handler",
+      "description": "Web Mvc Links Handler"
+    }
+  ],
+  "paths": {
+    "/aisp/account-access-consents": {
+      "post": {
+        "tags": [
+          "v3.1-AccountRequests"
+        ],
+        "summary": "Create an account access consent",
+        "description": "Create an account access consent",
+        "operationId": "createAccountAccessConsentUsingPOST_2",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Create an Account Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBReadRequest1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-aisp_id",
+            "in": "header",
+            "description": "The AISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "201": {
+            "description": "FRAccount1 Request resource successfully created",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/account-access-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "v3.1-AccountRequests"
+        ],
+        "summary": "Get an account access consent",
+        "description": "Get an account access consent",
+        "operationId": "getAccountConsentUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the Account access consent resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Access Consent resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "v3.1-AccountRequests"
+        ],
+        "summary": "Delete an account access consent",
+        "description": "Delete an account access consent",
+        "operationId": "deleteAccountConsentUsingDELETE_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "Unique identification as assigned by the ASPSP to uniquely identify the account request resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "Account Access Consent resource successfully deleted"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "tpp_client_credential"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts": {
+      "get": {
+        "tags": [
+          "v3.1-Accounts"
+        ],
+        "summary": "Get Accounts",
+        "description": "Get a list of accounts",
+        "operationId": "getAccountsUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "string",
+            "default": "0",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accounts successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}": {
+      "get": {
+        "tags": [
+          "v3.1-Accounts"
+        ],
+        "summary": "Get Account",
+        "description": "Get an account",
+        "operationId": "getAccountUsingGET_5",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account resource successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadAccount2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/balances": {
+      "get": {
+        "tags": [
+          "v1.1-Balances",
+          "v3.1-Balances"
+        ],
+        "summary": "Get Account Balances",
+        "description": "Get Balances related to an account",
+        "operationId": "getAccountBalancesUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.1-Beneficiaries"
+        ],
+        "summary": "Get Account Beneficiaries",
+        "description": "Get Beneficiaries related to an account",
+        "operationId": "getAccountBeneficiariesUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Beneficiaries  successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/direct-debits": {
+      "get": {
+        "tags": [
+          "v1.1-Direct-Debits",
+          "v3.1-Direct-Debits"
+        ],
+        "summary": "Get Account Direct Debits",
+        "description": "Get Direct Debits related to an account",
+        "operationId": "getAccountDirectDebitsUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/offers": {
+      "get": {
+        "tags": [
+          "v3.1-Offers"
+        ],
+        "summary": "Get Account Offers",
+        "description": "Get Offers related to an account",
+        "operationId": "getAccountOffers_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/party": {
+      "get": {
+        "tags": [
+          "v3.1-Party"
+        ],
+        "summary": "Get Account Party",
+        "description": "Get Party related to an account",
+        "operationId": "getAccountParty_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/product": {
+      "get": {
+        "tags": [
+          "v3.1-Products"
+        ],
+        "summary": "Get Account Product",
+        "description": "Get Product related to an account",
+        "operationId": "getAccountProductUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Product successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.1-Scheduled-Payments"
+        ],
+        "summary": "Get Account Scheduled Payments",
+        "description": "Get Scheduled Payments related to an account",
+        "operationId": "getAccountScheduledPayments_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.1-Standing-Orders"
+        ],
+        "summary": "Get Account Standing Orders",
+        "description": "Get Standing Orders related to an account",
+        "operationId": "getAccountStandingOrdersUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder4"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements": {
+      "get": {
+        "tags": [
+          "v3.1-Statements"
+        ],
+        "summary": "Get Account Statements",
+        "description": "Get Statements related to an account",
+        "operationId": "getAccountStatements_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}": {
+      "get": {
+        "tags": [
+          "v3.1-Statements"
+        ],
+        "summary": "Get Statement",
+        "description": "Get Statement related to an account",
+        "operationId": "getAccountStatement_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/file": {
+      "get": {
+        "tags": [
+          "v3.1-Statements"
+        ],
+        "summary": "Get Statement File",
+        "description": "Get Statement File related to an account",
+        "operationId": "getAccountStatementFile_1",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP accept header. Statements only implemented for certain media types.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement File successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/statements/{StatementId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.1-Transactions"
+        ],
+        "summary": "Get Statement Transactions",
+        "description": "Get Statement Transactions related to an account",
+        "operationId": "getAccountStatementTransactions_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "StatementId",
+            "in": "path",
+            "description": "A unique identifier used to identify the statement resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction4"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/accounts/{AccountId}/transactions": {
+      "get": {
+        "tags": [
+          "v3.1-Transactions"
+        ],
+        "summary": "Get Account Transactions",
+        "description": "Get transactions related to an account",
+        "operationId": "getAccountTransactionsUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "AccountId",
+            "in": "path",
+            "description": "A unique identifier used to identify the account resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction4"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/balances": {
+      "get": {
+        "tags": [
+          "v3.1-Balances"
+        ],
+        "summary": "Get Balances",
+        "description": "Get Balances",
+        "operationId": "getBalancesUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balances successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBalance1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/beneficiaries": {
+      "get": {
+        "tags": [
+          "v3.1-Beneficiaries"
+        ],
+        "summary": "Get Beneficiaries",
+        "description": "Get Beneficiaries",
+        "operationId": "getBeneficiariesUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Beneficiaries successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadBeneficiary2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/direct-debits": {
+      "get": {
+        "tags": [
+          "v3.1-Direct-Debits"
+        ],
+        "summary": "Get Direct Debits",
+        "description": "Get Direct Debits",
+        "operationId": "getDirectDebitsUsingGET_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Direct Debits successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadDirectDebit1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/offers": {
+      "get": {
+        "tags": [
+          "v3.1-Offers"
+        ],
+        "summary": "Get Offers",
+        "description": "Get Offers",
+        "operationId": "getOffers_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Offers successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadOffer1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/party": {
+      "get": {
+        "tags": [
+          "v3.1-Party"
+        ],
+        "summary": "Get Party",
+        "description": "Get Party",
+        "operationId": "getParty_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-user-id",
+            "in": "header",
+            "description": "The OB user ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Party successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadParty1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/products": {
+      "get": {
+        "tags": [
+          "v3.1-Products"
+        ],
+        "summary": "Get Products",
+        "description": "Get Products",
+        "operationId": "getProductsUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Products successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadProduct2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/scheduled-payments": {
+      "get": {
+        "tags": [
+          "v3.1-Scheduled-Payments"
+        ],
+        "summary": "Get Scheduled Payments",
+        "description": "Get Scheduled Payments",
+        "operationId": "getScheduledPayments_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Scheduled Payment successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadScheduledPayment1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/standing-orders": {
+      "get": {
+        "tags": [
+          "v3.1-Standing-Orders"
+        ],
+        "summary": "Get Standing Orders",
+        "description": "Get Standing Orders",
+        "operationId": "getStandingOrdersUsingGET_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Standing Orders successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStandingOrder4"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/statements": {
+      "get": {
+        "tags": [
+          "v3.1-Statements"
+        ],
+        "summary": "Get Statements",
+        "description": "Get Statements",
+        "operationId": "getStatements_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toStatementDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter statements TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "The OB account IDs",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "The OB permissions",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "The origin http url",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Statement successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadStatement1"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/aisp/transactions": {
+      "get": {
+        "tags": [
+          "v3.1-Transactions"
+        ],
+        "summary": "Get Transactions",
+        "description": "Get Transactions",
+        "operationId": "getTransactionsUsingGET_4",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions FROM  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number.",
+            "required": false,
+            "type": "integer",
+            "default": 0,
+            "format": "int32",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "toBookingDateTime",
+            "in": "query",
+            "description": "The UTC ISO 8601 Date Time to filter transactions TO  NB Time component is optional - set to 00:00:00 for just Date.   The parameter must NOT have a timezone set",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-account-ids",
+            "in": "header",
+            "description": "x-ob-account-ids",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "x-ob-first-available-date",
+            "in": "header",
+            "description": "x-ob-first-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-last-available-date",
+            "in": "header",
+            "description": "x-ob-last-available-date",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-ob-permissions",
+            "in": "header",
+            "description": "x-ob-permissions",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ReadAccountsBasic",
+                "ReadAccountsDetail",
+                "ReadBalances",
+                "ReadBeneficiariesBasic",
+                "ReadBeneficiariesDetail",
+                "ReadDirectDebits",
+                "ReadOffers",
+                "ReadPAN",
+                "ReadParty",
+                "ReadPartyPSU",
+                "ReadProducts",
+                "ReadScheduledPaymentsBasic",
+                "ReadScheduledPaymentsDetail",
+                "ReadStandingOrdersBasic",
+                "ReadStandingOrdersDetail",
+                "ReadStatementsBasic",
+                "ReadStatementsDetail",
+                "ReadTransactionsBasic",
+                "ReadTransactionsCredits",
+                "ReadTransactionsDebits",
+                "ReadTransactionsDetail"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions successfully retrieved",
+            "schema": {
+              "$ref": "#/definitions/OBReadTransaction4"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "accounts"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls": {
+      "get": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Read all callback URLs",
+        "operationId": "readCallbackUrls",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Read",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Create a callback URL",
+        "operationId": "createCallbackURL",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Callback URLs Created",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "409": {
+            "description": "Conflict"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/callback-urls/{CallbackUrlId}": {
+      "put": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Amend a callback URI",
+        "operationId": "amendCallbackURL",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obCallbackUrl1Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrl1"
+            }
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "Header containing a detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Callback URLs Amended",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Callback URLs"
+        ],
+        "summary": "Delete a callback URI",
+        "operationId": "deleteCallbackURL",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "CallbackUrlId",
+            "in": "path",
+            "description": "CallbackUrlId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "Callback URLs Deleted",
+            "schema": {
+              "$ref": "#/definitions/OBCallbackUrlResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "accounts",
+              "payments",
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation Consents",
+        "operationId": "createFundsConfirmationConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmationConsent",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsent1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation  Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmation-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation Consents",
+        "operationId": "getFundsConfirmationConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationConsentResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Delete Funds Confirmation Consents",
+        "operationId": "deleteFundsConfirmationConsentsConsentId_3",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-pisp-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Consents Deleted",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations": {
+      "post": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Create Funds Confirmation",
+        "operationId": "createFundsConfirmation_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obFundsConfirmation",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmation1"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "201": {
+            "description": "Funds Confirmation Created",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/cbpii/funds-confirmations/{FundsConfirmationId}": {
+      "get": {
+        "tags": [
+          "Funds Confirmation"
+        ],
+        "summary": "Get Funds Confirmation",
+        "operationId": "getFundsConfirmationId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FundsConfirmationId",
+            "in": "path",
+            "description": "FundsConfirmationId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funds Confirmation Read",
+            "schema": {
+              "$ref": "#/definitions/OBFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "fundsconfirmations"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payment Consents",
+        "operationId": "createDomesticPaymentConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payment Consents",
+        "operationId": "getDomesticPaymentConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "domestic-payment-consents-api-controller"
+        ],
+        "summary": "Get Domestic Payment Consents Funds Confirmation",
+        "operationId": "getDomesticPaymentConsentsConsentIdFundsConfirmation_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payment Consents Funds Confirmation Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments": {
+      "post": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Create Domestic Payments",
+        "operationId": "createDomesticPayments_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomestic2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomestic2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-payments/{DomesticPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Payments"
+        ],
+        "summary": "Get Domestic Payments",
+        "operationId": "getDomesticPaymentsDomesticPaymentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticPaymentId",
+            "in": "path",
+            "description": "DomesticPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payment Consents",
+        "operationId": "createDomesticScheduledPaymentConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduledConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payment Consents",
+        "operationId": "getDomesticScheduledPaymentConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments": {
+      "post": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Create Domestic Scheduled Payments",
+        "operationId": "createDomesticScheduledPayments",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticScheduled2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduled2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "Domestic Scheduled Payments"
+        ],
+        "summary": "Get Domestic Scheduled Payments",
+        "operationId": "getDomesticScheduledPaymentsDomesticScheduledPaymentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticScheduledPaymentId",
+            "in": "path",
+            "description": "DomesticScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Order Consents",
+        "operationId": "createDomesticStandingOrderConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticStandingOrderConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Order Consents",
+        "operationId": "getDomesticStandingOrderConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders": {
+      "post": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Create Domestic Standing Orders",
+        "operationId": "createDomesticStandingOrders",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteDomesticStandingOrder2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrder2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse2"
+            }
+          },
+          "201": {
+            "description": "Domestic Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/domestic-standing-orders/{DomesticStandingOrderId}": {
+      "get": {
+        "tags": [
+          "Domestic Standing Orders"
+        ],
+        "summary": "Get Domestic Standing Orders",
+        "operationId": "getDomesticStandingOrdersDomesticStandingOrderId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "DomesticStandingOrderId",
+            "in": "path",
+            "description": "DomesticStandingOrderId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domestic Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteDomesticStandingOrderResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsents_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFileConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP Client ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "File Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents",
+        "operationId": "getFilePaymentConsentsConsentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payment-consents/{ConsentId}/file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payment Consents File",
+        "operationId": "getFilePaymentConsentsConsentIdFile_1",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payment Consents",
+        "operationId": "createFilePaymentConsentsConsentIdFile_1",
+        "consumes": [
+          "*/*"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "fileParam",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/ResponseEntity"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments": {
+      "post": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Create File Payments",
+        "operationId": "createFilePayments_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteFile2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteFile2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "201": {
+            "description": "File Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFileResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/file-payments/{FilePaymentId}/report-file": {
+      "get": {
+        "tags": [
+          "File Payments"
+        ],
+        "summary": "Get File Payments",
+        "operationId": "getFilePaymentsFilePaymentIdReportFile_3",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "FilePaymentId",
+            "in": "path",
+            "description": "FilePaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Payments Read",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payment Consents",
+        "operationId": "createInternationalPaymentConsents_3",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "International Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payment Consents",
+        "operationId": "getInternationalPaymentConsentsConsentId_3",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "international-payment-consents-api-controller"
+        ],
+        "summary": "Get International Payment Consents Funds Confirmation",
+        "operationId": "getInternationalPaymentConsentsConsentIdFundsConfirmation_2",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments": {
+      "post": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Create International Payments",
+        "operationId": "createInternationalPayments_1",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternational2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternational2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "201": {
+            "description": "International Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-payments/{InternationalPaymentId}": {
+      "get": {
+        "tags": [
+          "International Payments"
+        ],
+        "summary": "Get International Payments",
+        "operationId": "getInternationalPaymentsInternationalPaymentId_1",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalPaymentId",
+            "in": "path",
+            "description": "InternationalPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payment Consents",
+        "operationId": "createInternationalScheduledPaymentConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduledConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payment Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payment Consents",
+        "operationId": "getInternationalScheduledPaymentConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payment-consents/{ConsentId}/funds-confirmation": {
+      "get": {
+        "tags": [
+          "international-scheduled-payment-consents-api-controller"
+        ],
+        "summary": "Get International Scheduled Payment Consents Funds Confirmation",
+        "operationId": "getInternationalScheduledPaymentConsentsConsentIdFundsConfirmation",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-url",
+            "in": "header",
+            "description": "x-ob-url",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Payment Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteFundsConfirmationResponse1"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": []
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments": {
+      "post": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Create International Scheduled Payments",
+        "operationId": "createInternationalScheduledPayments",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalScheduled2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduled2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "201": {
+            "description": "International Scheduled Payments Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}": {
+      "get": {
+        "tags": [
+          "International Scheduled Payments"
+        ],
+        "summary": "Get International Scheduled Payments",
+        "operationId": "getInternationalScheduledPaymentsInternationalScheduledPaymentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalScheduledPaymentId",
+            "in": "path",
+            "description": "InternationalScheduledPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Scheduled Payments Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalScheduledResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Order Consents",
+        "operationId": "createInternationalStandingOrderConsents",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalStandingOrderConsent2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ob-client-id",
+            "in": "header",
+            "description": "The PISP ID",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse2"
+            }
+          },
+          "201": {
+            "description": "International Standing Order Consents Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-order-consents/{ConsentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Order Consents",
+        "operationId": "getInternationalStandingOrderConsentsConsentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConsentId",
+            "in": "path",
+            "description": "ConsentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Order Consents Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderConsentResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders": {
+      "post": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Create International Standing Orders",
+        "operationId": "createInternationalStandingOrders",
+        "consumes": [
+          "application/json;charset=utf-8"
+        ],
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "obWriteInternationalStandingOrder2Param",
+            "description": "Default",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrder2"
+            }
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-idempotency-key",
+            "in": "header",
+            "description": "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-jws-signature",
+            "in": "header",
+            "description": "A detached JWS signature of the body of the payload.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse2"
+            }
+          },
+          "201": {
+            "description": "International Standing Orders Created",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "PSUOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    },
+    "/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}": {
+      "get": {
+        "tags": [
+          "International Standing Orders"
+        ],
+        "summary": "Get International Standing Orders",
+        "operationId": "getInternationalStandingOrdersInternationalStandingOrderPaymentId",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "An Authorisation Token as per https://tools.ietf.org/html/rfc6750",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "InternationalStandingOrderPaymentId",
+            "in": "path",
+            "description": "InternationalStandingOrderPaymentId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-customer-user-agent",
+            "in": "header",
+            "description": "Indicates the user-agent that the PSU is using.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-ip-address",
+            "in": "header",
+            "description": "The PSU's IP address if the PSU is currently logged in with the TPP.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-customer-last-logged-time",
+            "in": "header",
+            "description": "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "x-fapi-financial-id",
+            "in": "header",
+            "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-fapi-interaction-id",
+            "in": "header",
+            "description": "An RFC4122 UID used as a correlation id.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "International Standing Orders Read",
+            "schema": {
+              "$ref": "#/definitions/OBWriteInternationalStandingOrderResponse2"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "406": {
+            "description": "Not Acceptable"
+          },
+          "429": {
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/OBErrorResponse1"
+            }
+          }
+        },
+        "security": [
+          {
+            "TPPOAuth2Security": [
+              "payments"
+            ]
+          }
+        ],
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Algorithm": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        }
+      },
+      "title": "Algorithm"
+    },
+    "BCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits",
+          "items": {
+            "$ref": "#/definitions/BCAOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails"
+        }
+      },
+      "title": "BCA"
+    },
+    "BCAFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Other",
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCAccountFeeQuarterly",
+              "ServiceCFixedTariff",
+              "ServiceCBusiDepAccBreakage",
+              "ServiceCMinimumMonthlyFee",
+              "ServiceCOther"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "BCAFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "BCAFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "BCAFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "BCAOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/BCAFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "Electronic",
+            "Mixed",
+            "Other"
+          ]
+        }
+      },
+      "title": "BCAOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "Base64": {
+      "type": "object",
+      "title": "Base64"
+    },
+    "Base64URL": {
+      "type": "object",
+      "title": "Base64URL"
+    },
+    "CreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest",
+      "description": "Details about the interest that may be payable to the BCA account holders"
+    },
+    "CreditInterest1": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "description": "The group of tiers or bands for which credit interest can be applied.",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBandSet"
+          }
+        }
+      },
+      "title": "CreditInterest1",
+      "description": "Details about the interest that may be payable to the PCA account holders"
+    },
+    "CreditInterest1TierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the PCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "PerAcademicTerm",
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a PCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterest1TierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterest1TierBandSet": {
+      "type": "object",
+      "required": [
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the PCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterest1TierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterest1TierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "CreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the BCA product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "Daily",
+            "HalfYearly",
+            "Monthly",
+            "Other",
+            "Quarterly",
+            "PerStatementDate",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "description": "Type of interest rate, Fixed or Variable",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a BCA."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "CreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "CreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "description": "Methods of calculating interest",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "PayAway",
+            "SelfCredit"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TierBand": {
+          "type": "array",
+          "description": "Tier Band Details",
+          "items": {
+            "$ref": "#/definitions/CreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "CreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "FRAccount3": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccount3"
+    },
+    "FRAccountAccessConsent1": {
+      "type": "object",
+      "properties": {
+        "accountAccessConsent": {
+          "$ref": "#/definitions/OBReadConsentResponse1"
+        },
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "consentId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountAccessConsent1"
+    },
+    "FRAccountData4": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "beneficiaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        },
+        "directDebits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        },
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "product": {
+          "$ref": "#/definitions/OBReadProduct2DataProduct"
+        },
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        },
+        "standingOrders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        },
+        "statements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "FRAccountData4"
+    },
+    "FRAccountRequest1": {
+      "type": "object",
+      "properties": {
+        "accountIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accountRequest": {
+          "$ref": "#/definitions/OBReadResponse1"
+        },
+        "accountRequestId": {
+          "type": "string"
+        },
+        "aisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "aispId": {
+          "type": "string"
+        },
+        "aispName": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountRequest1"
+    },
+    "FRAccountWithBalance": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/OBAccount3"
+        },
+        "balances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "latestStatementId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "title": "FRAccountWithBalance"
+    },
+    "FRBalance1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "balance": {
+          "$ref": "#/definitions/OBCashBalance1"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "currency": {
+          "type": "string"
+        },
+        "currencyAndAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "id": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRBalance1"
+    },
+    "FRCallbackUrl1": {
+      "type": "object",
+      "properties": {
+        "callBackUrlString": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obCallbackUrl": {
+          "$ref": "#/definitions/OBCallbackUrl1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRCallbackUrl1"
+    },
+    "FRDomesticConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticConsent": {
+          "$ref": "#/definitions/OBWriteDomesticConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticConsent2"
+    },
+    "FRDomesticScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticScheduledConsent": {
+          "$ref": "#/definitions/OBWriteDomesticScheduledConsent2"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticScheduledConsent2"
+    },
+    "FRDomesticStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "domesticStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteDomesticStandingOrderConsent3"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRDomesticStandingOrderConsent3"
+    },
+    "FREventNotification": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "errors": {
+          "$ref": "#/definitions/OBEventPolling1SetErrs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "jti": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "signedJwt": {
+          "type": "string"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FREventNotification"
+    },
+    "FREventSubscription1": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obEventSubscription1": {
+          "$ref": "#/definitions/OBEventSubscription1"
+        },
+        "tppId": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        }
+      },
+      "title": "FREventSubscription1"
+    },
+    "FRFileConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fileContent": {
+          "type": "string"
+        },
+        "fileHash": {
+          "type": "string"
+        },
+        "fileType": {
+          "type": "string",
+          "enum": [
+            "UK_OBIE_PAYMENT_INITIATION_V3_0",
+            "UK_OBIE_PAYMENT_INITIATION_V3_1",
+            "UK_OBIE_PAIN_001"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "payments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRFilePayment"
+          }
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "writeFileConsent": {
+          "$ref": "#/definitions/OBWriteFileConsent2"
+        }
+      },
+      "title": "FRFileConsent2"
+    },
+    "FRFilePayment": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "creditorAccountIdentification": {
+          "type": "string"
+        },
+        "endToEndIdentification": {
+          "type": "string"
+        },
+        "instructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "instructionIdentification": {
+          "type": "string"
+        },
+        "remittanceReference": {
+          "type": "string"
+        },
+        "remittanceUnstructured": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        }
+      },
+      "title": "FRFilePayment"
+    },
+    "FRFundsConfirmationConsent1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "debtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "fundsConfirmationConsent": {
+          "$ref": "#/definitions/OBFundsConfirmationConsent1"
+        },
+        "id": {
+          "type": "string"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRFundsConfirmationConsent1"
+    },
+    "FRInternationalConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "internationalConsent": {
+          "$ref": "#/definitions/OBWriteInternationalConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalConsent2"
+    },
+    "FRInternationalScheduledConsent2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "calculatedExchangeRate": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "internationalScheduledConsent": {
+          "$ref": "#/definitions/OBWriteInternationalScheduledConsent2"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalScheduledConsent2"
+    },
+    "FRInternationalStandingOrderConsent3": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "internationalStandingOrderConsent": {
+          "$ref": "#/definitions/OBWriteInternationalStandingOrderConsent3"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRInternationalStandingOrderConsent3"
+    },
+    "FRPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "new": {
+          "type": "boolean"
+        },
+        "obVersion": {
+          "type": "string",
+          "enum": [
+            "v1_1",
+            "v2_0",
+            "v3_0",
+            "v3_1",
+            "v3_1_1",
+            "v3_1_2"
+          ]
+        },
+        "paymentSetupRequest": {
+          "$ref": "#/definitions/OBPaymentSetup1"
+        },
+        "pisp": {
+          "$ref": "#/definitions/Tpp"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "pispName": {
+          "type": "string"
+        },
+        "risk": {
+          "$ref": "#/definitions/OBRisk1"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "AUTHORISED",
+            "AWAITINGAUTHORISATION",
+            "CONSUMED",
+            "REJECTED",
+            "ACCEPTEDCUSTOMERPROFILE",
+            "ACCEPTEDSETTLEMENTCOMPLETED",
+            "ACCEPTEDSETTLEMENTINPROCESS",
+            "ACCEPTEDTECHNICALVALIDATION",
+            "PENDING",
+            "REVOKED",
+            "AWAITINGUPLOAD"
+          ]
+        },
+        "statusUpdate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "title": "FRPaymentSetup1"
+    },
+    "FRScheduledPayment2": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "scheduledPayment": {
+          "$ref": "#/definitions/OBScheduledPayment2"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "COMPLETED",
+            "REJECTED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRScheduledPayment2"
+    },
+    "FRStandingOrder5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "pispId": {
+          "type": "string"
+        },
+        "rejectionReason": {
+          "type": "string"
+        },
+        "standingOrder": {
+          "$ref": "#/definitions/OBStandingOrder5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "REJECTED",
+            "COMPLETED"
+          ]
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRStandingOrder5"
+    },
+    "FRTransaction5": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "bookingDateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transaction": {
+          "$ref": "#/definitions/OBTransaction5"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "FRTransaction5"
+    },
+    "FRUserData4": {
+      "type": "object",
+      "properties": {
+        "accountDatas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "party": {
+          "$ref": "#/definitions/OBParty2"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "title": "FRUserData4"
+    },
+    "FeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "FeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "absoluteFile": {
+          "$ref": "#/definitions/File"
+        },
+        "absolutePath": {
+          "type": "string"
+        },
+        "canonicalFile": {
+          "$ref": "#/definitions/File"
+        },
+        "canonicalPath": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "boolean"
+        },
+        "file": {
+          "type": "boolean"
+        },
+        "freeSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "parentFile": {
+          "$ref": "#/definitions/File"
+        },
+        "path": {
+          "type": "string"
+        },
+        "totalSpace": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "usableSpace": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "title": "File"
+    },
+    "InputStream": {
+      "type": "object",
+      "title": "InputStream"
+    },
+    "JWK": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "keyID": {
+          "type": "string"
+        },
+        "keyOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "sign",
+              "verify",
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+              "deriveKey",
+              "deriveBits"
+            ]
+          }
+        },
+        "keyStore": {
+          "$ref": "#/definitions/KeyStore"
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "keyUse": {
+          "$ref": "#/definitions/KeyUse"
+        },
+        "parsedX509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/X509Certificate"
+          }
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "requiredParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "x509CertChain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Base64"
+          }
+        },
+        "x509CertSHA256Thumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertThumbprint": {
+          "$ref": "#/definitions/Base64URL"
+        },
+        "x509CertURL": {
+          "$ref": "#/definitions/URI"
+        }
+      },
+      "title": "JWK"
+    },
+    "JWKSet": {
+      "type": "object",
+      "properties": {
+        "additionalMembers": {
+          "type": "object"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JWK"
+          }
+        }
+      },
+      "title": "JWKSet"
+    },
+    "JWTClaimsSet": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims": {
+          "type": "object"
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issueTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "jwtid": {
+          "type": "string"
+        },
+        "notBeforeTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "title": "JWTClaimsSet"
+    },
+    "KeyStore": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "title": "KeyStore"
+    },
+    "KeyType": {
+      "type": "object",
+      "properties": {
+        "requirement": {
+          "type": "string",
+          "enum": [
+            "REQUIRED",
+            "RECOMMENDED",
+            "OPTIONAL"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyType"
+    },
+    "KeyUse": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "KeyUse"
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean"
+        }
+      },
+      "title": "Link"
+    },
+    "Links": {
+      "type": "object",
+      "required": [
+        "Self"
+      ],
+      "properties": {
+        "First": {
+          "type": "string"
+        },
+        "Last": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "Prev": {
+          "type": "string"
+        },
+        "Self": {
+          "type": "string"
+        }
+      },
+      "title": "Links",
+      "description": "Links relevant to the payload"
+    },
+    "Map«string,Link»": {
+      "type": "object",
+      "title": "Map«string,Link»",
+      "additionalProperties": {
+        "$ref": "#/definitions/Link"
+      }
+    },
+    "Meta": {
+      "type": "object",
+      "properties": {
+        "FirstAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TotalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Meta",
+      "description": "Meta Data relevant to the payload"
+    },
+    "ModelAndView": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "object"
+        },
+        "modelMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "view": {
+          "$ref": "#/definitions/View"
+        },
+        "viewName": {
+          "type": "string"
+        }
+      },
+      "title": "ModelAndView"
+    },
+    "OBAccount1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBAccount1",
+      "description": "Account"
+    },
+    "OBAccount2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount3"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        }
+      },
+      "title": "OBAccount2",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBAccount3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "AccountSubType",
+        "AccountType",
+        "Currency"
+      ],
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Provides the details to identify an account.",
+          "items": {
+            "$ref": "#/definitions/OBCashAccount5"
+          }
+        },
+        "AccountId": {
+          "type": "string"
+        },
+        "AccountSubType": {
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "AccountType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "Currency": {
+          "type": "string",
+          "description": "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Specifies the description of the account type."
+        },
+        "Nickname": {
+          "type": "string",
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        }
+      },
+      "title": "OBAccount3",
+      "description": "Unambiguous identification of the account to which credit and debit entries are made."
+    },
+    "OBActiveOrHistoricCurrencyAndAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBActiveOrHistoricCurrencyAndAmount"
+    },
+    "OBAuthorisation1": {
+      "type": "object",
+      "required": [
+        "AuthorisationType"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Single"
+          ]
+        },
+        "CompletionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBAuthorisation1",
+      "description": "The authorisation type request from the TPP."
+    },
+    "OBBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "SubCode"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Specifies the family within a domain."
+        },
+        "SubCode": {
+          "type": "string",
+          "description": "Specifies the sub-product family within a specific family."
+        }
+      },
+      "title": "OBBankTransactionCodeStructure1",
+      "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+    },
+    "OBBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        }
+      },
+      "title": "OBBeneficiary1",
+      "description": "Beneficiary"
+    },
+    "OBBeneficiary2": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary2"
+    },
+    "OBBeneficiary3": {
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "BeneficiaryId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBBeneficiary3"
+    },
+    "OBBranchAndFinancialInstitutionIdentification2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "BICFI"
+          ]
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification2"
+    },
+    "OBBranchAndFinancialInstitutionIdentification3": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification3",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBBranchAndFinancialInstitutionIdentification4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification4",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of the servicing institution."
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification5",
+      "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account."
+    },
+    "OBBranchAndFinancialInstitutionIdentification6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which an agent is known and which is usually used to identify that agent."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "SchemeName": {
+          "type": "string"
+        }
+      },
+      "title": "OBBranchAndFinancialInstitutionIdentification6",
+      "description": "Financial institution servicing an account for the debtor."
+    },
+    "OBCallbackUrl1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlData1"
+        }
+      },
+      "title": "OBCallbackUrl1"
+    },
+    "OBCallbackUrlData1": {
+      "type": "object",
+      "required": [
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlData1"
+    },
+    "OBCallbackUrlResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlResponse1"
+    },
+    "OBCallbackUrlResponseData1": {
+      "type": "object",
+      "required": [
+        "CallbackUrlId",
+        "Url",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrlId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "Url": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version for the event notification."
+        }
+      },
+      "title": "OBCallbackUrlResponseData1"
+    },
+    "OBCallbackUrlsResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBCallbackUrlsResponseData1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBCallbackUrlsResponse1"
+    },
+    "OBCallbackUrlsResponseData1": {
+      "type": "object",
+      "properties": {
+        "CallbackUrl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBCallbackUrlResponseData1"
+          }
+        }
+      },
+      "title": "OBCallbackUrlsResponseData1"
+    },
+    "OBCashAccount1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount1",
+      "description": "Provides the details to identify an account."
+    },
+    "OBCashAccount2": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "SchemeName": {
+          "type": "string",
+          "enum": [
+            "IBAN",
+            "PAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string"
+        }
+      },
+      "title": "OBCashAccount2"
+    },
+    "OBCashAccount3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list."
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount5": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Beneficiary account identification."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount5",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccount6": {
+      "type": "object",
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccount6",
+      "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+    },
+    "OBCashAccountCreditor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number. ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountCreditor1",
+      "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+    },
+    "OBCashAccountCreditor3": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "Name",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account. OB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountCreditor3",
+      "description": "Provides the details to identify the beneficiary account."
+    },
+    "OBCashAccountDebtor1": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account. Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+        },
+        "SchemeName": {
+          "type": "string",
+          "description": "Name of the identification scheme, in a coded form as published in an external list.",
+          "enum": [
+            "IBAN",
+            "SortCodeAccountNumber"
+          ]
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        }
+      },
+      "title": "OBCashAccountDebtor1",
+      "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+    },
+    "OBCashAccountDebtor4": {
+      "type": "object",
+      "required": [
+        "Identification",
+        "SchemeName"
+      ],
+      "properties": {
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        },
+        "SchemeName": {
+          "type": "string"
+        },
+        "SecondaryIdentification": {
+          "type": "string",
+          "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+        }
+      },
+      "title": "OBCashAccountDebtor4",
+      "description": "Provides the details to identify the debtor account."
+    },
+    "OBCashBalance1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance.  Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditLine": {
+          "type": "array",
+          "description": "Set of elements used to provide details on the credit line.",
+          "items": {
+            "$ref": "#/definitions/OBCreditLine1"
+          }
+        },
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the date (and time) of the balance. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBCashBalance1",
+      "description": "Set of elements used to define the balance details."
+    },
+    "OBCharge1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Charge type, in a coded form."
+        }
+      },
+      "title": "OBCharge1",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "ChargeBearer",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBCharge2Amount"
+        },
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2",
+      "description": "Set of elements used to provide details of a charge for the payment initiation."
+    },
+    "OBCharge2Amount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBCharge2Amount",
+      "description": "Amount of money associated with the charge type."
+    },
+    "OBCreditLine1": {
+      "type": "object",
+      "required": [
+        "Included"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Included": {
+          "type": "boolean",
+          "description": "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account."
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Available",
+            "Credit",
+            "Emergency",
+            "Pre-Agreed",
+            "Temporary"
+          ]
+        }
+      },
+      "title": "OBCreditLine1",
+      "description": "Set of elements used to provide details on the credit line."
+    },
+    "OBCurrencyExchange5": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "SourceCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique identification to unambiguously identify the foreign exchange contract."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "QuotationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which an exchange rate is quoted. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SourceCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "TargetCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency from which an amount is to be converted in a currency conversion."
+        }
+      },
+      "title": "OBCurrencyExchange5",
+      "description": "Set of elements used to provide details on the currency exchange."
+    },
+    "OBDirectDebit1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "MandateIdentification",
+        "Name"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "DirectDebitId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+        },
+        "DirectDebitStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "MandateIdentification": {
+          "type": "string",
+          "description": "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of Service User."
+        },
+        "PreviousPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "PreviousPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date of most recent direct debit collection. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDirectDebit1",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBDomestic1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBDomestic1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomestic2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+    },
+    "OBDomestic2InstructedAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomestic2InstructedAmount",
+      "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain."
+    },
+    "OBDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBDomesticScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorPostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+    },
+    "OBDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBDomesticStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "FirstPaymentAmount",
+        "FirstPaymentDateTime",
+        "Frequency"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FinalPaymentAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3FirstPaymentAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "RecurringPaymentAmount": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3RecurringPaymentAmount"
+        },
+        "RecurringPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first recurring payment for a Standing Order schedule will be made.  Usage: This must be populated only if the first recurring date is different to the first payment date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBDomesticStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+    },
+    "OBDomesticStandingOrder3FinalPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FinalPaymentAmount",
+      "description": "The amount of the final Standing Order"
+    },
+    "OBDomesticStandingOrder3FirstPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3FirstPaymentAmount",
+      "description": "The amount of the first Standing Order"
+    },
+    "OBDomesticStandingOrder3RecurringPaymentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Currency"
+      ],
+      "properties": {
+        "Amount": {
+          "type": "string"
+        },
+        "Currency": {
+          "type": "string"
+        }
+      },
+      "title": "OBDomesticStandingOrder3RecurringPaymentAmount",
+      "description": "The amount of the recurring Standing Order"
+    },
+    "OBEquivalentAmount": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CurrencyOfTransfer"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        }
+      },
+      "title": "OBEquivalentAmount",
+      "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR)."
+    },
+    "OBError1": {
+      "type": "object",
+      "required": [
+        "ErrorCode",
+        "Message"
+      ],
+      "properties": {
+        "ErrorCode": {
+          "type": "string",
+          "description": "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+        },
+        "Message": {
+          "type": "string",
+          "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBIE doesn't standardise this field"
+        },
+        "Path": {
+          "type": "string",
+          "description": "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+        },
+        "Url": {
+          "type": "string",
+          "description": "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+        }
+      },
+      "title": "OBError1"
+    },
+    "OBErrorResponse1": {
+      "type": "object",
+      "required": [
+        "Code",
+        "Errors",
+        "Message"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "High level textual error code, to help categorize the errors."
+        },
+        "Errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBError1"
+          }
+        },
+        "Id": {
+          "type": "string",
+          "description": "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+        },
+        "Message": {
+          "type": "string",
+          "description": "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+        }
+      },
+      "title": "OBErrorResponse1",
+      "description": "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+    },
+    "OBEventPolling1": {
+      "type": "object",
+      "properties": {
+        "ack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        },
+        "maxEvents": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+        },
+        "returnImmediately": {
+          "type": "boolean",
+          "description": "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+        },
+        "setErrs": {
+          "type": "object",
+          "description": "An object that encapsulates all negative acknowledgements transmitted by the TPP",
+          "additionalProperties": {
+            "$ref": "#/definitions/OBEventPolling1SetErrs"
+          }
+        }
+      },
+      "title": "OBEventPolling1"
+    },
+    "OBEventPolling1SetErrs": {
+      "type": "object",
+      "required": [
+        "description",
+        "err"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable string that provides additional diagnostic information"
+        },
+        "err": {
+          "type": "string",
+          "description": "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+        }
+      },
+      "title": "OBEventPolling1SetErrs"
+    },
+    "OBEventPollingResponse1": {
+      "type": "object",
+      "required": [
+        "moreAvailable",
+        "sets"
+      ],
+      "properties": {
+        "moreAvailable": {
+          "type": "boolean",
+          "description": "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+        },
+        "sets": {
+          "type": "object",
+          "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBEventPollingResponse1"
+    },
+    "OBEventSubscription1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscription1Data"
+        }
+      },
+      "title": "OBEventSubscription1"
+    },
+    "OBEventSubscription1Data": {
+      "type": "object",
+      "required": [
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscription1Data"
+    },
+    "OBEventSubscriptionResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1"
+    },
+    "OBEventSubscriptionResponse1Data": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBEventSubscriptionsResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1"
+    },
+    "OBEventSubscriptionsResponse1Data": {
+      "type": "object",
+      "properties": {
+        "EventSubscription": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBEventSubscriptionsResponse1DataEventSubscription"
+          }
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1Data"
+    },
+    "OBEventSubscriptionsResponse1DataEventSubscription": {
+      "type": "object",
+      "required": [
+        "EventSubscriptionId",
+        "Version"
+      ],
+      "properties": {
+        "CallbackUrl": {
+          "type": "string",
+          "description": "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+        },
+        "EventSubscriptionId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+        },
+        "EventTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "title": "OBEventSubscriptionsResponse1DataEventSubscription"
+    },
+    "OBExchangeRate1": {
+      "type": "object",
+      "required": [
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate1",
+      "description": "Provides details on the currency exchange rate and contract."
+    },
+    "OBExchangeRate2": {
+      "type": "object",
+      "required": [
+        "ExchangeRate",
+        "RateType",
+        "UnitCurrency"
+      ],
+      "properties": {
+        "ContractIdentification": {
+          "type": "string",
+          "description": "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+        },
+        "ExchangeRate": {
+          "type": "number",
+          "description": "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the exchange rate agreement will expire. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "RateType": {
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Agreed",
+            "Indicative"
+          ]
+        },
+        "UnitCurrency": {
+          "type": "string",
+          "description": "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+        }
+      },
+      "title": "OBExchangeRate2",
+      "description": "Further detailed information on the exchange rate that has been used in the payment transaction."
+    },
+    "OBFile1": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string",
+          "description": "Specifies the payment file type."
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFile1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFile2": {
+      "type": "object",
+      "required": [
+        "FileHash",
+        "FileType"
+      ],
+      "properties": {
+        "ControlSum": {
+          "type": "number",
+          "description": "Total of all individual amounts included in the group, irrespective of currencies."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FileHash": {
+          "type": "string",
+          "description": "A base64 encoding of a SHA256 hash of the file to be uploaded."
+        },
+        "FileReference": {
+          "type": "string",
+          "description": "Reference for the file."
+        },
+        "FileType": {
+          "type": "string"
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "NumberOfTransactions": {
+          "type": "string",
+          "description": "Number of individual transactions contained in the payment information group."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBFile2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+    },
+    "OBFundsAvailableResult1": {
+      "type": "object",
+      "required": [
+        "FundsAvailable",
+        "FundsAvailableDateTime"
+      ],
+      "properties": {
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the availability of funds given the Amount in the consent request."
+        },
+        "FundsAvailableDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the funds availability check was generated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsAvailableResult1",
+      "description": "Result of a funds availability check."
+    },
+    "OBFundsConfirmation1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationData1"
+        }
+      },
+      "title": "OBFundsConfirmation1"
+    },
+    "OBFundsConfirmationConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentData1"
+        }
+      },
+      "title": "OBFundsConfirmationConsent1"
+    },
+    "OBFundsConfirmationConsentData1": {
+      "type": "object",
+      "required": [
+        "DebtorAccount"
+      ],
+      "properties": {
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentData1"
+    },
+    "OBFundsConfirmationConsentDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DebtorAccount",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBFundsConfirmationConsentDataResponse1"
+    },
+    "OBFundsConfirmationConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationConsentDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationConsentResponse1"
+    },
+    "OBFundsConfirmationData1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationData1"
+    },
+    "OBFundsConfirmationDataResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FundsAvailable",
+        "FundsConfirmationId",
+        "InstructedAmount",
+        "Reference"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FundsAvailable": {
+          "type": "boolean",
+          "description": "Flag to indicate the result of a confirmation of funds check."
+        },
+        "FundsConfirmationId": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+        }
+      },
+      "title": "OBFundsConfirmationDataResponse1"
+    },
+    "OBFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBFundsConfirmationDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBFundsConfirmationResponse1"
+    },
+    "OBInitiation1": {
+      "type": "object",
+      "required": [
+        "EndToEndIdentification",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor1"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInitiation1"
+    },
+    "OBInternational1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        }
+      },
+      "title": "OBInternational1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternational2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "EndToEndIdentification",
+        "InstructedAmount",
+        "InstructionIdentification"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternational2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+    },
+    "OBInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string",
+          "description": "User community specific instrument. Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBInternationalScheduled1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "InstructedAmount",
+        "InstructionIdentification",
+        "RequestedExecutionDateTime"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "EndToEndIdentification": {
+          "type": "string",
+          "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain. Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction. OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate1"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "InstructionIdentification": {
+          "type": "string",
+          "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. Usage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+        },
+        "InstructionPriority": {
+          "type": "string",
+          "enum": [
+            "Normal",
+            "Urgent"
+          ]
+        },
+        "LocalInstrument": {
+          "type": "string"
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "RemittanceInformation": {
+          "$ref": "#/definitions/OBRemittanceInformation1"
+        },
+        "RequestedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the initiating party requests the clearing agent to process the payment.  Usage: This is the date on which the debtor's account is to be debited. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalScheduled2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+    },
+    "OBInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date. "
+        },
+        "Purpose": {
+          "type": "string",
+          "description": "Specifies the external purpose code in the format of character string with a maximum length of 35 characters. The list of valid codes is an external code list published separately. External code sets can be downloaded from www.iso20022.org."
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        }
+      },
+      "title": "OBInternationalStandingOrder1",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED).  ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder2",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "CreditorAccount",
+        "CurrencyOfTransfer",
+        "FirstPaymentDateTime",
+        "Frequency",
+        "InstructedAmount"
+      ],
+      "properties": {
+        "ChargeBearer": {
+          "type": "string",
+          "enum": [
+            "BorneByCreditor",
+            "BorneByDebtor",
+            "FollowingServiceLevel",
+            "Shared"
+          ]
+        },
+        "Creditor": {
+          "$ref": "#/definitions/OBPartyIdentification43"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccountCreditor3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyOfTransfer": {
+          "type": "string",
+          "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccountDebtor4"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBDomestic2InstructedAmount"
+        },
+        "NumberOfPayments": {
+          "type": "string",
+          "description": "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+        },
+        "Purpose": {
+          "type": "string"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBInternationalStandingOrder3",
+      "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+    },
+    "OBMerchantDetails1": {
+      "type": "object",
+      "properties": {
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantName": {
+          "type": "string",
+          "description": "Name by which the merchant is known."
+        }
+      },
+      "title": "OBMerchantDetails1",
+      "description": "Details of the merchant involved in the transaction."
+    },
+    "OBMultiAuthorisation1": {
+      "type": "object",
+      "required": [
+        "Status"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "LastUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last date and time at the authorisation flow was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "NumberReceived": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "NumberRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingFurtherAuthorisation",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBMultiAuthorisation1",
+      "description": "The multiple authorisation flow response from the ASPSP."
+    },
+    "OBOffer1": {
+      "type": "object",
+      "required": [
+        "AccountId"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Further details of the offer."
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Fee": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "OfferId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+        },
+        "OfferType": {
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "LimitIncrease",
+            "MoneyTransfer",
+            "Other",
+            "PromotionalRate"
+          ]
+        },
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the offer type."
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the offer starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Term": {
+          "type": "string",
+          "description": "Further details of the term of the offer."
+        },
+        "URL": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the offer type."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (Uniform Resource Locator) where documentation on the offer can be found"
+        }
+      },
+      "title": "OBOffer1"
+    },
+    "OBOtherCodeType10": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType10"
+    },
+    "OBOtherCodeType11": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType11",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OBOtherCodeType12": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType12",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OBOtherCodeType13": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType13",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OBOtherCodeType14": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType14",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OBOtherCodeType15": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType15",
+      "description": "Other fee rate type which is not in the standard rate type list"
+    },
+    "OBOtherCodeType16": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType16",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OBOtherCodeType17": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType17",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OBOtherCodeType18": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBOtherCodeType18",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OBOtherFeeChargeDetailType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OBOtherFeeChargeDetailType",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OBParty1": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        }
+      },
+      "title": "OBParty1"
+    },
+    "OBParty2": {
+      "type": "object",
+      "required": [
+        "PartyId"
+      ],
+      "properties": {
+        "AccountRole": {
+          "type": "string"
+        },
+        "Address": {
+          "type": "array",
+          "description": "Postal address of a party.",
+          "items": {
+            "$ref": "#/definitions/OBPostalAddress8"
+          }
+        },
+        "BeneficialOwnership": {
+          "type": "boolean",
+          "description": "A flag to indicate a party’s beneficial ownership of the related account."
+        },
+        "EmailAddress": {
+          "type": "string",
+          "description": "Address for electronic mail (e-mail)."
+        },
+        "FullLegalName": {
+          "type": "string",
+          "description": "The full legal name of the party."
+        },
+        "LegalStructure": {
+          "type": "string"
+        },
+        "Mobile": {
+          "type": "string",
+          "description": "Collection of information that identifies a mobile phone number, as defined by telecom services."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PartyId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+        },
+        "PartyNumber": {
+          "type": "string",
+          "description": "Number assigned by an agent to identify its customer."
+        },
+        "PartyType": {
+          "type": "string",
+          "enum": [
+            "Delegate",
+            "Joint",
+            "Sole"
+          ]
+        },
+        "Phone": {
+          "type": "string",
+          "description": "Collection of information that identifies a phone number, as defined by telecom services."
+        },
+        "Relationships": {
+          "$ref": "#/definitions/OBPartyRelationships1"
+        }
+      },
+      "title": "OBParty2"
+    },
+    "OBPartyIdentification43": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name by which a party is known and which is usually used to identify that party."
+        },
+        "PostalAddress": {
+          "$ref": "#/definitions/OBPostalAddress6"
+        }
+      },
+      "title": "OBPartyIdentification43",
+      "description": "Party to which an amount of money is due."
+    },
+    "OBPartyRelationships1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "$ref": "#/definitions/OBRelationship1"
+        }
+      },
+      "title": "OBPartyRelationships1",
+      "description": "The Party's relationships with other resources."
+    },
+    "OBPaymentDataSetup1": {
+      "type": "object",
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        }
+      },
+      "title": "OBPaymentDataSetup1"
+    },
+    "OBPaymentDataSetupResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSetupResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentDataSubmission1": {
+      "type": "object",
+      "required": [
+        "PaymentId"
+      ],
+      "properties": {
+        "Initiation": {
+          "$ref": "#/definitions/OBInitiation1"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        }
+      },
+      "title": "OBPaymentDataSubmission1"
+    },
+    "OBPaymentDataSubmissionResponse1": {
+      "type": "object",
+      "required": [
+        "CreationDateTime",
+        "PaymentId",
+        "PaymentSubmissionId"
+      ],
+      "properties": {
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "PaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment setup resource."
+        },
+        "PaymentSubmissionId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the payment submission resource."
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the payment resource.",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        }
+      },
+      "title": "OBPaymentDataSubmissionResponse1",
+      "description": "Reflection of The Main Data Payload, with Created Resource ID, Status and Timestamp"
+    },
+    "OBPaymentSetup1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetup1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetup1",
+      "description": "Allows setup of a payment"
+    },
+    "OBPaymentSetupResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSetupResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSetupResponse1"
+    },
+    "OBPaymentSubmission1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmission1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBPaymentSubmission1",
+      "description": "Allows Submission of a payment"
+    },
+    "OBPaymentSubmissionResponse1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBPaymentDataSubmissionResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBPaymentSubmissionResponse1"
+    },
+    "OBPostalAddress6": {
+      "type": "object",
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country such as state, region, county."
+        },
+        "Department": {
+          "type": "string",
+          "description": "Identification of a division of a large organisation or building."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "SubDepartment": {
+          "type": "string",
+          "description": "Identification of a sub-division of a large organisation or building."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress6",
+      "description": "Information that locates and identifies a specific address, as defined by postal services."
+    },
+    "OBPostalAddress8": {
+      "type": "object",
+      "required": [
+        "Country"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressType": {
+          "type": "string",
+          "enum": [
+            "Business",
+            "Correspondence",
+            "DeliveryTo",
+            "MailTo",
+            "POBox",
+            "Postal",
+            "Residential",
+            "Statement"
+          ]
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "string",
+          "description": "Identifies a subdivision of a country eg, state, region, county."
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBPostalAddress8",
+      "description": "Postal address of a party."
+    },
+    "OBProduct1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductIdentifier",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "ProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Descriptive code for the product category.",
+          "enum": [
+            "BCA",
+            "PCA"
+          ]
+        },
+        "SecondaryProductIdentifier": {
+          "type": "string",
+          "description": "Identifier within the parent organisation for the product. Must be unique in the organisation."
+        }
+      },
+      "title": "OBProduct1",
+      "description": "Product"
+    },
+    "OBReadAccount1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataAccount1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount1"
+    },
+    "OBReadAccount2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount2"
+    },
+    "OBReadAccount2Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount2"
+          }
+        }
+      },
+      "title": "OBReadAccount2Data"
+    },
+    "OBReadAccount3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadAccount3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadAccount3"
+    },
+    "OBReadAccount3Data": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+          "items": {
+            "$ref": "#/definitions/OBAccount3"
+          }
+        }
+      },
+      "title": "OBReadAccount3Data"
+    },
+    "OBReadBalance1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBalance1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBalance1"
+    },
+    "OBReadBalance1Data": {
+      "type": "object",
+      "required": [
+        "Balance"
+      ],
+      "properties": {
+        "Balance": {
+          "type": "array",
+          "description": "Set of elements used to define the balance details.",
+          "items": {
+            "$ref": "#/definitions/OBCashBalance1"
+          }
+        }
+      },
+      "title": "OBReadBalance1Data"
+    },
+    "OBReadBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataBeneficiary1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary1"
+    },
+    "OBReadBeneficiary2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary2"
+    },
+    "OBReadBeneficiary2Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary2"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary2Data"
+    },
+    "OBReadBeneficiary3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadBeneficiary3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadBeneficiary3"
+    },
+    "OBReadBeneficiary3Data": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary3"
+          }
+        }
+      },
+      "title": "OBReadBeneficiary3Data"
+    },
+    "OBReadConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadConsentResponse1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadConsentResponse1"
+    },
+    "OBReadConsentResponse1Data": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Permissions",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account access consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadConsentResponse1Data"
+    },
+    "OBReadData1": {
+      "type": "object",
+      "required": [
+        "Permissions"
+      ],
+      "properties": {
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadData1"
+    },
+    "OBReadDataAccount1": {
+      "type": "object",
+      "properties": {
+        "Account": {
+          "type": "array",
+          "description": "Account",
+          "items": {
+            "$ref": "#/definitions/OBAccount1"
+          }
+        }
+      },
+      "title": "OBReadDataAccount1",
+      "description": "Data"
+    },
+    "OBReadDataBeneficiary1": {
+      "type": "object",
+      "properties": {
+        "Beneficiary": {
+          "type": "array",
+          "description": "Beneficiary",
+          "items": {
+            "$ref": "#/definitions/OBBeneficiary1"
+          }
+        }
+      },
+      "title": "OBReadDataBeneficiary1",
+      "description": "Data"
+    },
+    "OBReadDataProduct1": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "description": "Product",
+          "items": {
+            "$ref": "#/definitions/OBProduct1"
+          }
+        }
+      },
+      "title": "OBReadDataProduct1",
+      "description": "Data"
+    },
+    "OBReadDataResponse1": {
+      "type": "object",
+      "required": [
+        "AccountRequestId",
+        "CreationDateTime",
+        "Permissions"
+      ],
+      "properties": {
+        "AccountRequestId": {
+          "type": "string",
+          "description": "Unique identification as assigned to identify the account request resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpirationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Permissions": {
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Specifies the status of the account request resource.",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
+          ]
+        },
+        "TransactionFromDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "TransactionToDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBReadDataResponse1",
+      "description": "Account Request Response"
+    },
+    "OBReadDataStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "StandingOrder",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder1"
+          }
+        }
+      },
+      "title": "OBReadDataStandingOrder1",
+      "description": "Data"
+    },
+    "OBReadDataTransaction1": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Transaction",
+          "items": {
+            "$ref": "#/definitions/OBTransaction1"
+          }
+        }
+      },
+      "title": "OBReadDataTransaction1",
+      "description": "Data"
+    },
+    "OBReadDirectDebit1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDirectDebit1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadDirectDebit1"
+    },
+    "OBReadDirectDebit1Data": {
+      "type": "object",
+      "properties": {
+        "DirectDebit": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBDirectDebit1"
+          }
+        }
+      },
+      "title": "OBReadDirectDebit1Data"
+    },
+    "OBReadOffer1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadOffer1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadOffer1"
+    },
+    "OBReadOffer1Data": {
+      "type": "object",
+      "properties": {
+        "Offer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBOffer1"
+          }
+        }
+      },
+      "title": "OBReadOffer1Data"
+    },
+    "OBReadParty1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty1"
+    },
+    "OBReadParty1Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty1"
+        }
+      },
+      "title": "OBReadParty1Data"
+    },
+    "OBReadParty2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty2"
+    },
+    "OBReadParty2Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "$ref": "#/definitions/OBParty2"
+        }
+      },
+      "title": "OBReadParty2Data"
+    },
+    "OBReadParty3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadParty3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadParty3"
+    },
+    "OBReadParty3Data": {
+      "type": "object",
+      "properties": {
+        "Party": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBParty2"
+          }
+        }
+      },
+      "title": "OBReadParty3Data"
+    },
+    "OBReadProduct1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataProduct1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct1"
+    },
+    "OBReadProduct2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadProduct2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadProduct2"
+    },
+    "OBReadProduct2Data": {
+      "type": "object",
+      "properties": {
+        "Product": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataProduct"
+          }
+        }
+      },
+      "title": "OBReadProduct2Data"
+    },
+    "OBReadProduct2DataOtherProductType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterest"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description of the Product associated with the account"
+        },
+        "LoanInterest": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterest"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the product"
+        },
+        "OtherFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherFeesCharges"
+          }
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraft"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeProductDetails"
+        },
+        "Repayment": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepayment"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductType",
+      "description": "Other product type details associated with the account."
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterest": {
+      "type": "object",
+      "required": [
+        "TierBandSet"
+      ],
+      "properties": {
+        "TierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterest",
+      "description": "Details about the interest that may be payable to the Account holders"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBand": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FixedVariableInterestRateType",
+        "TierValueMinimum",
+        "aer"
+      ],
+      "properties": {
+        "AER": {
+          "type": "string"
+        },
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "BankInterestRate": {
+          "type": "string",
+          "description": "Bank Interest for the product"
+        },
+        "BankInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is credit interest calculated for the account.",
+          "enum": [
+            "FQAT",
+            "FQDY",
+            "FQHY",
+            "FQMY",
+            "FQOT",
+            "FQQY",
+            "FQSD",
+            "FQWY",
+            "FQYY"
+          ]
+        },
+        "DepositInterestAppliedCoverage": {
+          "type": "string",
+          "description": "Amount on which Interest applied.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for the Product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherBankInterestType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum deposit value for which the credit interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum deposit value for which the credit interest tier applies."
+        },
+        "aer": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "Destination",
+        "TierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Destination": {
+          "type": "string",
+          "description": "Describes whether accrued interest is payable only to the BCA or to another bank account",
+          "enum": [
+            "INOT",
+            "INPA",
+            "INSC"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherDestination": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeCreditInterestTierBand"
+          }
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet",
+      "description": "The group of tiers or bands for which credit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeFeeApplicableRange": {
+      "type": "object",
+      "properties": {
+        "MaximumAmount": {
+          "type": "string",
+          "description": "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+        },
+        "MaximumRate": {
+          "type": "string",
+          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        },
+        "MinimumAmount": {
+          "type": "string",
+          "description": "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+        },
+        "MinimumRate": {
+          "type": "string",
+          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeApplicableRange",
+      "description": "Range or amounts or rates for which the fee/charge applies"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterest": {
+      "type": "object",
+      "required": [
+        "LoanInterestTierBandSet"
+      ],
+      "properties": {
+        "LoanInterestTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterest",
+      "description": "Details about the interest that may be payable to the SME Loan holders"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap",
+      "description": "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType15"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges": {
+      "type": "object",
+      "required": [
+        "LoanInterestFeeChargeDetail"
+      ],
+      "properties": {
+        "LoanInterestFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap"
+          }
+        },
+        "LoanInterestFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand": {
+      "type": "object",
+      "required": [
+        "FixedVariableInterestRateType",
+        "MinTermPeriod",
+        "RepAPR",
+        "TierValueMinTerm",
+        "TierValueMinimum"
+      ],
+      "properties": {
+        "FixedVariableInterestRateType": {
+          "type": "string",
+          "enum": [
+            "Fixed",
+            "Variable"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanProviderInterestRate": {
+          "type": "string",
+          "description": "Loan provider Interest for the SME Loan product"
+        },
+        "LoanProviderInterestRateType": {
+          "type": "string",
+          "description": "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "MaxTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Maximum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MinTermPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the Minimum Term",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherLoanProviderInterestRateType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType"
+        },
+        "RepAPR": {
+          "type": "string",
+          "description": "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees."
+        },
+        "TierValueMaxTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum loan term for which the loan interest tier applies."
+        },
+        "TierValueMaximum": {
+          "type": "string",
+          "description": "Maximum loan value for which the loan interest tier applies."
+        },
+        "TierValueMinTerm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum loan term for which the loan interest tier applies."
+        },
+        "TierValueMinimum": {
+          "type": "string",
+          "description": "Minimum loan value for which the loan interest tier applies."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand",
+      "description": "Tier Band Details"
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet": {
+      "type": "object",
+      "required": [
+        "CalculationMethod",
+        "LoanInterestTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "CalculationMethod": {
+          "type": "string",
+          "enum": [
+            "Compound",
+            "SimpleInterest"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+        },
+        "LoanInterestFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges"
+          }
+        },
+        "LoanInterestTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand"
+          }
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherCalculationMethod": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet",
+      "description": "The group of tiers or bands for which debit interest can be applied."
+    },
+    "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType",
+      "description": "Other loan interest rate types which are not available in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeFeeChargeDetail"
+          }
+        },
+        "OtherTariffType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOtherTariffType"
+        },
+        "TariffName": {
+          "type": "string",
+          "description": "Name of the tariff"
+        },
+        "TariffType": {
+          "type": "string",
+          "description": "TariffType which defines the fee and charges.",
+          "enum": [
+            "TTEL",
+            "TTMX",
+            "TTOT"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+    },
+    "OBReadProduct2DataOtherProductTypeOtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraft",
+      "description": "Borrowing details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FBAO",
+              "FBAR",
+              "FBEB",
+              "FBIT",
+              "FBOR",
+              "FBOS",
+              "FBSC",
+              "FBTO",
+              "FBUB",
+              "FBUT",
+              "FTOT",
+              "FTUT"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType11"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType12"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType14"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherCodeType13"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "OVCO",
+            "OVOD",
+            "OVOT"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "INBA",
+            "INTI",
+            "INWH"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OBReadProduct2DataOtherProductTypeProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherSegment": {
+          "$ref": "#/definitions/OBOtherCodeType10"
+        },
+        "Segment": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "GEAS",
+              "GEBA",
+              "GEBR",
+              "GEBU",
+              "GECI",
+              "GECS",
+              "GEFB",
+              "GEFG",
+              "GEG",
+              "GEGR",
+              "GEGS",
+              "GEOT",
+              "GEOV",
+              "GEPA",
+              "GEPR",
+              "GERE",
+              "GEST",
+              "GEYA",
+              "GEYO",
+              "PSCA",
+              "PSES",
+              "PSNC",
+              "PSNP",
+              "PSRG",
+              "PSSS",
+              "PSST",
+              "PSSW"
+            ]
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeProductDetails"
+    },
+    "OBReadProduct2DataOtherProductTypeRepayment": {
+      "type": "object",
+      "properties": {
+        "AmountType": {
+          "type": "string",
+          "description": "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc",
+          "enum": [
+            "RABD",
+            "RABL",
+            "RACI",
+            "RAFC",
+            "RAIO",
+            "RALT",
+            "USOT"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherAmountType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType"
+        },
+        "OtherRepaymentFrequency": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency"
+        },
+        "OtherRepaymentType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType"
+        },
+        "RepaymentFeeCharges": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges"
+        },
+        "RepaymentFrequency": {
+          "type": "string",
+          "description": "Repayment frequency",
+          "enum": [
+            "SMDA",
+            "SMFL",
+            "SMFO",
+            "SMHY",
+            "SMMO",
+            "SMOT",
+            "SMQU",
+            "SMWE",
+            "SMYE"
+          ]
+        },
+        "RepaymentHoliday": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday"
+          }
+        },
+        "RepaymentType": {
+          "type": "string",
+          "description": "Repayment type",
+          "enum": [
+            "USBA",
+            "USBU",
+            "USCI",
+            "USCS",
+            "USER",
+            "USFA",
+            "USFB",
+            "USFI",
+            "USIO",
+            "USOT",
+            "USPF",
+            "USRW",
+            "USSL"
+          ]
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepayment",
+      "description": "Repayment details of the Loan product"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType",
+      "description": "Other amount type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency",
+      "description": "Other repayment frequency which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType",
+      "description": "Other repayment type which is not in the standard code list"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges": {
+      "type": "object",
+      "required": [
+        "RepaymentFeeChargeDetail"
+      ],
+      "properties": {
+        "RepaymentFeeChargeCap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap"
+          }
+        },
+        "RepaymentFeeChargeDetail": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges",
+      "description": "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string"
+        },
+        "FeeCapOccurrence": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FeeType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "FEPF",
+              "FTOT",
+              "FYAF",
+              "FYAM",
+              "FYAQ",
+              "FYCP",
+              "FYDB",
+              "FYMI",
+              "FYXX"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap",
+      "description": "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "CalculationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "enum": [
+            "FEAC",
+            "FEAO",
+            "FECP",
+            "FEDA",
+            "FEHO",
+            "FEI",
+            "FEMO",
+            "FEOA",
+            "FEOT",
+            "FEPC",
+            "FEPH",
+            "FEPO",
+            "FEPS",
+            "FEPT",
+            "FEPTA",
+            "FEPTP",
+            "FEQU",
+            "FESM",
+            "FEST",
+            "FEWE",
+            "FEYE"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string"
+        },
+        "FeeRate": {
+          "type": "string"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "enum": [
+            "INBB",
+            "INFR",
+            "INGR",
+            "INLR",
+            "INNE",
+            "INOT"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "enum": [
+            "Other",
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCAccountFeeQuarterly",
+            "ServiceCFixedTariff",
+            "ServiceCBusiDepAccBreakage",
+            "ServiceCMinimumMonthlyFee",
+            "ServiceCOther"
+          ]
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Fee/charge which is usually negotiable rather than a fixed amount"
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType16"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OBOtherCodeType17"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OBOtherCodeType18"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OBOtherFeeChargeDetailType"
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail",
+      "description": "Details about specific fees/charges that are applied for repayment"
+    },
+    "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday": {
+      "type": "object",
+      "properties": {
+        "MaxHolidayLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum length/duration of a Repayment Holiday"
+        },
+        "MaxHolidayPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the repayment holiday",
+          "enum": [
+            "PACT",
+            "PDAY",
+            "PHYR",
+            "PMTH",
+            "PQTR",
+            "PWEK",
+            "PYER"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday",
+      "description": "Details of capital repayment holiday if any"
+    },
+    "OBReadProduct2DataProduct": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "ProductType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "Account Identification of the customer for Product Details"
+        },
+        "BCA": {
+          "$ref": "#/definitions/BCA"
+        },
+        "MarketingStateId": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Product Marketing State."
+        },
+        "OtherProductType": {
+          "$ref": "#/definitions/OBReadProduct2DataOtherProductType"
+        },
+        "PCA": {
+          "$ref": "#/definitions/PCA"
+        },
+        "ProductId": {
+          "type": "string",
+          "description": "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+        },
+        "ProductName": {
+          "type": "string",
+          "description": "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+        },
+        "ProductType": {
+          "type": "string",
+          "description": "Product type : Personal Current Account, Business Current Account",
+          "enum": [
+            "BusinessCurrentAccount",
+            "CommercialCreditCard",
+            "Other",
+            "PersonalCurrentAccount",
+            "SMELoan"
+          ]
+        },
+        "SecondaryProductId": {
+          "type": "string",
+          "description": "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+        },
+        "bca": {
+          "$ref": "#/definitions/BCA"
+        },
+        "pca": {
+          "$ref": "#/definitions/PCA"
+        }
+      },
+      "title": "OBReadProduct2DataProduct",
+      "description": "Product details associated with the Account"
+    },
+    "OBReadRequest1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadData1"
+        },
+        "Risk": {
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.",
+          "$ref": "#/definitions/OBRisk2"
+        }
+      },
+      "title": "OBReadRequest1",
+      "description": "Allows setup of an account access request"
+    },
+    "OBReadResponse1": {
+      "type": "object",
+      "required": [
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "type": "object",
+          "description": "The Risk payload is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+        }
+      },
+      "title": "OBReadResponse1"
+    },
+    "OBReadScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment1"
+    },
+    "OBReadScheduledPayment1Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment1"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment1Data"
+    },
+    "OBReadScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadScheduledPayment2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadScheduledPayment2"
+    },
+    "OBReadScheduledPayment2Data": {
+      "type": "object",
+      "properties": {
+        "ScheduledPayment": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBScheduledPayment2"
+          }
+        }
+      },
+      "title": "OBReadScheduledPayment2Data"
+    },
+    "OBReadStandingOrder1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataStandingOrder1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder1"
+    },
+    "OBReadStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder2"
+    },
+    "OBReadStandingOrder2Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "description": "Account to or from which a cash entry is made.",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder2"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder2Data"
+    },
+    "OBReadStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder3"
+    },
+    "OBReadStandingOrder3Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder3"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder3Data"
+    },
+    "OBReadStandingOrder4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder4"
+    },
+    "OBReadStandingOrder4Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder4"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder4Data"
+    },
+    "OBReadStandingOrder5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStandingOrder5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStandingOrder5"
+    },
+    "OBReadStandingOrder5Data": {
+      "type": "object",
+      "properties": {
+        "StandingOrder": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OBStandingOrder5"
+          }
+        }
+      },
+      "title": "OBReadStandingOrder5Data"
+    },
+    "OBReadStatement1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadStatement1Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadStatement1"
+    },
+    "OBReadStatement1Data": {
+      "type": "object",
+      "properties": {
+        "Statement": {
+          "type": "array",
+          "description": "Provides further details on a statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatement1"
+          }
+        }
+      },
+      "title": "OBReadStatement1Data"
+    },
+    "OBReadTransaction1": {
+      "type": "object",
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadDataTransaction1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction1"
+    },
+    "OBReadTransaction2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction2Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction2"
+    },
+    "OBReadTransaction2Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction2"
+          }
+        }
+      },
+      "title": "OBReadTransaction2Data"
+    },
+    "OBReadTransaction3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction3Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction3"
+    },
+    "OBReadTransaction3Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction3"
+          }
+        }
+      },
+      "title": "OBReadTransaction3Data"
+    },
+    "OBReadTransaction4": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction4Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction4"
+    },
+    "OBReadTransaction4Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction4"
+          }
+        }
+      },
+      "title": "OBReadTransaction4Data"
+    },
+    "OBReadTransaction5": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBReadTransaction5Data"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBReadTransaction5"
+    },
+    "OBReadTransaction5Data": {
+      "type": "object",
+      "properties": {
+        "Transaction": {
+          "type": "array",
+          "description": "Provides further details on an entry in the report.",
+          "items": {
+            "$ref": "#/definitions/OBTransaction5"
+          }
+        }
+      },
+      "title": "OBReadTransaction5Data"
+    },
+    "OBRelationship1": {
+      "type": "object",
+      "required": [
+        "Id",
+        "Related"
+      ],
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+        },
+        "Related": {
+          "type": "string",
+          "description": "Absolute URI to the related resource."
+        }
+      },
+      "title": "OBRelationship1",
+      "description": "Relationship to the Account resource."
+    },
+    "OBRemittanceInformation1": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. OB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+        },
+        "Unstructured": {
+          "type": "string",
+          "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+        }
+      },
+      "title": "OBRemittanceInformation1",
+      "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+    },
+    "OBRisk1": {
+      "type": "object",
+      "properties": {
+        "DeliveryAddress": {
+          "$ref": "#/definitions/OBRisk1DeliveryAddress"
+        },
+        "MerchantCategoryCode": {
+          "type": "string",
+          "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+        },
+        "MerchantCustomerIdentification": {
+          "type": "string",
+          "description": "The unique customer identifier of the PSU with the merchant."
+        },
+        "PaymentContextCode": {
+          "type": "string",
+          "enum": [
+            "BillPayment",
+            "EcommerceGoods",
+            "EcommerceServices",
+            "Other",
+            "PartyToParty"
+          ]
+        }
+      },
+      "title": "OBRisk1",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+    },
+    "OBRisk1DeliveryAddress": {
+      "type": "object",
+      "required": [
+        "Country",
+        "TownName"
+      ],
+      "properties": {
+        "AddressLine": {
+          "type": "array",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BuildingNumber": {
+          "type": "string",
+          "description": "Number that identifies the position of a building on a street."
+        },
+        "Country": {
+          "type": "string",
+          "description": "Nation with its own government, occupying a particular territory."
+        },
+        "CountrySubDivision": {
+          "type": "array",
+          "description": "Identifies a subdivision of a country, for instance state, region, county.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PostCode": {
+          "type": "string",
+          "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+        },
+        "StreetName": {
+          "type": "string",
+          "description": "Name of a street or thoroughfare."
+        },
+        "TownName": {
+          "type": "string",
+          "description": "Name of a built-up area, with defined boundaries, and a local government."
+        }
+      },
+      "title": "OBRisk1DeliveryAddress",
+      "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+    },
+    "OBRisk2": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBRisk2",
+      "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+    },
+    "OBScheduledPayment1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment1"
+    },
+    "OBScheduledPayment2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "InstructedAmount",
+        "ScheduledPaymentDateTime",
+        "ScheduledType"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "InstructedAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "ScheduledPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the scheduled payment will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ScheduledPaymentId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+        },
+        "ScheduledType": {
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        }
+      },
+      "title": "OBScheduledPayment2"
+    },
+    "OBStandingOrder1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "The date on which the first payment for a Standing Order schedule will be made."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Patterns:  EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay  The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) "
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "Servicer": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        }
+      },
+      "title": "OBStandingOrder1",
+      "description": "Standing Order"
+    },
+    "OBStandingOrder2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentAmount",
+        "NextPaymentDateTime"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount1"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "description": "Specifies the status of the standing order in code form.",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder2",
+      "description": "Account to or from which a cash entry is made."
+    },
+    "OBStandingOrder3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made.  This field is mandatory for Active Standing Orders. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        }
+      },
+      "title": "OBStandingOrder3"
+    },
+    "OBStandingOrder4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification4"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.  SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.  Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder4"
+    },
+    "OBStandingOrder5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Frequency"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount5"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification5"
+        },
+        "FinalPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FinalPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the final payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FirstPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "FirstPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the first payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Frequency": {
+          "type": "string",
+          "description": "Individual Definitions: EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(EvryDay)$|^(EvryWorkgDay)$|^IntrvlDay:(0?[2-9]|[1-2][0-9]|3[0-1])$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "NextPaymentAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "NextPaymentDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the next payment for a Standing Order schedule will be made. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Reference": {
+          "type": "string",
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+        },
+        "StandingOrderId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+        },
+        "StandingOrderStatusCode": {
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBStandingOrder5"
+    },
+    "OBStatement1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "CreationDateTime",
+        "EndDateTime",
+        "StartDateTime",
+        "Type"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "EndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period ends. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the statement period starts. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "StatementAmount": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementAmount1"
+          }
+        },
+        "StatementBenefit": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementBenefit1"
+          }
+        },
+        "StatementDateTime": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementDateTime1"
+          }
+        },
+        "StatementDescription": {
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatementFee": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementFee1"
+          }
+        },
+        "StatementId": {
+          "type": "string",
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+        },
+        "StatementInterest": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementInterest1"
+          }
+        },
+        "StatementRate": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementRate1"
+          }
+        },
+        "StatementReference": {
+          "type": "string",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "StatementValue": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+          "items": {
+            "$ref": "#/definitions/OBStatementValue1"
+          }
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        }
+      },
+      "title": "OBStatement1",
+      "description": "Provides further details on a statement resource."
+    },
+    "OBStatementAmount1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementAmount1",
+      "description": "Set of elements used to provide details of a generic amount for the statement resource."
+    },
+    "OBStatementBenefit1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Benefit type, in a coded form."
+        }
+      },
+      "title": "OBStatementBenefit1",
+      "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+    },
+    "OBStatementDateTime1": {
+      "type": "object",
+      "required": [
+        "DateTime",
+        "Type"
+      ],
+      "properties": {
+        "DateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time associated with the date time type. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Type": {
+          "type": "string",
+          "description": "Date time type, in a coded form."
+        }
+      },
+      "title": "OBStatementDateTime1",
+      "description": "Set of elements used to provide details of a generic date time for the statement resource."
+    },
+    "OBStatementFee1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Fee type, in a coded form."
+        }
+      },
+      "title": "OBStatementFee1",
+      "description": "Set of elements used to provide details of a fee for the statement resource."
+    },
+    "OBStatementInterest1": {
+      "type": "object",
+      "required": [
+        "Amount",
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the amount is a credit or a debit.  Usage: A zero amount is considered to be a credit amount.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Interest amount type, in a coded form."
+        }
+      },
+      "title": "OBStatementInterest1",
+      "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+    },
+    "OBStatementRate1": {
+      "type": "object",
+      "required": [
+        "Rate",
+        "Type"
+      ],
+      "properties": {
+        "Rate": {
+          "type": "string",
+          "description": "Rate associated with the statement rate type."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Statement rate type, in a coded form."
+        }
+      },
+      "title": "OBStatementRate1",
+      "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+    },
+    "OBStatementValue1": {
+      "type": "object",
+      "required": [
+        "Type",
+        "Value"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "Statement value type, in a coded form."
+        },
+        "Value": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value associated with the statement value type."
+        }
+      },
+      "title": "OBStatementValue1",
+      "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+    },
+    "OBSupplementaryData1": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "title": "OBSupplementaryData1",
+      "description": "Additional information that can not be captured in the structured fields and/or any other specific block."
+    },
+    "OBTransaction1": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction. This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit entry.  Usage: If entry status is pending and value date is present, then the value date refers to an expected/requested value date. For entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the  number of availability days.  All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction1"
+    },
+    "OBTransaction2": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string",
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount2"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
+        },
+        "EquivalentAmount": {
+          "$ref": "#/definitions/OBEquivalentAmount"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/ProprietaryBankTransactionCodeStructure1"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string",
+          "description": "Further details of the transaction.  This is the transaction narrative, which is unstructured text."
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction2",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction3",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction3ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction3ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransaction4": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount3"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction3ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction4",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5": {
+      "type": "object",
+      "required": [
+        "AccountId",
+        "Amount",
+        "BookingDateTime",
+        "CreditDebitIndicator",
+        "Status"
+      ],
+      "properties": {
+        "AccountId": {
+          "type": "string"
+        },
+        "AddressLine": {
+          "type": "string",
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+        },
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "Balance": {
+          "$ref": "#/definitions/OBTransactionCashBalance"
+        },
+        "BankTransactionCode": {
+          "$ref": "#/definitions/OBBankTransactionCodeStructure1"
+        },
+        "BookingDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CardInstrument": {
+          "$ref": "#/definitions/OBTransactionCardInstrument1"
+        },
+        "ChargeAmount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the transaction is a credit or a debit entry.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "CreditorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "CreditorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "CurrencyExchange": {
+          "$ref": "#/definitions/OBCurrencyExchange5"
+        },
+        "DebtorAccount": {
+          "$ref": "#/definitions/OBCashAccount6"
+        },
+        "DebtorAgent": {
+          "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification6"
+        },
+        "MerchantDetails": {
+          "$ref": "#/definitions/OBMerchantDetails1"
+        },
+        "ProprietaryBankTransactionCode": {
+          "$ref": "#/definitions/OBTransaction5ProprietaryBankTransactionCode"
+        },
+        "StatementReference": {
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        },
+        "TransactionId": {
+          "type": "string",
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+        },
+        "TransactionInformation": {
+          "type": "string"
+        },
+        "TransactionReference": {
+          "type": "string",
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+        },
+        "ValueDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBTransaction5",
+      "description": "Provides further details on an entry in the report."
+    },
+    "OBTransaction5ProprietaryBankTransactionCode": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "OBTransaction5ProprietaryBankTransactionCode",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "OBTransactionCardInstrument1": {
+      "type": "object",
+      "required": [
+        "CardSchemeName"
+      ],
+      "properties": {
+        "AuthorisationType": {
+          "type": "string",
+          "enum": [
+            "ConsumerDevice",
+            "Contactless",
+            "None",
+            "PIN"
+          ]
+        },
+        "CardSchemeName": {
+          "type": "string",
+          "enum": [
+            "AmericanExpress",
+            "Diners",
+            "Discover",
+            "MasterCard",
+            "VISA"
+          ]
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the cardholder using the card instrument."
+        }
+      },
+      "title": "OBTransactionCardInstrument1",
+      "description": "Set of elements to describe the card instrument used in the transaction."
+    },
+    "OBTransactionCashBalance": {
+      "type": "object",
+      "required": [
+        "CreditDebitIndicator",
+        "Type"
+      ],
+      "properties": {
+        "Amount": {
+          "$ref": "#/definitions/OBActiveOrHistoricCurrencyAndAmount"
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "description": "Indicates whether the balance is a credit or a debit balance. Usage: A zero balance is considered to be a credit balance.",
+          "enum": [
+            "Credit",
+            "Debit"
+          ]
+        },
+        "Type": {
+          "type": "string",
+          "description": "Balance type, in a coded form.",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "ClosingCleared",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "InterimCleared",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "OpeningCleared",
+            "PreviouslyClosedBooked"
+          ]
+        }
+      },
+      "title": "OBTransactionCashBalance",
+      "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+    },
+    "OBWriteDataDomestic1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomestic1"
+    },
+    "OBWriteDataDomestic2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomestic2"
+    },
+    "OBWriteDataDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent1"
+    },
+    "OBWriteDataDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        }
+      },
+      "title": "OBWriteDataDomesticConsent2"
+    },
+    "OBWriteDataDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse1"
+    },
+    "OBWriteDataDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticConsentResponse2"
+    },
+    "OBWriteDataDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse1"
+    },
+    "OBWriteDataDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomestic2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticResponse2"
+    },
+    "OBWriteDataDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled1"
+    },
+    "OBWriteDataDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduled2"
+    },
+    "OBWriteDataDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent1"
+    },
+    "OBWriteDataDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsent2"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDataDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDataDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse1"
+    },
+    "OBWriteDataDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticScheduledPaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticScheduled2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticScheduledResponse2"
+    },
+    "OBWriteDataDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder1"
+    },
+    "OBWriteDataDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder2"
+    },
+    "OBWriteDataDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrder3"
+    },
+    "OBWriteDataDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent1"
+    },
+    "OBWriteDataDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent2"
+    },
+    "OBWriteDataDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsent3"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDataDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse1"
+    },
+    "OBWriteDataDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse2"
+    },
+    "OBWriteDataDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "DomesticStandingOrderId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "DomesticStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBDomesticStandingOrder3"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataDomesticStandingOrderResponse3"
+    },
+    "OBWriteDataFile1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFile1"
+    },
+    "OBWriteDataFile2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFile2"
+    },
+    "OBWriteDataFileConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        }
+      },
+      "title": "OBWriteDataFileConsent1"
+    },
+    "OBWriteDataFileConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        }
+      },
+      "title": "OBWriteDataFileConsent2"
+    },
+    "OBWriteDataFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse1"
+    },
+    "OBWriteDataFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "AwaitingUpload",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the consent resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileConsentResponse2"
+    },
+    "OBWriteDataFileResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile1"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse1"
+    },
+    "OBWriteDataFileResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "FilePaymentId",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "FilePaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBFile2"
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataFileResponse2"
+    },
+    "OBWriteDataFundsConfirmationResponse1": {
+      "type": "object",
+      "properties": {
+        "FundsAvailableResult": {
+          "$ref": "#/definitions/OBFundsAvailableResult1"
+        },
+        "SupplementaryData": {
+          "$ref": "#/definitions/OBSupplementaryData1"
+        }
+      },
+      "title": "OBWriteDataFundsConfirmationResponse1"
+    },
+    "OBWriteDataInternational1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternational1"
+    },
+    "OBWriteDataInternational2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternational2"
+    },
+    "OBWriteDataInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent1"
+    },
+    "OBWriteDataInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        }
+      },
+      "title": "OBWriteDataInternationalConsent2"
+    },
+    "OBWriteDataInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse1"
+    },
+    "OBWriteDataInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalConsentResponse2"
+    },
+    "OBWriteDataInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational1"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse1"
+    },
+    "OBWriteDataInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternational2"
+        },
+        "InternationalPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "AcceptedSettlementCompleted",
+            "AcceptedSettlementInProcess",
+            "AcceptedTechnicalValidation",
+            "AcceptedCustomerProfile",
+            "Pending",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalResponse2"
+    },
+    "OBWriteDataInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled1"
+    },
+    "OBWriteDataInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduled2"
+    },
+    "OBWriteDataInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent1"
+    },
+    "OBWriteDataInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsent2"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse1"
+    },
+    "OBWriteDataInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledConsentResponse2"
+    },
+    "OBWriteDataInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled1"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse1"
+    },
+    "OBWriteDataInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalScheduledPaymentId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the message was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExchangeRateInformation": {
+          "$ref": "#/definitions/OBExchangeRate2"
+        },
+        "ExpectedExecutionDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected execution date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "ExpectedSettlementDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expected settlement date and time for the payment resource. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalScheduled2"
+        },
+        "InternationalScheduledPaymentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalScheduledResponse2"
+    },
+    "OBWriteDataInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder1"
+    },
+    "OBWriteDataInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder2"
+    },
+    "OBWriteDataInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "Initiation"
+      ],
+      "properties": {
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrder3"
+    },
+    "OBWriteDataInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent1"
+    },
+    "OBWriteDataInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent2"
+    },
+    "OBWriteDataInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Initiation",
+        "Permission"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsent3"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "Permission",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Authorisation": {
+          "$ref": "#/definitions/OBAuthorisation1"
+        },
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "CutOffDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specified cut-off date and time for the payment consent. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "Permission": {
+          "type": "string",
+          "enum": [
+            "Create"
+          ]
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Consumed",
+            "Rejected"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteDataInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder1"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse1"
+    },
+    "OBWriteDataInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge1"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder2"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse2"
+    },
+    "OBWriteDataInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "ConsentId",
+        "CreationDateTime",
+        "Initiation",
+        "InternationalStandingOrderId",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "properties": {
+        "Charges": {
+          "type": "array",
+          "description": "Set of elements used to provide details of a charge for the payment initiation.",
+          "items": {
+            "$ref": "#/definitions/OBCharge2"
+          }
+        },
+        "ConsentId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+        },
+        "CreationDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        },
+        "Initiation": {
+          "$ref": "#/definitions/OBInternationalStandingOrder3"
+        },
+        "InternationalStandingOrderId": {
+          "type": "string",
+          "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+        },
+        "MultiAuthorisation": {
+          "$ref": "#/definitions/OBMultiAuthorisation1"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "InitiationCompleted",
+            "InitiationFailed",
+            "InitiationPending"
+          ]
+        },
+        "StatusUpdateDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00"
+        }
+      },
+      "title": "OBWriteDataInternationalStandingOrderResponse3"
+    },
+    "OBWriteDomestic1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic1"
+    },
+    "OBWriteDomestic2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomestic2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomestic2"
+    },
+    "OBWriteDomesticConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent1"
+    },
+    "OBWriteDomesticConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsent2"
+    },
+    "OBWriteDomesticConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse1"
+    },
+    "OBWriteDomesticConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticConsentResponse2"
+    },
+    "OBWriteDomesticResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse1"
+    },
+    "OBWriteDomesticResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticResponse2"
+    },
+    "OBWriteDomesticScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled1"
+    },
+    "OBWriteDomesticScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduled2"
+    },
+    "OBWriteDomesticScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent1"
+    },
+    "OBWriteDomesticScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsent2"
+    },
+    "OBWriteDomesticScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse1"
+    },
+    "OBWriteDomesticScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticScheduledConsentResponse2"
+    },
+    "OBWriteDomesticScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse1"
+    },
+    "OBWriteDomesticScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticScheduledResponse2"
+    },
+    "OBWriteDomesticStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder1"
+    },
+    "OBWriteDomesticStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder2"
+    },
+    "OBWriteDomesticStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrder3"
+    },
+    "OBWriteDomesticStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent1"
+    },
+    "OBWriteDomesticStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent2"
+    },
+    "OBWriteDomesticStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsent3"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse1"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse2"
+    },
+    "OBWriteDomesticStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderConsentResponse3"
+    },
+    "OBWriteDomesticStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse1"
+    },
+    "OBWriteDomesticStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse2"
+    },
+    "OBWriteDomesticStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataDomesticStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteDomesticStandingOrderResponse3"
+    },
+    "OBWriteFile1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile1"
+        }
+      },
+      "title": "OBWriteFile1"
+    },
+    "OBWriteFile2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFile2"
+        }
+      },
+      "title": "OBWriteFile2"
+    },
+    "OBWriteFileConsent1": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent1"
+        }
+      },
+      "title": "OBWriteFileConsent1"
+    },
+    "OBWriteFileConsent2": {
+      "type": "object",
+      "required": [
+        "Data"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsent2"
+        }
+      },
+      "title": "OBWriteFileConsent2"
+    },
+    "OBWriteFileConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse1"
+    },
+    "OBWriteFileConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileConsentResponse2"
+    },
+    "OBWriteFileResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse1"
+    },
+    "OBWriteFileResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFileResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFileResponse2"
+    },
+    "OBWriteFundsConfirmationResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataFundsConfirmationResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteFundsConfirmationResponse1"
+    },
+    "OBWriteInternational1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational1"
+    },
+    "OBWriteInternational2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternational2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternational2"
+    },
+    "OBWriteInternationalConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent1"
+    },
+    "OBWriteInternationalConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsent2"
+    },
+    "OBWriteInternationalConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse1"
+    },
+    "OBWriteInternationalConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalConsentResponse2"
+    },
+    "OBWriteInternationalResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse1"
+    },
+    "OBWriteInternationalResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalResponse2"
+    },
+    "OBWriteInternationalScheduled1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled1"
+    },
+    "OBWriteInternationalScheduled2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduled2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduled2"
+    },
+    "OBWriteInternationalScheduledConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent1"
+    },
+    "OBWriteInternationalScheduledConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsent2"
+    },
+    "OBWriteInternationalScheduledConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse1"
+    },
+    "OBWriteInternationalScheduledConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalScheduledConsentResponse2"
+    },
+    "OBWriteInternationalScheduledResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse1"
+    },
+    "OBWriteInternationalScheduledResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalScheduledResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalScheduledResponse2"
+    },
+    "OBWriteInternationalStandingOrder1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder1"
+    },
+    "OBWriteInternationalStandingOrder2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder2"
+    },
+    "OBWriteInternationalStandingOrder3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrder3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrder3"
+    },
+    "OBWriteInternationalStandingOrderConsent1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent1"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent1"
+    },
+    "OBWriteInternationalStandingOrderConsent2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent2"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent2"
+    },
+    "OBWriteInternationalStandingOrderConsent3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsent3"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsent3"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse1"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse2"
+    },
+    "OBWriteInternationalStandingOrderConsentResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta",
+        "Risk"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderConsentResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        },
+        "Risk": {
+          "$ref": "#/definitions/OBRisk1"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderConsentResponse3"
+    },
+    "OBWriteInternationalStandingOrderResponse1": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse1"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse1"
+    },
+    "OBWriteInternationalStandingOrderResponse2": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse2"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse2"
+    },
+    "OBWriteInternationalStandingOrderResponse3": {
+      "type": "object",
+      "required": [
+        "Data",
+        "Links",
+        "Meta"
+      ],
+      "properties": {
+        "Data": {
+          "$ref": "#/definitions/OBWriteDataInternationalStandingOrderResponse3"
+        },
+        "Links": {
+          "$ref": "#/definitions/Links"
+        },
+        "Meta": {
+          "$ref": "#/definitions/Meta"
+        }
+      },
+      "title": "OBWriteInternationalStandingOrderResponse3"
+    },
+    "OIDCRegistrationResponse": {
+      "type": "object",
+      "properties": {
+        "application_type": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_id_issued_at": {
+          "type": "string"
+        },
+        "client_name": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "client_secret_expires_at": {
+          "type": "string"
+        },
+        "client_uri": {
+          "type": "string"
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default_acr_values": {
+          "type": "string"
+        },
+        "default_max_age": {
+          "type": "string"
+        },
+        "grant_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_token_encrypted_response_alg": {
+          "type": "string"
+        },
+        "id_token_encrypted_response_enc": {
+          "type": "string"
+        },
+        "id_token_signed_response_alg": {
+          "type": "string"
+        },
+        "initiate_login_uri": {
+          "type": "string"
+        },
+        "jwks": {
+          "$ref": "#/definitions/JWKSet"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "logo_uri": {
+          "type": "string"
+        },
+        "policy_uri": {
+          "type": "string"
+        },
+        "redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "registration_access_token": {
+          "type": "string"
+        },
+        "registration_client_uri": {
+          "type": "string"
+        },
+        "request_object_encryption_alg": {
+          "type": "string"
+        },
+        "request_object_encryption_enc": {
+          "type": "string"
+        },
+        "request_object_signing_alg": {
+          "type": "string"
+        },
+        "request_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_auth_time": {
+          "type": "string"
+        },
+        "response_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scope": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sector_identifier_uri": {
+          "type": "string"
+        },
+        "software_id": {
+          "type": "string"
+        },
+        "software_statement": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string"
+        },
+        "tls_client_auth_subject_dn": {
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string"
+        },
+        "token_endpoint_auth_signing_alg": {
+          "type": "string"
+        },
+        "tos_uri": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_alg": {
+          "type": "string"
+        },
+        "userinfo_encrypted_response_enc": {
+          "type": "string"
+        },
+        "userinfo_signed_response_alg": {
+          "type": "string"
+        }
+      },
+      "title": "OIDCRegistrationResponse"
+    },
+    "Optional«FRAccount3»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRAccount3»"
+    },
+    "Optional«FRBalance1»": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "present": {
+          "type": "boolean"
+        }
+      },
+      "title": "Optional«FRBalance1»"
+    },
+    "OtherApplicationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency",
+      "description": "Other application frequencies that are not available in the standard code list"
+    },
+    "OtherApplicationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherApplicationFrequency1",
+      "description": "Other application frequencies not covered in the standard code list"
+    },
+    "OtherBankInterestType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherBankInterestType",
+      "description": "Other interest rate types which are not available in the standard code list"
+    },
+    "OtherCalculationFrequency": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency",
+      "description": "Other calculation frequency which is not available in the standard code set."
+    },
+    "OtherCalculationFrequency1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherCalculationFrequency1",
+      "description": "Other calculation frequency which is not available in standard code set."
+    },
+    "OtherFeeCategoryType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeCategoryType"
+    },
+    "OtherFeeRateType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType",
+      "description": "Other fee rate type code which is not available in the standard code set"
+    },
+    "OtherFeeRateType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeRateType1",
+      "description": "Other fee rate type which is not available in the standard code set"
+    },
+    "OtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType",
+      "description": "Other Fee type which is not available in the standard code set"
+    },
+    "OtherFeeType1": {
+      "type": "object",
+      "required": [
+        "Description",
+        "FeeCategory",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherFeeType1",
+      "description": "Other Fee/charge type which is not available in the standard code set"
+    },
+    "OtherFeesCharges": {
+      "type": "object",
+      "required": [
+        "FeeChargeDetail"
+      ],
+      "properties": {
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeChargeDetail": {
+          "type": "array",
+          "description": "Other fees/charges details",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OtherFeesCharges",
+      "description": "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+    },
+    "OtherFeesChargesFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ServiceCAccountFee",
+              "ServiceCAccountFeeMonthly",
+              "ServiceCOther",
+              "Other"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for adding  extra details for fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "OtherFeesChargesFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeCategory",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How frequently the fee/charge is calculated",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeApplicableRange": {
+          "$ref": "#/definitions/FeeApplicableRange"
+        },
+        "FeeCategory": {
+          "type": "string",
+          "description": "Categorisation of fees and charges into standard categories.",
+          "enum": [
+            "Other",
+            "Servicing"
+          ]
+        },
+        "FeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/OtherFeesChargesFeeChargeCap"
+          }
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Fee/Charge Type",
+          "enum": [
+            "ServiceCAccountFee",
+            "ServiceCAccountFeeMonthly",
+            "ServiceCOther",
+            "Other"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the fee/charge details.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency1"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency1"
+        },
+        "OtherFeeCategoryType": {
+          "$ref": "#/definitions/OtherFeeCategoryType"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType1"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType1"
+        }
+      },
+      "title": "OtherFeesChargesFeeChargeDetail",
+      "description": "Other fees/charges details"
+    },
+    "OtherTariffType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OtherTariffType",
+      "description": "Other tariff type which is not in the standard list."
+    },
+    "Overdraft": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft",
+      "description": "Borrowing details"
+    },
+    "Overdraft1": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBandSet"
+      ],
+      "properties": {
+        "Notes": {
+          "type": "array",
+          "description": "Associated Notes about the overdraft rates",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftTierBandSet": {
+          "type": "array",
+          "description": "Tier band set details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBandSet"
+          }
+        }
+      },
+      "title": "Overdraft1",
+      "description": "Details about Overdraft rates, fees & charges"
+    },
+    "Overdraft1OverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "AcademicTerm",
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "AnnualReview",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge"
+    },
+    "Overdraft1OverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "AccountClosing",
+            "AccountOpening",
+            "AcademicTerm",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAccountAnniversary",
+            "Other",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "LinkedBaseRate",
+            "Gross",
+            "Net",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "AnnualReview",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Specifies for the overdraft control feature/benefit"
+        },
+        "OverdraftFeeChargeCap": {
+          "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+        }
+      },
+      "title": "Overdraft1OverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "Overdraft1OverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "Overdraft1OverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "Overdraft1OverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "Overdraft1OverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Interest charged on whole amount or tiered/banded",
+          "enum": [
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "Overdraft1OverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "Overdraft1OverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/Overdraft1OverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand",
+            "Other"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Tiered",
+            "Whole",
+            "Banded"
+          ]
+        }
+      },
+      "title": "Overdraft1OverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "OverdraftOtherFeeType": {
+      "type": "object",
+      "required": [
+        "Description",
+        "Name"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "The four letter Mnemonic used within an XML file to identify a code"
+        },
+        "Description": {
+          "type": "string",
+          "description": "Description to describe the purpose of the code"
+        },
+        "Name": {
+          "type": "string",
+          "description": "Long name associated with the code"
+        }
+      },
+      "title": "OverdraftOtherFeeType",
+      "description": "Other fee type code which is not available in the standard code set"
+    },
+    "OverdraftOverdraftFeeChargeCap": {
+      "type": "object",
+      "required": [
+        "FeeType",
+        "MinMaxType"
+      ],
+      "properties": {
+        "CappingPeriod": {
+          "type": "string",
+          "description": "Period e.g. day, week, month etc. for which the fee/charge is capped",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "FeeCapAmount": {
+          "type": "string",
+          "description": "Cap amount charged for a fee/charge"
+        },
+        "FeeCapOccurrence": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "FeeType": {
+          "type": "array",
+          "description": "Fee/charge type which is being capped",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ArrangedOverdraft",
+              "AnnualReview",
+              "EmergencyBorrowing",
+              "BorrowingItem",
+              "OverdraftRenewal",
+              "OverdraftSetup",
+              "Surcharge",
+              "TempOverdraft",
+              "UnauthorisedBorrowing",
+              "UnauthorisedPaidTrans",
+              "Other",
+              "UnauthorisedUnpaidTrans"
+            ]
+          }
+        },
+        "MinMaxType": {
+          "type": "string",
+          "description": "Min Max type",
+          "enum": [
+            "Minimum",
+            "Maximum"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Notes related to Overdraft fee charge cap",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherFeeType": {
+          "type": "array",
+          "description": "Other fee type code which is not available in the standard code set",
+          "items": {
+            "$ref": "#/definitions/OverdraftOtherFeeType"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeCap",
+      "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+    },
+    "OverdraftOverdraftFeeChargeDetail": {
+      "type": "object",
+      "required": [
+        "ApplicationFrequency",
+        "FeeType"
+      ],
+      "properties": {
+        "ApplicationFrequency": {
+          "type": "string",
+          "description": "Frequency at which the overdraft charge is applied to the account",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "CalculationFrequency": {
+          "type": "string",
+          "description": "How often is the overdraft fee/charge calculated for the account.",
+          "enum": [
+            "OnClosing",
+            "OnOpening",
+            "ChargingPeriod",
+            "Daily",
+            "PerItem",
+            "Monthly",
+            "OnAnniversary",
+            "Other",
+            "PerHundredPounds",
+            "PerHour",
+            "PerOccurrence",
+            "PerSheet",
+            "PerTransaction",
+            "PerTransactionAmount",
+            "PerTransactionPercentage",
+            "Quarterly",
+            "SixMonthly",
+            "StatementMonthly",
+            "Weekly",
+            "Yearly"
+          ]
+        },
+        "FeeAmount": {
+          "type": "string",
+          "description": "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+        },
+        "FeeRate": {
+          "type": "string",
+          "description": "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+        },
+        "FeeRateType": {
+          "type": "string",
+          "description": "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)",
+          "enum": [
+            "Gross",
+            "Other"
+          ]
+        },
+        "FeeType": {
+          "type": "string",
+          "description": "Overdraft fee type",
+          "enum": [
+            "ArrangedOverdraft",
+            "AnnualReview",
+            "EmergencyBorrowing",
+            "BorrowingItem",
+            "OverdraftRenewal",
+            "OverdraftSetup",
+            "Surcharge",
+            "TempOverdraft",
+            "UnauthorisedBorrowing",
+            "UnauthorisedPaidTrans",
+            "Other",
+            "UnauthorisedUnpaidTrans"
+          ]
+        },
+        "IncrementalBorrowingAmount": {
+          "type": "string",
+          "description": "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+        },
+        "NegotiableIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether fee and charges are negotiable"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Free text for capturing any other info related to Overdraft Fees Charge Details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OtherApplicationFrequency": {
+          "$ref": "#/definitions/OtherApplicationFrequency"
+        },
+        "OtherCalculationFrequency": {
+          "$ref": "#/definitions/OtherCalculationFrequency"
+        },
+        "OtherFeeRateType": {
+          "$ref": "#/definitions/OtherFeeRateType"
+        },
+        "OtherFeeType": {
+          "$ref": "#/definitions/OtherFeeType"
+        },
+        "OverdraftControlIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+        },
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeeChargeDetail",
+      "description": "Details about the fees/charges"
+    },
+    "OverdraftOverdraftFeesCharges": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges",
+      "description": "Overdraft fees and charges"
+    },
+    "OverdraftOverdraftFeesCharges1": {
+      "type": "object",
+      "required": [
+        "OverdraftFeeChargeDetail"
+      ],
+      "properties": {
+        "OverdraftFeeChargeCap": {
+          "type": "array",
+          "description": "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeCap"
+          }
+        },
+        "OverdraftFeeChargeDetail": {
+          "type": "array",
+          "description": "Details about the fees/charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeeChargeDetail"
+          }
+        }
+      },
+      "title": "OverdraftOverdraftFeesCharges1",
+      "description": "Overdraft fees and charges details"
+    },
+    "OverdraftOverdraftTierBand": {
+      "type": "object",
+      "required": [
+        "TierValueMin"
+      ],
+      "properties": {
+        "AgreementLengthMax": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the maximum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementLengthMin": {
+          "type": "number",
+          "format": "float",
+          "description": "Specifies the minimum length of a band for a fixed overdraft agreement"
+        },
+        "AgreementPeriod": {
+          "type": "string",
+          "description": "Specifies the period of a fixed length overdraft agreement",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "BankGuaranteedIndicator": {
+          "type": "boolean",
+          "description": "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+        },
+        "EAR": {
+          "type": "string"
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Tier/band details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges"
+          }
+        },
+        "OverdraftInterestChargingCoverage": {
+          "type": "string",
+          "description": "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        },
+        "TierValueMax": {
+          "type": "string",
+          "description": "Maximum value of Overdraft Tier/Band"
+        },
+        "TierValueMin": {
+          "type": "string",
+          "description": "Minimum value of Overdraft Tier/Band"
+        },
+        "ear": {
+          "type": "string",
+          "description": "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft."
+        }
+      },
+      "title": "OverdraftOverdraftTierBand",
+      "description": "Provides overdraft details for a specific tier or band"
+    },
+    "OverdraftOverdraftTierBandSet": {
+      "type": "object",
+      "required": [
+        "OverdraftTierBand",
+        "TierBandMethod"
+      ],
+      "properties": {
+        "AuthorisedIndicator": {
+          "type": "boolean",
+          "description": "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+        },
+        "BufferAmount": {
+          "type": "string",
+          "description": "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+        },
+        "Identification": {
+          "type": "string",
+          "description": "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the overdraft Tier Band Set details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OverdraftFeesCharges": {
+          "type": "array",
+          "description": "Overdraft fees and charges details",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftFeesCharges1"
+          }
+        },
+        "OverdraftTierBand": {
+          "type": "array",
+          "description": "Provides overdraft details for a specific tier or band",
+          "items": {
+            "$ref": "#/definitions/OverdraftOverdraftTierBand"
+          }
+        },
+        "OverdraftType": {
+          "type": "string",
+          "description": "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.",
+          "enum": [
+            "Committed",
+            "OnDemand"
+          ]
+        },
+        "TierBandMethod": {
+          "type": "string",
+          "description": "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.",
+          "enum": [
+            "Banded",
+            "Tiered",
+            "Whole"
+          ]
+        }
+      },
+      "title": "OverdraftOverdraftTierBandSet",
+      "description": "Tier band set details"
+    },
+    "PCA": {
+      "type": "object",
+      "properties": {
+        "CreditInterest": {
+          "$ref": "#/definitions/CreditInterest1"
+        },
+        "OtherFeesCharges": {
+          "$ref": "#/definitions/OtherFeesCharges"
+        },
+        "Overdraft": {
+          "$ref": "#/definitions/Overdraft1"
+        },
+        "ProductDetails": {
+          "$ref": "#/definitions/ProductDetails1"
+        }
+      },
+      "title": "PCA"
+    },
+    "Pageable": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "paged": {
+          "type": "boolean"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "unpaged": {
+          "type": "boolean"
+        }
+      },
+      "title": "Pageable"
+    },
+    "Page«FRAccountData4»": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FRAccountData4"
+          }
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "first": {
+          "type": "boolean"
+        },
+        "last": {
+          "type": "boolean"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "numberOfElements": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageable": {
+          "$ref": "#/definitions/Pageable"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort"
+        },
+        "totalElements": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPages": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "Page«FRAccountData4»"
+    },
+    "Principal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "Principal"
+    },
+    "ProductDetails": {
+      "type": "object",
+      "properties": {
+        "FeeFreeLength": {
+          "type": "number",
+          "format": "float",
+          "description": "The length/duration of the fee free period"
+        },
+        "FeeFreeLengthPeriod": {
+          "type": "string",
+          "description": "The unit of period (days, weeks, months etc.) of the promotional length",
+          "enum": [
+            "Day",
+            "Half Year",
+            "Month",
+            "Quarter",
+            "Week",
+            "Year"
+          ]
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ClientAccount",
+              "Standard",
+              "NonCommercialChaitiesClbSoc",
+              "NonCommercialPublicAuthGovt",
+              "Religious",
+              "SectorSpecific",
+              "Startup",
+              "Switcher"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails"
+    },
+    "ProductDetails1": {
+      "type": "object",
+      "properties": {
+        "MonthlyMaximumCharge": {
+          "type": "string",
+          "description": "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+        },
+        "Notes": {
+          "type": "array",
+          "description": "Optional additional notes to supplement the Core product details",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Segment": {
+          "type": "array",
+          "description": "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Basic",
+              "BenefitAndReward",
+              "CreditInterest",
+              "Cashback",
+              "General",
+              "Graduate",
+              "Other",
+              "Overdraft",
+              "Packaged",
+              "Premium",
+              "Reward",
+              "Student",
+              "YoungAdult",
+              "Youth"
+            ]
+          }
+        }
+      },
+      "title": "ProductDetails1"
+    },
+    "ProprietaryBankTransactionCodeStructure1": {
+      "type": "object",
+      "required": [
+        "Code"
+      ],
+      "properties": {
+        "Code": {
+          "type": "string",
+          "description": "Proprietary bank transaction code to identify the underlying transaction."
+        },
+        "Issuer": {
+          "type": "string",
+          "description": "Identification of the issuer of the proprietary bank transaction code."
+        }
+      },
+      "title": "ProprietaryBankTransactionCodeStructure1",
+      "description": "Set of elements to fully identify a proprietary bank transaction code."
+    },
+    "PublicKey": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "title": "PublicKey"
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "#/definitions/File"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "readable": {
+          "type": "boolean"
+        },
+        "uri": {
+          "$ref": "#/definitions/URI"
+        },
+        "url": {
+          "$ref": "#/definitions/URL"
+        }
+      },
+      "title": "Resource"
+    },
+    "ResponseEntity": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object"
+        },
+        "statusCode": {
+          "type": "string",
+          "enum": [
+            "100 CONTINUE",
+            "101 SWITCHING_PROTOCOLS",
+            "102 PROCESSING",
+            "103 CHECKPOINT",
+            "200 OK",
+            "201 CREATED",
+            "202 ACCEPTED",
+            "203 NON_AUTHORITATIVE_INFORMATION",
+            "204 NO_CONTENT",
+            "205 RESET_CONTENT",
+            "206 PARTIAL_CONTENT",
+            "207 MULTI_STATUS",
+            "208 ALREADY_REPORTED",
+            "226 IM_USED",
+            "300 MULTIPLE_CHOICES",
+            "301 MOVED_PERMANENTLY",
+            "302 FOUND",
+            "302 MOVED_TEMPORARILY",
+            "303 SEE_OTHER",
+            "304 NOT_MODIFIED",
+            "305 USE_PROXY",
+            "307 TEMPORARY_REDIRECT",
+            "308 PERMANENT_REDIRECT",
+            "400 BAD_REQUEST",
+            "401 UNAUTHORIZED",
+            "402 PAYMENT_REQUIRED",
+            "403 FORBIDDEN",
+            "404 NOT_FOUND",
+            "405 METHOD_NOT_ALLOWED",
+            "406 NOT_ACCEPTABLE",
+            "407 PROXY_AUTHENTICATION_REQUIRED",
+            "408 REQUEST_TIMEOUT",
+            "409 CONFLICT",
+            "410 GONE",
+            "411 LENGTH_REQUIRED",
+            "412 PRECONDITION_FAILED",
+            "413 PAYLOAD_TOO_LARGE",
+            "413 REQUEST_ENTITY_TOO_LARGE",
+            "414 URI_TOO_LONG",
+            "414 REQUEST_URI_TOO_LONG",
+            "415 UNSUPPORTED_MEDIA_TYPE",
+            "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+            "417 EXPECTATION_FAILED",
+            "418 I_AM_A_TEAPOT",
+            "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+            "420 METHOD_FAILURE",
+            "421 DESTINATION_LOCKED",
+            "422 UNPROCESSABLE_ENTITY",
+            "423 LOCKED",
+            "424 FAILED_DEPENDENCY",
+            "426 UPGRADE_REQUIRED",
+            "428 PRECONDITION_REQUIRED",
+            "429 TOO_MANY_REQUESTS",
+            "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+            "500 INTERNAL_SERVER_ERROR",
+            "501 NOT_IMPLEMENTED",
+            "502 BAD_GATEWAY",
+            "503 SERVICE_UNAVAILABLE",
+            "504 GATEWAY_TIMEOUT",
+            "505 HTTP_VERSION_NOT_SUPPORTED",
+            "506 VARIANT_ALSO_NEGOTIATES",
+            "507 INSUFFICIENT_STORAGE",
+            "508 LOOP_DETECTED",
+            "509 BANDWIDTH_LIMIT_EXCEEDED",
+            "510 NOT_EXTENDED",
+            "511 NETWORK_AUTHENTICATION_REQUIRED"
+          ]
+        },
+        "statusCodeValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "ResponseEntity"
+    },
+    "Sort": {
+      "type": "object",
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "sorted": {
+          "type": "boolean"
+        },
+        "unsorted": {
+          "type": "boolean"
+        }
+      },
+      "title": "Sort"
+    },
+    "Tpp": {
+      "type": "object",
+      "properties": {
+        "certificateCn": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "directoryId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "logo": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "officialName": {
+          "type": "string"
+        },
+        "registrationResponse": {
+          "$ref": "#/definitions/OIDCRegistrationResponse"
+        },
+        "ssa": {
+          "type": "string"
+        },
+        "ssaClaim": {
+          "$ref": "#/definitions/JWTClaimsSet"
+        },
+        "tppRequest": {
+          "type": "string"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AISP",
+              "PISP",
+              "ASPSP",
+              "CBPII",
+              "DATA"
+            ]
+          }
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "title": "Tpp"
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "absolute": {
+          "type": "boolean"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "opaque": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "query": {
+          "type": "string"
+        },
+        "rawAuthority": {
+          "type": "string"
+        },
+        "rawFragment": {
+          "type": "string"
+        },
+        "rawPath": {
+          "type": "string"
+        },
+        "rawQuery": {
+          "type": "string"
+        },
+        "rawSchemeSpecificPart": {
+          "type": "string"
+        },
+        "rawUserInfo": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "schemeSpecificPart": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URI"
+    },
+    "URL": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "defaultPort": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "file": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "userInfo": {
+          "type": "string"
+        }
+      },
+      "title": "URL"
+    },
+    "View": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "title": "View"
+    },
+    "X500Principal": {
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "title": "X500Principal"
+    },
+    "X509Certificate": {
+      "type": "object",
+      "properties": {
+        "basicConstraints": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "criticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "encoded": {
+          "type": "string",
+          "format": "byte"
+        },
+        "extendedKeyUsage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issuerAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "issuerDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "issuerUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "issuerX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "keyUsage": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nonCriticalExtensionOIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notAfter": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "serialNumber": {
+          "type": "integer"
+        },
+        "sigAlgName": {
+          "type": "string"
+        },
+        "sigAlgOID": {
+          "type": "string"
+        },
+        "sigAlgParams": {
+          "type": "string",
+          "format": "byte"
+        },
+        "signature": {
+          "type": "string",
+          "format": "byte"
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "subjectDN": {
+          "$ref": "#/definitions/Principal"
+        },
+        "subjectUniqueID": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "subjectX500Principal": {
+          "$ref": "#/definitions/X500Principal"
+        },
+        "tbscertificate": {
+          "type": "string",
+          "format": "byte"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "X509Certificate"
+    }
+  }
+}


### PR DESCRIPTION
Still work in progress but wanted to share initial workings with the
team. I reverse generated the swagger by enabling SpringFox swagger
endpoints and then refactoring the various endpoints into the different
specs. The specs need to live separately because the `swagger-codegen`
tool uses the first part of the path to decide which java files to
create, because the first path was `/openbanking` for all APIs it was
creating one massive file.

To tests run

```
forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/generate-bank-resource-server.sh spring spring-mvc --group-id com.forgerock.openbanking -DuseBeanValidation=true -DinterfaceOnly=true
```

See https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/108
for more information