### PR TITLE
Fix CLIENT_CREDENTIALS Grant type

### DIFF
--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/domesticpayments/DomesticPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/domesticpayments/DomesticPaymentsApiController.java
@@ -160,7 +160,7 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -196,7 +196,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -207,7 +207,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/file/FilePaymentsApiController.java
@@ -160,7 +160,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)
@@ -200,7 +200,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/internationalpayments/InternationalPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/internationalpayments/InternationalPaymentsApiController.java
@@ -159,7 +159,7 @@ public class InternationalPaymentsApiController implements InternationalPayments
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -189,7 +189,7 @@ public class InternationalScheduledPaymentsApiController implements Internationa
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -198,7 +198,7 @@ public class InternationalStandingOrdersApiController implements InternationalSt
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -187,7 +187,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -199,7 +199,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/file/FilePaymentsApiController.java
@@ -157,7 +157,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)
@@ -197,7 +197,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalpayments/InternationalPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalpayments/InternationalPaymentsApiController.java
@@ -38,6 +38,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse2;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational2;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse2;
 
@@ -156,12 +157,13 @@ public class InternationalPaymentsApiController implements InternationalPayments
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)
                 .execute(
                         (String tppId) -> {
+                            HttpHeaders additionalHttpHeaders = new HttpHeaders();
                             return rsStoreGateway.toRsStore(request, new HttpHeaders(), OBWriteInternationalResponse2.class);
                         }
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -181,7 +181,7 @@ public class InternationalScheduledPaymentsApiController implements Internationa
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -194,7 +194,7 @@ public class InternationalStandingOrdersApiController implements InternationalSt
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -192,7 +192,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -188,7 +188,7 @@ public class InternationalStandingOrdersApiController implements InternationalSt
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -188,7 +188,7 @@ public class InternationalStandingOrdersApiController implements InternationalSt
 
             Principal principal
     ) throws OBErrorResponseException {
-        return rsEndpointWrapperService.paymentSubmissionEndpoint()
+        return rsEndpointWrapperService.paymentsRequestPaymentIdEndpoint()
                 .authorization(authorization)
                 .xFapiFinancialId(xFapiFinancialId)
                 .principal(principal)


### PR DESCRIPTION
Fix the issues related with the authorisation access token with the grant type CLIENT_CREDENTIALS used to allow access payment endpoints.
 
Issue related:
https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/222
https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/223
https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/224

OLD issue related:
https://github.com/ForgeCloud/ob-reference-implementation/issues/1831