### PR TITLE
bumped the parent version 1.0.73

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.72</version>
+        <version>1.0.73</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Bumped parent version 1.0.73, contains the latest version of:
- uk-datamodel
- uk-extensions