### PR TITLE
Skip builds for [maven-release-plugin] commits

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name == 'push' && contains(toJson(github.event.commits), '[maven-release-plugin]') == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This change will allow you to skip builds when it has the commit message containing [maven-release-plugin]