### PR TITLE
Push Docker images to GCR instead of Codefresh

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build and Test
         run: |
           sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           mvn -ntp verify
         env:
           FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build and Test
         run: |
           sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
           mvn -ntp verify
         env:
           FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build and Test
         run: |
           sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           mvn -ntp verify
         env:
           FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build and Test
         run: |
           sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           mvn -ntp verify
         env:
           FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-        echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+        echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-        echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+        echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-        docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+        docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build and Test
       run: |
         sudo bash -c 'echo "127.0.0.1   jwkms rs-api rs-store rs-rcs config.dev-ob.forgerock.financial" >> /etc/hosts'
-        docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+        echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
         mvn -ntp verify
       env:
         FR_PRIVATE_REPO_USER: ${{ secrets.FR_PRIVATE_REPO_USER }}

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/bank-ui:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/bank/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION
   build_manual_onboarding:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/manual-onboarding:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/manual-onboarding/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,10 +54,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/bank-ui:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/bank/docker/Dockerfile -t r.cfcr.io/openbanking/obri/bank-ui:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/bank-ui:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/bank-ui:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/bank/docker/Dockerfile -t eu.gcr.io/openbanking/obri/bank-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/bank-ui:$BUILD_VERSION
   build_manual_onboarding:
     name: Build Register App
     runs-on: ubuntu-latest
@@ -81,10 +81,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/manual-onboarding:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/manual-onboarding/docker/Dockerfile -t r.cfcr.io/openbanking/obri/manual-onboarding:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/manual-onboarding:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/manual-onboarding:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/manual-onboarding/docker/Dockerfile -t eu.gcr.io/openbanking/obri/manual-onboarding:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/manual-onboarding:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/bank-ui:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/bank/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION
   build_manual_onboarding:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/manual-onboarding:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/manual-onboarding/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,10 +54,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/bank-ui:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/bank-ui:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/bank/docker/Dockerfile -t eu.gcr.io/openbanking/obri/bank-ui:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/bank-ui:$BUILD_VERSION
+          docker build -f projects/bank/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION
   build_manual_onboarding:
     name: Build Register App
     runs-on: ubuntu-latest
@@ -81,10 +81,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/manual-onboarding:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/manual-onboarding:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/manual-onboarding/docker/Dockerfile -t eu.gcr.io/openbanking/obri/manual-onboarding:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/manual-onboarding:$BUILD_VERSION
+          docker build -f projects/manual-onboarding/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/bank-ui:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/bank/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/bank-ui:$BUILD_VERSION
   build_manual_onboarding:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/manual-onboarding:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/manual-onboarding/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/manual-onboarding:$BUILD_VERSION
   update_ob_deploy:

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/Dockerfile
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/Dockerfile
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
@@ -178,7 +178,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-api-sample</repository>
+                    <repository>eu.gcr.io/openbanking/obri/rs-api-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
@@ -178,7 +178,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/openbanking/obri/rs-api-sample</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-api-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/docker-compose.yml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "18888:8888"
   environment:

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/docker-compose.yml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking/obri/config
   ports:
    - "18888:8888"
   environment:

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/Dockerfile
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/Dockerfile
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
@@ -146,7 +146,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/openbanking/obri/rs-store-sample</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-store-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
@@ -146,7 +146,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-store-sample</repository>
+                    <repository>eu.gcr.io/openbanking/obri/rs-store-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/docker-compose.yml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking/obri/config
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/docker-compose.yml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/docker-compose.yml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking/obri/config
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/docker-compose.yml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
@@ -151,7 +151,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>eu.gcr.io/openbanking/obri/register-sample</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/register-sample</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
@@ -151,7 +151,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/register-sample</repository>
+					<repository>eu.gcr.io/openbanking/obri/register-sample</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
@@ -178,7 +178,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-api-sample</repository>
+                    <repository>eu.gcr.io/openbanking/obri/rs-api-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
@@ -178,7 +178,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/openbanking/obri/rs-api-sample</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-api-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/docker-compose.yml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "18888:8888"
   environment:

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/docker-compose.yml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking/obri/config
   ports:
    - "18888:8888"
   environment:

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
@@ -185,7 +185,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/rs-simulator-sample</repository>
+					<repository>eu.gcr.io/openbanking/obri/rs-simulator-sample</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
@@ -185,7 +185,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>eu.gcr.io/openbanking/obri/rs-simulator-sample</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/rs-simulator-sample</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
@@ -196,7 +196,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/rs-ui-sample</repository>
+					<repository>eu.gcr.io/openbanking/obri/rs-ui-sample</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
@@ -196,7 +196,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>eu.gcr.io/openbanking/obri/rs-ui-sample</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/rs-ui-sample</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
@@ -146,7 +146,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/openbanking/obri/rs-store-sample</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-store-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
@@ -146,7 +146,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-store-sample</repository>
+                    <repository>eu.gcr.io/openbanking/obri/rs-store-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/docker-compose.yml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking/obri/config
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/docker-compose.yml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/Dockerfile
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
@@ -127,7 +127,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/openbanking/obri/rs-rcs-sample</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-rcs-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
@@ -127,7 +127,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-rcs-sample</repository>
+                    <repository>eu.gcr.io/openbanking/obri/rs-rcs-sample</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/docker-compose.yml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking/obri/config
   ports:
    - "38888:8888"
   environment:

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/docker-compose.yml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "38888:8888"
   environment:


### PR DESCRIPTION
Push/pull Docker images to/from GCR instead of Codefresh. This references a new Github secret called `GCR_JSON_KEY` which is a new access token for Google Cloud with a limited scope for the container registry.

Part of https://github.com/ForgeCloud/ob-deploy/issues/468