### PR TITLE
Make OBRisk1.PaymentCodeContext field configurably a required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,16 +101,25 @@ Use latest version of ob-commons
 remove unused file
 [ea0beafab3e80a3](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/ea0beafab3e80a3) Julien Renaux *2020-04-24 08:45:41*
 upgrade common ui. https://github.com/OpenBankingToolkit/openbanking-common/issues/59
+## forgerock-openbanking-aspsp-1.0.79
+### GitHub [#175](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/175) Use new merge-master flow
+[d0113073476393f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d0113073476393f) Jonathan Gazeley *2020-04-21 13:51:06*
+Use new merge-master flow (#175)
+
+Use new merge-master flow
+### GitHub [#177](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/177) upgrade CLI
+[de8bdc233ca80db](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/de8bdc233ca80db) Julien Renaux *2020-04-23 15:01:15*
+upgrade CLI (#177)
+
+* upgrade CLI
+
+* push latest image
+
+* adding docker-compose.override.yml into gitignore
+[c5ae6dc9c2e6c6c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c5ae6dc9c2e6c6c) JamieB *2020-04-24 10:47:30*
+Use latest version of ob-commons
 [e567d3cd251e50f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e567d3cd251e50f) JamieB *2020-04-22 15:53:06*
 Updated ui project version to updating-ui-version-to-
-## forgerock-openbanking-aspsp-1.0.80
-### GitHub [#184](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/184) upgrade @forgerock/openbanking-ui-cli. https://github.com/OpenBanking…
-[f351e3229a4ea1e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/f351e3229a4ea1e) Julien Renaux *2020-04-29 16:38:42*
-upgrade @forgerock/openbanking-ui-cli. https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/8 (#184)
-[fd08b064e6746e4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/fd08b064e6746e4) Matt Wills *2020-05-05 12:50:27*
-Waiver 007 expiry - enabled detached JWT signature verification (#219)
-[475850b80e3e28f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/475850b80e3e28f) jorgesanchezperez *2020-05-13 10:53:11*
-Fix CLIENT_CREDENTIALS Grant type thru all payments APIs and versions APIS
 ## forgerock-openbanking-aspsp-1.0.78
 ### GitHub [#167](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/167) fix missing translation
 [5938b495358e044](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/5938b495358e044) Julien Renaux *2020-03-25 13:08:00*

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentConsentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentConsentsApi.java
@@ -57,11 +57,29 @@ import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE
 @RequestMapping(value = "/open-banking/v3.1/pisp")
 public interface DomesticPaymentConsentsApi {
 
-    @ApiOperation(value = "Create Domestic Payment Consents", nickname = "createDomesticPaymentConsents", notes = "", response = OBWriteDomesticConsentResponse2.class, authorizations = {
+    /**
+     *  createDomesticPaymentConsents
+     * @param obWriteDomesticConsent2Param
+     * @param xFapiFinancialId
+     * @param authorization
+     * @param xIdempotencyKey
+     * @param xJwsSignature
+     * @param xFapiCustomerLastLoggedTime
+     * @param xFapiCustomerIpAddress
+     * @param xFapiInteractionId
+     * @param xCustomerUserAgent
+     * @param request
+     * @param principal
+     * @return
+     * @throws OBErrorResponseException
+     */
+    @ApiOperation(value = "Create Domestic Payment Consents", nickname = "createDomesticPaymentConsents", notes = "",
+            response = OBWriteDomesticConsentResponse2.class, authorizations = {
             @Authorization(value = "TPPOAuth2Security", scopes = {
                     @AuthorizationScope(scope = "payments", description = "Generic payment scope")
             })
     }, tags = {"Domestic Payments",})
+
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "Domestic Payment Consents Created", response = OBWriteDomesticConsentResponse2.class),
             @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
@@ -72,7 +90,9 @@ public interface DomesticPaymentConsentsApi {
             @ApiResponse(code = 415, message = "Unsupported Media Type"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+
     @PreAuthorize("hasAuthority('ROLE_PISP')")
+
     @OpenBankingAPI(
             obReference = OBReference.CREATE_DOMESTIC_PAYMENT_CONSENT
     )

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentsApiController.java
@@ -55,11 +55,20 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DomesticPaymentsApiController.class);
 
+
     @Autowired
+    public DomesticPaymentsApiController(DomesticPaymentService paymentsService,
+                                  RSEndpointWrapperService rsEndpointWrapperService,
+                                  RsStoreGateway rsStoreGateway){
+        this.paymentsService = paymentsService;
+        this.rsEndpointWrapperService = rsEndpointWrapperService;
+        this.rsStoreGateway = rsStoreGateway;
+    }
+
     private DomesticPaymentService paymentsService;
-    @Autowired
+
     private RSEndpointWrapperService rsEndpointWrapperService;
-    @Autowired
+
     private RsStoreGateway rsStoreGateway;
 
     @Override
@@ -111,6 +120,7 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
                     f.verifyPaymentStatus();
                     f.verifyRiskAndInitiation(obWriteDomestic2Param.getData().getInitiation(), obWriteDomestic2Param.getRisk());
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
+                    f.verifyRisk(obWriteDomestic2Param.getRisk());
                 })
                 .execute(
                         (String tppId) -> {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -99,6 +99,7 @@ public class DomesticScheduledPaymentConsentsApiController implements DomesticSc
                 .filters(f -> {
                             f.verifyIdempotencyKeyLength(xIdempotencyKey);
                             f.verifyJwsDetachedSignature(xJwsSignature, request);
+                            f.validateRisk(obWriteDomesticScheduledConsent2Param.getRisk());
                         }
                 )
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -53,8 +53,13 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
     private static final Logger LOGGER = LoggerFactory.getLogger(DomesticStandingOrderConsentsApiController.class);
 
     @Autowired
+    public DomesticStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                      RsStoreGateway rsStoreGateway) {
+        this.rsEndpointWrapperService = rsEndpointWrapperService;
+        this.rsStoreGateway = rsStoreGateway;
+    }
+
     private RSEndpointWrapperService rsEndpointWrapperService;
-    @Autowired
     private RsStoreGateway rsStoreGateway;
 
     @Override
@@ -99,6 +104,7 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                 .filters(f -> {
                         f.verifyIdempotencyKeyLength(xIdempotencyKey);
                         f.verifyJwsDetachedSignature(xJwsSignature, request);
+                        f.validateRisk(obWriteDomesticStandingOrderConsent2Param.getRisk());
                 }
                 )
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/file/FilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/file/FilePaymentConsentsApiController.java
@@ -55,11 +55,16 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 @Slf4j
 public class FilePaymentConsentsApiController implements FilePaymentConsentsApi {
 
-    @Autowired
+    public FilePaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                            RsStoreGateway rsStoreGateway,
+                                            FilePaymentService filePaymentService) {
+        this.rsEndpointWrapperService = rsEndpointWrapperService;
+        this.rsStoreGateway = rsStoreGateway;
+        this.filePaymentService = filePaymentService;
+    }
+
     private RSEndpointWrapperService rsEndpointWrapperService;
-    @Autowired
     private RsStoreGateway rsStoreGateway;
-    @Autowired
     private FilePaymentService filePaymentService;
 
     @Override

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -30,6 +30,7 @@ import io.swagger.annotations.ApiParam;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -61,6 +62,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
     private ExchangeRateVerifier exchangeRateVerifier;
     private InternationalPaymentService paymentsService;
 
+    @Autowired
     public InternationalPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
                                                      RsStoreGateway rsStoreGateway,
                                                      ExchangeRateVerifier exchangeRateVerifier,
@@ -113,6 +115,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
                 .filters(f -> {
                             f.verifyIdempotencyKeyLength(xIdempotencyKey);
                             f.verifyJwsDetachedSignature(xJwsSignature, request);
+                            f.validateRisk(obWriteInternationalConsent2Param.getRisk());
                         }
                 )
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -114,6 +114,7 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .filters(f -> {
                             f.verifyIdempotencyKeyLength(xIdempotencyKey);
                             f.verifyJwsDetachedSignature(xJwsSignature, request);
+                            f.validateRisk(obWriteInternationalScheduledConsent2Param.getRisk());
                         }
 
                 )

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -54,7 +54,8 @@ public class InternationalStandingOrderConsentsApiController implements Internat
     private final RSEndpointWrapperService rsEndpointWrapperService;
     private final RsStoreGateway rsStoreGateway;
 
-    public InternationalStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway) {
+    public InternationalStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                           RsStoreGateway rsStoreGateway) {
         this.rsEndpointWrapperService = rsEndpointWrapperService;
         this.rsStoreGateway = rsStoreGateway;
     }
@@ -101,6 +102,7 @@ public class InternationalStandingOrderConsentsApiController implements Internat
                 .filters(f -> {
                             f.verifyIdempotencyKeyLength(xIdempotencyKey);
                             f.verifyJwsDetachedSignature(xJwsSignature, request);
+                            f.validateRisk(obWriteInternationalStandingOrderConsent2Param.getRisk());
                         }
                 )
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticpayments/DomesticPaymentConsentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticpayments/DomesticPaymentConsentsApi.java
@@ -38,6 +38,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
         obReference = OBReference.DOMESTIC_PAYMENTS
 )
 @RequestMapping(value = "/open-banking/v3.1.1/pisp")
-public interface DomesticPaymentConsentsApi extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.domesticpayments.DomesticPaymentConsentsApi {
-
+public interface DomesticPaymentConsentsApi
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.domesticpayments.DomesticPaymentConsentsApi {
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -20,9 +20,23 @@
  */
 package com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.domesticpayments;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import com.forgerock.openbanking.common.services.store.payment.DomesticPaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticPaymentConsentsApiV3.1.1")
-public class DomesticPaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.domesticpayments.DomesticPaymentConsentsApiController implements DomesticPaymentConsentsApi {
+public class DomesticPaymentConsentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.domesticpayments.DomesticPaymentConsentsApiController
+        implements DomesticPaymentConsentsApi {
+    @Autowired
+    public DomesticPaymentConsentsApiController(RSEndpointWrapperService aRSEndpointWrapperService,
+                                         RsStoreGateway aRsStoreGateway,
+                                         DomesticPaymentService aPaymentsService,
+                                         ObjectMapper aMapper){
+        super(aRSEndpointWrapperService, aRsStoreGateway, aPaymentsService, aMapper);
+    }
 
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticpayments/DomesticPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticpayments/DomesticPaymentsApiController.java
@@ -20,9 +20,21 @@
  */
 package com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.domesticpayments;
 
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import com.forgerock.openbanking.common.services.store.payment.DomesticPaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticPaymentsApiV3.1.1")
-public class DomesticPaymentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.domesticpayments.DomesticPaymentsApiController implements DomesticPaymentsApi {
+public class DomesticPaymentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.domesticpayments.DomesticPaymentsApiController
+        implements DomesticPaymentsApi {
 
+    @Autowired
+    public DomesticPaymentsApiController(DomesticPaymentService paymentsService,
+                                         RSEndpointWrapperService rsEndpointWrapperService,
+                                         RsStoreGateway rsStoreGateway){
+        super(paymentsService, rsEndpointWrapperService, rsStoreGateway);
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -53,8 +53,15 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
     private static final Logger LOGGER = LoggerFactory.getLogger(DomesticStandingOrderConsentsApiController.class);
 
     @Autowired
+    public DomesticStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                      RsStoreGateway rsStoreGateway) {
+        this.rsEndpointWrapperService = rsEndpointWrapperService;
+        this.rsStoreGateway = rsStoreGateway;
+    }
+
+
     private RSEndpointWrapperService rsEndpointWrapperService;
-    @Autowired
+
     private RsStoreGateway rsStoreGateway;
 
     @Override
@@ -99,6 +106,7 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                 .filters(f -> {
                         f.verifyIdempotencyKeyLength(xIdempotencyKey);
                         f.verifyJwsDetachedSignature(xJwsSignature, request);
+                        f.validateRisk(OBWriteDomesticStandingOrderConsent3Param.getRisk());
                 }
                 )
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/file/FilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/file/FilePaymentConsentsApiController.java
@@ -20,9 +20,21 @@
  */
 package com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.file;
 
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 @Controller("FilePaymentConsentsApiV3.1.1")
-public class FilePaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.file.FilePaymentConsentsApiController implements FilePaymentConsentsApi {
+public class FilePaymentConsentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.file.FilePaymentConsentsApiController
+        implements FilePaymentConsentsApi {
 
+    @Autowired
+    public FilePaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                            RsStoreGateway rsStoreGateway,
+                                            FilePaymentService filePaymentService) {
+        super(rsEndpointWrapperService, rsStoreGateway, filePaymentService);
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -31,7 +31,10 @@ import org.springframework.stereotype.Controller;
 public class InternationalPaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController implements InternationalPaymentConsentsApi {
 
     @Autowired
-    public InternationalPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway, ExchangeRateVerifier exchangeRateVerifier, InternationalPaymentService paymentsService) {
+    public InternationalPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                     RsStoreGateway rsStoreGateway,
+                                                     ExchangeRateVerifier exchangeRateVerifier,
+                                                     InternationalPaymentService paymentsService) {
         super(rsEndpointWrapperService, rsStoreGateway, exchangeRateVerifier, paymentsService);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -27,9 +27,14 @@ import com.forgerock.openbanking.common.services.store.payment.InternationalSche
 import org.springframework.stereotype.Controller;
 
 @Controller("InternationalScheduledPaymentConsentsApiV3.1.1")
-public class InternationalScheduledPaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.internationalscheduledpayments.InternationalScheduledPaymentConsentsApiController implements InternationalScheduledPaymentConsentsApi {
+public class InternationalScheduledPaymentConsentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1.internationalscheduledpayments.InternationalScheduledPaymentConsentsApiController
+        implements InternationalScheduledPaymentConsentsApi {
 
-    public InternationalScheduledPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway, ExchangeRateVerifier exchangeRateVerifier, InternationalScheduledPaymentService paymentsService) {
+    public InternationalScheduledPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                              RsStoreGateway rsStoreGateway,
+                                                              ExchangeRateVerifier exchangeRateVerifier,
+                                                              InternationalScheduledPaymentService paymentsService) {
         super(rsEndpointWrapperService, rsStoreGateway, exchangeRateVerifier, paymentsService);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -48,7 +48,8 @@ public class InternationalStandingOrderConsentsApiController implements Internat
     private final RSEndpointWrapperService rsEndpointWrapperService;
     private final RsStoreGateway rsStoreGateway;
 
-    public InternationalStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway) {
+    public InternationalStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                           RsStoreGateway rsStoreGateway) {
         this.rsEndpointWrapperService = rsEndpointWrapperService;
         this.rsStoreGateway = rsStoreGateway;
     }
@@ -95,6 +96,7 @@ public class InternationalStandingOrderConsentsApiController implements Internat
                 .filters(f -> {
                             f.verifyIdempotencyKeyLength(xIdempotencyKey);
                             f.verifyJwsDetachedSignature(xJwsSignature, request);
+                            f.validateRisk(OBWriteInternationalStandingOrderConsent3Param.getRisk());
                         }
                 )
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -20,9 +20,20 @@
  */
 package com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_2.domesticpayments;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import com.forgerock.openbanking.common.services.store.payment.DomesticPaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticPaymentConsentsApiV3.1.2")
 public class DomesticPaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.domesticpayments.DomesticPaymentConsentsApiController implements DomesticPaymentConsentsApi {
-
+    @Autowired
+    public DomesticPaymentConsentsApiController(RSEndpointWrapperService aRSEndpointWrapperService,
+                                         RsStoreGateway aRsStoreGateway,
+                                         DomesticPaymentService aPaymentsService,
+                                         ObjectMapper aMapper){
+        super(aRSEndpointWrapperService, aRsStoreGateway, aPaymentsService, aMapper);
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/domesticpayments/DomesticPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/domesticpayments/DomesticPaymentsApiController.java
@@ -20,9 +20,21 @@
  */
 package com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_2.domesticpayments;
 
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import com.forgerock.openbanking.common.services.store.payment.DomesticPaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticPaymentsApiV3.1.2")
-public class DomesticPaymentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.domesticpayments.DomesticPaymentsApiController implements DomesticPaymentsApi {
+public class DomesticPaymentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.domesticpayments.DomesticPaymentsApiController
+        implements DomesticPaymentsApi {
 
+    @Autowired
+    public DomesticPaymentsApiController(DomesticPaymentService paymentsService,
+                                         RSEndpointWrapperService rsEndpointWrapperService,
+                                         RsStoreGateway rsStoreGateway) {
+        super(paymentsService, rsEndpointWrapperService, rsStoreGateway);
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -20,8 +20,18 @@
  */
 package com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_2.domesticstandingorders;
 
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticStandingOrderConsentsApiV3.1.2")
-public class DomesticStandingOrderConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController implements DomesticStandingOrderConsentsApi {
+public class DomesticStandingOrderConsentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController
+        implements DomesticStandingOrderConsentsApi {
+
+    @Autowired
+    public DomesticStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway) {
+        super(rsEndpointWrapperService, rsStoreGateway);
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/file/FilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/file/FilePaymentConsentsApiController.java
@@ -20,9 +20,21 @@
  */
 package com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_2.file;
 
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 @Controller("FilePaymentConsentsApiV3.1.2")
-public class FilePaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.file.FilePaymentConsentsApiController implements FilePaymentConsentsApi {
+public class FilePaymentConsentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.file.FilePaymentConsentsApiController
+        implements FilePaymentConsentsApi {
 
+    @Autowired
+    public FilePaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                            RsStoreGateway rsStoreGateway,
+                                            FilePaymentService filePaymentService) {
+        super(rsEndpointWrapperService, rsStoreGateway, filePaymentService);
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -31,7 +31,10 @@ import org.springframework.stereotype.Controller;
 public class InternationalPaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.internationalpayments.InternationalPaymentConsentsApiController implements InternationalPaymentConsentsApi {
 
     @Autowired
-    public InternationalPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway, ExchangeRateVerifier exchangeRateVerifier, InternationalPaymentService paymentsService) {
+    public InternationalPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                     RsStoreGateway rsStoreGateway,
+                                                     ExchangeRateVerifier exchangeRateVerifier,
+                                                     InternationalPaymentService paymentsService) {
         super(rsEndpointWrapperService, rsStoreGateway, exchangeRateVerifier, paymentsService);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -27,9 +27,14 @@ import com.forgerock.openbanking.common.services.store.payment.InternationalSche
 import org.springframework.stereotype.Controller;
 
 @Controller("InternationalScheduledPaymentConsentsApiV3.1.2")
-public class InternationalScheduledPaymentConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.internationalscheduledpayments.InternationalScheduledPaymentConsentsApiController implements InternationalScheduledPaymentConsentsApi {
+public class InternationalScheduledPaymentConsentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.internationalscheduledpayments.InternationalScheduledPaymentConsentsApiController
+        implements InternationalScheduledPaymentConsentsApi {
 
-    public InternationalScheduledPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway, ExchangeRateVerifier exchangeRateVerifier, InternationalScheduledPaymentService paymentsService) {
+    public InternationalScheduledPaymentConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                              RsStoreGateway rsStoreGateway,
+                                                              ExchangeRateVerifier exchangeRateVerifier,
+                                                              InternationalScheduledPaymentService paymentsService) {
         super(rsEndpointWrapperService, rsStoreGateway, exchangeRateVerifier, paymentsService);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_2/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -25,9 +25,12 @@ import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import org.springframework.stereotype.Controller;
 
 @Controller("InternationalStandingOrderConsentsApiV3.1.2")
-public class InternationalStandingOrderConsentsApiController extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.internationalstandingorders.InternationalStandingOrderConsentsApiController implements InternationalStandingOrderConsentsApi {
+public class InternationalStandingOrderConsentsApiController
+        extends com.forgerock.openbanking.aspsp.rs.api.payment.v3_1_1.internationalstandingorders.InternationalStandingOrderConsentsApiController
+        implements InternationalStandingOrderConsentsApi {
 
-    public InternationalStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService, RsStoreGateway rsStoreGateway) {
+    public InternationalStandingOrderConsentsApiController(RSEndpointWrapperService rsEndpointWrapperService,
+                                                           RsStoreGateway rsStoreGateway) {
         super(rsEndpointWrapperService, rsStoreGateway);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/verifier/OBRisk1Validator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/verifier/OBRisk1Validator.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.api.payment.verifier;
+
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.model.error.OBRIErrorType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.org.openbanking.datamodel.payment.OBRisk1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
+
+/**
+ * Provides validation for OBRisk1 objects passed to payment interfaces
+ *
+ * This class became necessary when an implementor needed to be able to deviate from the OB specification and enforce
+ * that the optional field {@code PaymentContextCode} within the {@code OBRisk1} class is provided.
+ *
+ * @see <a href="https://openbankinguk.github.io/read-write-api-site3/v3.1.5/profiles/payment-initiation-api-profile.html#obrisk1">OB specifications</a>
+ */
+@Component
+@Slf4j
+public class OBRisk1Validator {
+
+    private boolean requirePaymentContextCode;
+
+    /**
+     * Constructor
+     * @param requirePaymentContextCode boolean value. Annotated so that this validator can be enabled in spring
+     *                                  config using the property
+     *                                  {@code rs.api.payment.validate.risk.require-payment-context-code}
+     */
+    public OBRisk1Validator(@Value("${rs.api.payment.validate.risk.require-payment-context-code:false}") boolean requirePaymentContextCode) {
+        this.requirePaymentContextCode = requirePaymentContextCode;
+    }
+
+    /**
+     * If the object was constructed with {@code requirePaymentContextCode = true}, this method will throw an
+     * OBErrorException if the consent object passed in contains either a null risk object, or a risk object with a
+     * null PaymentContextCode.
+     * @param risk - the risk object to be validated.
+     * @throws OBErrorException
+     */
+    public void validate(final OBRisk1 risk) throws OBErrorException{
+        if(requirePaymentContextCode){
+            if(risk == null || risk.getPaymentContextCode() == null){
+                log.debug("'Risk.PaymentContextCode' failed validation as it was not specified. The Risk was:" +
+                        " {}", risk);
+                throw new OBErrorException(OBRIErrorType.PAYMENT_CODE_CONTEXT_INVALID);
+            }
+        }
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/RSEndpointWrapperService.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/RSEndpointWrapperService.java
@@ -26,6 +26,7 @@ import com.forgerock.openbanking.am.config.AMOpenBankingConfiguration;
 import com.forgerock.openbanking.am.services.AMResourceServerService;
 import com.forgerock.openbanking.aspsp.rs.api.payment.verifier.BalanceTransferPaymentValidator;
 import com.forgerock.openbanking.aspsp.rs.api.payment.verifier.MoneyTransferPaymentValidator;
+import com.forgerock.openbanking.aspsp.rs.api.payment.verifier.OBRisk1Validator;
 import com.forgerock.openbanking.aspsp.rs.api.payment.verifier.PaymPaymentValidator;
 import com.forgerock.openbanking.aspsp.rs.wrappper.endpoints.*;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
@@ -62,6 +63,7 @@ public class RSEndpointWrapperService {
     public BalanceTransferPaymentValidator balanceTransferPaymentValidator;
     public MoneyTransferPaymentValidator moneyTransferPaymentValidator;
     public PaymPaymentValidator paymPaymentValidator;
+    public OBRisk1Validator riskValidator;
 
     @Autowired
     public RSEndpointWrapperService(OBHeaderCheckerService obHeaderCheckerService,
@@ -79,7 +81,8 @@ public class RSEndpointWrapperService {
                                     BalanceTransferPaymentValidator balanceTransferPaymentValidator,
                                     MoneyTransferPaymentValidator moneyTransferPaymentValidator,
                                     AMResourceServerService amResourceServerService,
-                                    PaymPaymentValidator paymPaymentValidator
+                                    PaymPaymentValidator paymPaymentValidator,
+                                    OBRisk1Validator riskValidator
     ) {
         this.obHeaderCheckerService = obHeaderCheckerService;
         this.cryptoApiClient = cryptoApiClient;
@@ -97,6 +100,7 @@ public class RSEndpointWrapperService {
         this.moneyTransferPaymentValidator = moneyTransferPaymentValidator;
         this.paymPaymentValidator = paymPaymentValidator;
         this.amResourceServerService = amResourceServerService;
+        this.riskValidator = riskValidator;
     }
 
     public AccountsAndTransactionsEndpointWrapper accountAndTransactionEndpoint() {
@@ -112,7 +116,8 @@ public class RSEndpointWrapperService {
     }
 
     public PaymentsApiEndpointWrapper paymentEndpoint() {
-        return new PaymentsApiEndpointWrapper(this, balanceTransferPaymentValidator, moneyTransferPaymentValidator, paymPaymentValidator);
+        return new PaymentsApiEndpointWrapper(this, balanceTransferPaymentValidator, moneyTransferPaymentValidator,
+                paymPaymentValidator, riskValidator);
     }
 
     public FilePaymentsApiEndpointWrapper filePaymentEndpoint() {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/RSEndpointWrapper.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/RSEndpointWrapper.java
@@ -43,6 +43,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import uk.org.openbanking.OBConstants;
 import uk.org.openbanking.OBHeaders;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/verifier/OBRisk1ValidatorTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/verifier/OBRisk1ValidatorTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.api.payment.verifier;
+
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.payment.OBRisk1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
+
+
+public class OBRisk1ValidatorTest {
+
+    @Test
+    public void validate_no_side_effects_when_disabled_null_risk() throws OBErrorException {
+        // Given
+        OBRisk1Validator disabledValidator = new OBRisk1Validator(false);
+
+        // When
+        disabledValidator.validate(null);
+    }
+
+    @Test(expected = OBErrorException.class)
+    public void validate_fails_when_null_risk() throws OBErrorException {
+        // Given
+        OBRisk1Validator enabledValidator = new OBRisk1Validator(true);
+
+        // When
+        enabledValidator.validate(null);
+    }
+
+    @Test
+    public void validate_no_side_effects_when_disabled_null_pcc() throws OBErrorException {
+        // Given
+        OBRisk1Validator disabledValidator = new OBRisk1Validator(false);
+
+        // When
+        OBRisk1 risk = new OBRisk1();
+        disabledValidator.validate(risk);
+    }
+
+    @Test(expected = OBErrorException.class)
+    public void validate_fails_when_null_pcc() throws OBErrorException {
+        // Given
+        OBRisk1Validator disabledValidator = new OBRisk1Validator(true);
+
+        // When
+        OBRisk1 risk = new OBRisk1();
+        disabledValidator.validate(risk);
+    }
+
+    @Test
+    public void validate_no_throw_when_valid_pcc() throws OBErrorException {
+        // Given
+        OBRisk1Validator disabledValidator = new OBRisk1Validator(true);
+
+        // When
+        OBRisk1 risk = new OBRisk1();
+        risk.setPaymentContextCode(OBExternalPaymentContext1Code.BILLPAYMENT);
+        disabledValidator.validate(risk);
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PaymentsApiEndpointWrapperTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PaymentsApiEndpointWrapperTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.wrappper.endpoints;
+
+import com.forgerock.openbanking.aspsp.rs.api.payment.verifier.OBRisk1Validator;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaymentsApiEndpointWrapperTest {
+
+    private PaymentsApiEndpointWrapper endpointWrapper;
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void validatePaymentCodeContext_throwsException() throws OBErrorException {
+        expectedEx.expect(OBErrorException.class);
+        expectedEx.expectMessage("The 'OBRisk1.PaymentCodeContext' field must be set and be valid");
+        OBRisk1Validator riskValidator = new OBRisk1Validator(true);
+        endpointWrapper = new PaymentsApiEndpointWrapper(null, null, null, null, riskValidator);
+
+        OBWriteDomesticConsent2 consent = new OBWriteDomesticConsent2();
+        endpointWrapper.validateRisk(consent.getRisk());
+    }
+
+
+    @Test
+    public void validatePaymentCodeContext_no_validator() throws OBErrorException {
+        expectedEx.expect(NullPointerException.class);
+        expectedEx.expectMessage("validatePaymentCodeContext called but no validator present");
+        OBRisk1Validator riskValidator = new OBRisk1Validator(true);
+        endpointWrapper = new PaymentsApiEndpointWrapper(null, null, null, null, null);
+
+        OBWriteDomesticConsent2 consent = new OBWriteDomesticConsent2();
+        endpointWrapper.validateRisk(consent.getRisk());
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PaymentsRequestPaymentIdEndpointWrapperTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PaymentsRequestPaymentIdEndpointWrapperTest.java
@@ -78,7 +78,7 @@ public class PaymentsRequestPaymentIdEndpointWrapperTest {
         RSEndpointWrapperService rsEndpointWrapperService = new RSEndpointWrapperService(obHeaderCheckerService, cryptoApiClient,
                 null, null, rsConfiguration, null,
                 null, false, null, rsConfiguration.financialId, amOpenBankingConfiguration, null,
-                null, null, amResourceServerService, null);
+                null, null, amResourceServerService, null, null);
 
         wrapper = new PaymentsRequestPaymentIdEndpointWrapper(rsEndpointWrapperService) {
             @Override

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PaymentsSubmissionEndpointWrapperTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PaymentsSubmissionEndpointWrapperTest.java
@@ -78,7 +78,7 @@ public class PaymentsSubmissionEndpointWrapperTest {
         RSEndpointWrapperService rsEndpointWrapperService = new RSEndpointWrapperService(obHeaderCheckerService, cryptoApiClient,
                 null, null, rsConfiguration, null,
                 null, false, null, rsConfiguration.financialId, amOpenBankingConfiguration, null,
-                null, null, amResourceServerService, null);
+                null, null, amResourceServerService, null, null);
 
         wrapper = new PaymentsSubmissionsEndpointWrapper(rsEndpointWrapperService) {
             @Override

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/RSEndpointWrapperTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/RSEndpointWrapperTest.java
@@ -37,7 +37,8 @@ public class RSEndpointWrapperTest {
     public void verifyIdempotencyKey_invalid() {
         // Given (stubbed endpoint wrapper)
         TestRSEndpointWrapper testRSEndpointWrapper = new TestRSEndpointWrapper(
-                new RSEndpointWrapperService(new OBHeaderCheckerService(null), null, null, null,null, null, null, true,null, null, null, null, null, null, null, null)
+                new RSEndpointWrapperService(new OBHeaderCheckerService(null), null, null, null,null, null, null,
+                        true,null, null, null, null, null, null, null, null, null)
         );
 
         // When (idempotency key is not valid)
@@ -54,7 +55,8 @@ public class RSEndpointWrapperTest {
     public void verifyIdempotencyKey_valid() throws Exception {
         // Given (stubbed endpoint wrapper)
         TestRSEndpointWrapper testRSEndpointWrapper = new TestRSEndpointWrapper(
-                new RSEndpointWrapperService(new OBHeaderCheckerService(null), null, null, null, null, null, null, true,null, null, null, null, null, null, null, null)
+                new RSEndpointWrapperService(new OBHeaderCheckerService(null), null, null, null, null, null, null,
+                        true,null, null, null, null, null, null, null, null, null)
         );
 
         // When (idempotency key is valid)

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.0.75</ob-common.version>
+        <ob-common.version>1.0.76</ob-common.version>
         <ob-auth.version>1.0.57</ob-auth.version>
         <ob-jwkms.version>1.1.67</ob-jwkms.version>
         <ob-clients.version>1.0.32</ob-clients.version>


### PR DESCRIPTION
Part fix for https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/196

Some implementors have expressed a need to be able to enfore that a
PaymentCodeContext is provided in the Risk object when requesting a
consent. This PR enables this feature to be turned on by setting the
following spring config setting to true;
`rs.api.payment.validate.risk.require-payment-context-code`