### PR TITLE
Repositories and document classes for new v3.1.3 model objects

### DIFF
--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRAccount4.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRAccount4.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.model.openbanking.v3_1_3.account;
+
+import com.forgerock.openbanking.common.model.openbanking.forgerock.FRAccount;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBAccount6;
+
+import java.util.Date;
+
+/**
+ * Representation of an account. This model is only useful for the demo
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document
+public class FRAccount4 implements FRAccount {
+
+    @Id
+    @Indexed
+    public String id;
+    @Indexed
+    public String userID;
+    public OBAccount6 account;
+    @Indexed
+    public String latestStatementId;
+
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRBeneficiary4.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRBeneficiary4.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.model.openbanking.v3_1_3.account;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBBeneficiary4;
+
+import java.util.Date;
+
+/**
+ * Representation of an account. This model is only useful for the demo
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+public class FRBeneficiary4 {
+
+    @Id
+    @Indexed
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBBeneficiary4 beneficiary;
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRDirectDebit4.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRDirectDebit4.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.model.openbanking.v3_1_3.account;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebit;
+
+import java.util.Date;
+
+/**
+ * Representation of an account. This model is only useful for the demo
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document
+public class FRDirectDebit4 {
+
+    @Id
+    @Indexed
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBReadDirectDebit2DataDirectDebit directDebit;
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRScheduledPayment4.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRScheduledPayment4.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.model.openbanking.v3_1_3.account;
+
+import com.forgerock.openbanking.common.model.openbanking.status.ScheduledPaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
+
+import java.util.Date;
+
+/**
+ * Representation of an account. This model is only useful for the demo
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document
+public class FRScheduledPayment4 {
+
+    @Id
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBScheduledPayment3 scheduledPayment;
+
+    @Indexed
+    public String pispId;
+
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+    public String rejectionReason;
+
+    public ScheduledPaymentStatus status;
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRStatement4.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/v3_1_3/account/FRStatement4.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.model.openbanking.v3_1_3.account;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBStatement2;
+import uk.org.openbanking.jackson.DateTimeDeserializer;
+import uk.org.openbanking.jackson.DateTimeSerializer;
+
+import java.util.Date;
+
+/**
+ * Representation of an account. This model is only useful for the demo
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document
+public class FRStatement4 {
+
+    @Id
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBStatement2 statement;
+    @JsonDeserialize(using = DateTimeDeserializer.class)
+    @JsonSerialize(using = DateTimeSerializer.class)
+    private DateTime startDateTime = null;
+    private DateTime endDateTime = null;
+
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v3_1_3/accounts/AccountsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v3_1_3/accounts/AccountsApiController.java
@@ -20,15 +20,18 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v3_1_3.accounts;
 
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_1.accounts.accounts.FRAccount3Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.accounts.FRAccount4Repository;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRAccount3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRAccount4;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import uk.org.openbanking.datamodel.account.*;
+import uk.org.openbanking.datamodel.account.OBAccount6;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.account.OBReadAccount5;
+import uk.org.openbanking.datamodel.account.OBReadAccount5Data;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,10 +41,10 @@ import java.util.stream.Collectors;
 @Slf4j
 public class AccountsApiController implements AccountsApi {
 
-    private final FRAccount3Repository frAccount3Repository;
+    private final FRAccount4Repository frAccount4Repository;
 
-    public AccountsApiController(FRAccount3Repository frAccount3Repository) {
-        this.frAccount3Repository = frAccount3Repository;
+    public AccountsApiController(FRAccount4Repository frAccount4Repository) {
+        this.frAccount4Repository = frAccount4Repository;
     }
 
     @Override
@@ -54,9 +57,9 @@ public class AccountsApiController implements AccountsApi {
                                                      List<OBExternalPermissions1Code> permissions,
                                                      String httpUrl) throws OBErrorResponseException {
         log.info("Read account {} with permission {}", accountId, permissions);
-        FRAccount3 response = frAccount3Repository.byAccountId(accountId, permissions);
+        FRAccount4 response = frAccount4Repository.byAccountId(accountId, permissions);
 
-        List<OBAccount6> obAccounts = Collections.singletonList(toOBAccount6(response.getAccount()));
+        List<OBAccount6> obAccounts = Collections.singletonList(response.getAccount());
         return ResponseEntity.ok(new OBReadAccount5()
                 .data(new OBReadAccount5Data().account(obAccounts))
                 .links(PaginationUtil.generateLinksOnePager(httpUrl))
@@ -75,10 +78,10 @@ public class AccountsApiController implements AccountsApi {
                                                       String httpUrl) throws OBErrorResponseException {
         log.info("Accounts from account ids {}", accountIds);
 
-        List<FRAccount3> frAccounts = frAccount3Repository.byAccountIds(accountIds, permissions);
+        List<FRAccount4> frAccounts = frAccount4Repository.byAccountIds(accountIds, permissions);
         List<OBAccount6> obAccounts = frAccounts
                 .stream()
-                .map(frAccount -> toOBAccount6(frAccount.getAccount()))
+                .map(frAccount -> frAccount.getAccount())
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(new OBReadAccount5()
@@ -87,42 +90,4 @@ public class AccountsApiController implements AccountsApi {
                 .meta(PaginationUtil.generateMetaData(1)));
     }
 
-    // TODO #232 - move to uk-datamodel repo
-    public static OBAccount6 toOBAccount6(OBAccount3 account) {
-        DateTime now = DateTime.now();
-        return account == null ? null : (new OBAccount6())
-                .accountId(account.getAccountId())
-                .status(OBAccountStatus1Code.ENABLED) // TODO #232 - populate this field from the datasource?
-                .statusUpdateDateTime(now) // TODO #232 - populate this field from the datasource?
-                .currency(account.getCurrency())
-                .accountType(account.getAccountType())
-                .accountSubType(account.getAccountSubType())
-                .description(account.getDescription())
-                .nickname(account.getNickname())
-                .openingDate(now) // TODO #232 - populate this field from the datasource?
-                .maturityDate(now) // TODO #232 - populate this field from the datasource?
-                .account(toOBAccount3Accounts(account.getAccount()))
-                .servicer(toOBBranchAndFinancialInstitutionIdentification50(account.getServicer()));
-    }
-
-    public static List<OBAccount3Account> toOBAccount3Accounts(List<OBCashAccount5> accounts) {
-        return accounts == null ? null : accounts
-                .stream()
-                .map(a -> toOBAccount3Account(a))
-                .collect(Collectors.toList());
-    }
-
-    public static OBAccount3Account toOBAccount3Account(OBCashAccount5 obCashAccount5) {
-        return obCashAccount5 == null ? null : (new OBAccount3Account())
-                .schemeName(obCashAccount5.getSchemeName())
-                .identification(obCashAccount5.getIdentification())
-                .name(obCashAccount5.getName())
-                .secondaryIdentification(obCashAccount5.getSecondaryIdentification());
-    }
-
-    public static OBBranchAndFinancialInstitutionIdentification50 toOBBranchAndFinancialInstitutionIdentification50(OBBranchAndFinancialInstitutionIdentification5 obBranchAndFinancialInstitutionIdentification5) {
-        return obBranchAndFinancialInstitutionIdentification5 == null ? null : (new OBBranchAndFinancialInstitutionIdentification50())
-                .schemeName(obBranchAndFinancialInstitutionIdentification5.getSchemeName())
-                .identification(obBranchAndFinancialInstitutionIdentification5.getIdentification());
-    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v3_1_3/beneficiaries/BeneficiariesApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v3_1_3/beneficiaries/BeneficiariesApiController.java
@@ -20,10 +20,10 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v3_1_3.beneficiaries;
 
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_1.accounts.beneficiaries.FRBeneficiary3Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.beneficiaries.FRBeneficiary4Repository;
 import com.forgerock.openbanking.aspsp.rs.store.utils.AccountDataInternalIdFilter;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRBeneficiary3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRBeneficiary4;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
@@ -32,12 +32,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import uk.org.openbanking.datamodel.account.OBBeneficiary3;
-import uk.org.openbanking.datamodel.account.OBBeneficiary4;
-import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification6;
-import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification60;
-import uk.org.openbanking.datamodel.account.OBCashAccount5;
-import uk.org.openbanking.datamodel.account.OBCashAccount50;
 import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
 import uk.org.openbanking.datamodel.account.OBReadBeneficiary4;
 import uk.org.openbanking.datamodel.account.OBReadBeneficiary4Data;
@@ -51,15 +45,15 @@ public class BeneficiariesApiController implements BeneficiariesApi {
 
     private final int pageLimitBeneficiaries;
 
-    private final FRBeneficiary3Repository frBeneficiary3Repository;
+    private final FRBeneficiary4Repository frBeneficiary4Repository;
 
     private final AccountDataInternalIdFilter accountDataInternalIdFilter;
 
     public BeneficiariesApiController(@Value("${rs.page.default.beneficiaries.size}") int pageLimitBeneficiaries,
-                                      FRBeneficiary3Repository frBeneficiary3Repository,
+                                      FRBeneficiary4Repository frBeneficiary4Repository,
                                       AccountDataInternalIdFilter accountDataInternalIdFilter) {
         this.pageLimitBeneficiaries = pageLimitBeneficiaries;
-        this.frBeneficiary3Repository = frBeneficiary3Repository;
+        this.frBeneficiary4Repository = frBeneficiary4Repository;
         this.accountDataInternalIdFilter = accountDataInternalIdFilter;
     }
 
@@ -75,7 +69,7 @@ public class BeneficiariesApiController implements BeneficiariesApi {
                                                                       String httpUrl) throws OBErrorResponseException {
         log.info("Read beneficiaries for account {} with minimumPermissions {}", accountId, permissions);
 
-        Page<FRBeneficiary3> beneficiaries = frBeneficiary3Repository.byAccountIdWithPermissions(accountId, permissions, PageRequest.of(page, pageLimitBeneficiaries));
+        Page<FRBeneficiary4> beneficiaries = frBeneficiary4Repository.byAccountIdWithPermissions(accountId, permissions, PageRequest.of(page, pageLimitBeneficiaries));
         return packageResponse(page, httpUrl, beneficiaries);
     }
 
@@ -91,49 +85,21 @@ public class BeneficiariesApiController implements BeneficiariesApi {
                                                                String httpUrl) throws OBErrorResponseException {
         log.info("Beneficaries from account ids {}", accountIds);
 
-        Page<FRBeneficiary3> beneficiaries = frBeneficiary3Repository.byAccountIdInWithPermissions(accountIds, permissions, PageRequest.of(page, pageLimitBeneficiaries));
+        Page<FRBeneficiary4> beneficiaries = frBeneficiary4Repository.byAccountIdInWithPermissions(accountIds, permissions, PageRequest.of(page, pageLimitBeneficiaries));
         return packageResponse(page, httpUrl, beneficiaries);
     }
 
-    private ResponseEntity<OBReadBeneficiary4> packageResponse(int page, String httpUrl, Page<FRBeneficiary3> beneficiaries) {
+    private ResponseEntity<OBReadBeneficiary4> packageResponse(int page, String httpUrl, Page<FRBeneficiary4> beneficiaries) {
         int totalPages = beneficiaries.getTotalPages();
 
         return ResponseEntity.ok(new OBReadBeneficiary4().data(new OBReadBeneficiary4Data().beneficiary(
                 beneficiaries.getContent()
                         .stream()
-                        .map(FRBeneficiary3::getBeneficiary)
+                        .map(FRBeneficiary4::getBeneficiary)
                         .map(b -> accountDataInternalIdFilter.apply(b))
-                        .map(b -> toOBBeneficiary4(b))
                         .collect(Collectors.toList())))
                 .links(PaginationUtil.generateLinks(httpUrl, page, totalPages))
                 .meta(PaginationUtil.generateMetaData(totalPages)));
     }
 
-    // TODO #232 - move to uk-datamodel
-    public static OBBeneficiary4 toOBBeneficiary4(OBBeneficiary3 obBeneficiary3) {
-        return obBeneficiary3 == null ? null : (new OBBeneficiary4())
-                .accountId(obBeneficiary3.getAccountId())
-                .beneficiaryId(obBeneficiary3.getBeneficiaryId())
-                .reference(obBeneficiary3.getReference())
-                .supplementaryData(null) // TODO #232 - populate this field from the datasource?
-                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification60(obBeneficiary3.getCreditorAgent()))
-                .creditorAccount(toOBCashAccount50(obBeneficiary3.getCreditorAccount()));
-    }
-
-
-    public static OBBranchAndFinancialInstitutionIdentification60 toOBBranchAndFinancialInstitutionIdentification60(OBBranchAndFinancialInstitutionIdentification6 identification) {
-        return identification == null ? null : (new OBBranchAndFinancialInstitutionIdentification60())
-                .schemeName(identification.getSchemeName())
-                .identification(identification.getIdentification())
-                .name(identification.getName())
-                .postalAddress(identification.getPostalAddress());
-    }
-
-    public static OBCashAccount50 toOBCashAccount50(OBCashAccount5 account) {
-        return account == null ? null : (new OBCashAccount50())
-                .schemeName(account.getSchemeName())
-                .identification(account.getIdentification())
-                .name(account.getName())
-                .secondaryIdentification(account.getSecondaryIdentification());
-    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v3_1_3/scheduledpayments/ScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v3_1_3/scheduledpayments/ScheduledPaymentsApiController.java
@@ -20,10 +20,10 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v3_1_3.scheduledpayments;
 
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_1.accounts.scheduledpayments.FRScheduledPayment2Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.scheduledpayments.FRScheduledPayment4Repository;
 import com.forgerock.openbanking.aspsp.rs.store.utils.AccountDataInternalIdFilter;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRScheduledPayment2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRScheduledPayment4;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
@@ -32,7 +32,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import uk.org.openbanking.datamodel.account.*;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3;
+import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3Data;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,15 +45,15 @@ public class ScheduledPaymentsApiController implements ScheduledPaymentsApi {
 
     private final int pageLimitSchedulePayments;
 
-    private final FRScheduledPayment2Repository frScheduledPayment2Repository;
+    private final FRScheduledPayment4Repository frScheduledPayment4Repository;
 
     private final AccountDataInternalIdFilter accountDataInternalIdFilter;
 
     public ScheduledPaymentsApiController(@Value("${rs.page.default.schedule-payments.size}") int pageLimitSchedulePayments,
-                                          FRScheduledPayment2Repository frScheduledPayment2Repository,
+                                          FRScheduledPayment4Repository frScheduledPayment4Repository,
                                           AccountDataInternalIdFilter accountDataInternalIdFilter) {
         this.pageLimitSchedulePayments = pageLimitSchedulePayments;
-        this.frScheduledPayment2Repository = frScheduledPayment2Repository;
+        this.frScheduledPayment4Repository = frScheduledPayment4Repository;
         this.accountDataInternalIdFilter = accountDataInternalIdFilter;
     }
 
@@ -67,7 +69,7 @@ public class ScheduledPaymentsApiController implements ScheduledPaymentsApi {
                                                                                String httpUrl) throws OBErrorResponseException {
         log.info("Read scheduled payments for account {} with minimumPermissions {}", accountId, permissions);
 
-        Page<FRScheduledPayment2> scheduledPayments = frScheduledPayment2Repository.byAccountIdWithPermissions(accountId, permissions, PageRequest.of(page, pageLimitSchedulePayments));
+        Page<FRScheduledPayment4> scheduledPayments = frScheduledPayment4Repository.byAccountIdWithPermissions(accountId, permissions, PageRequest.of(page, pageLimitSchedulePayments));
         return packageResponse(page, httpUrl, scheduledPayments);
     }
 
@@ -83,55 +85,21 @@ public class ScheduledPaymentsApiController implements ScheduledPaymentsApi {
                                                                         String httpUrl) throws OBErrorResponseException {
         log.info("Reading schedule payment from account ids {}", accountIds);
 
-        Page<FRScheduledPayment2> scheduledPayments = frScheduledPayment2Repository.byAccountIdInWithPermissions(accountIds, permissions, PageRequest.of(page, pageLimitSchedulePayments));
+        Page<FRScheduledPayment4> scheduledPayments = frScheduledPayment4Repository.byAccountIdInWithPermissions(accountIds, permissions, PageRequest.of(page, pageLimitSchedulePayments));
         return packageResponse(page, httpUrl, scheduledPayments);
     }
 
-    private ResponseEntity<OBReadScheduledPayment3> packageResponse(int page, String httpUrl, Page<FRScheduledPayment2> scheduledPayments) {
+    private ResponseEntity<OBReadScheduledPayment3> packageResponse(int page, String httpUrl, Page<FRScheduledPayment4> scheduledPayments) {
         int totalPages = scheduledPayments.getTotalPages();
 
         return ResponseEntity.ok(new OBReadScheduledPayment3().data(new OBReadScheduledPayment3Data().scheduledPayment(
                 scheduledPayments.getContent()
                         .stream()
-                        .map(FRScheduledPayment2::getScheduledPayment)
+                        .map(FRScheduledPayment4::getScheduledPayment)
                         .map(sp -> accountDataInternalIdFilter.apply(sp))
-                        .map(sp -> toOBScheduledPayment3(sp))
                         .collect(Collectors.toList())))
                 .links(PaginationUtil.generateLinks(httpUrl, page, totalPages))
                 .meta(PaginationUtil.generateMetaData(totalPages)));
     }
 
-    // TODO #232 - move to uk-datamodel repo
-    public static OBScheduledPayment3 toOBScheduledPayment3(OBScheduledPayment2 obScheduledPayment2) {
-        return obScheduledPayment2 == null ? null : (new OBScheduledPayment3())
-                .accountId(obScheduledPayment2.getAccountId())
-                .scheduledPaymentId(obScheduledPayment2.getScheduledPaymentId())
-                .scheduledPaymentDateTime(obScheduledPayment2.getScheduledPaymentDateTime())
-                .scheduledType(obScheduledPayment2.getScheduledType())
-                .reference(obScheduledPayment2.getReference())
-                .debtorReference(null) // TODO #232 - populate this field from the datasource?
-                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount1(obScheduledPayment2.getInstructedAmount()))
-                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification51(obScheduledPayment2.getCreditorAgent()))
-                .creditorAccount(toOBCashAccount51(obScheduledPayment2.getCreditorAccount()));
-    }
-
-    public static OBActiveOrHistoricCurrencyAndAmount1 toOBActiveOrHistoricCurrencyAndAmount1(OBActiveOrHistoricCurrencyAndAmount amount) {
-        return amount == null ? null : (new OBActiveOrHistoricCurrencyAndAmount1())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
-    }
-
-    public static OBBranchAndFinancialInstitutionIdentification51 toOBBranchAndFinancialInstitutionIdentification51(OBBranchAndFinancialInstitutionIdentification5 identification) {
-        return identification == null ? null : (new OBBranchAndFinancialInstitutionIdentification51())
-                .schemeName(identification.getSchemeName())
-                .identification(identification.getIdentification());
-    }
-
-    public static OBCashAccount51 toOBCashAccount51(OBCashAccount5 account) {
-        return account == null ? null : (new OBCashAccount51())
-                .schemeName(account.getSchemeName())
-                .identification(account.getIdentification())
-                .name(account.getName())
-                .secondaryIdentification(account.getSecondaryIdentification());
-    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/accounts/FRAccount4Repository.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/accounts/FRAccount4Repository.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.accounts;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRAccount4;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.Optional;
+
+
+public interface FRAccount4Repository extends MongoRepository<FRAccount4, String>, FRAccount4RepositoryCustom {
+
+    Collection<FRAccount4> findByUserID(@Param("userID") String userID);
+    Optional<FRAccount4> findByAccountAccountIdentification(@Param("identification") String identification);
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/accounts/FRAccount4RepositoryCustom.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/accounts/FRAccount4RepositoryCustom.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.accounts;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRAccount4;
+import org.joda.time.DateTime;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface FRAccount4RepositoryCustom {
+
+    Collection<FRAccount4> byUserIDWithPermissions(
+            @Param("userID") String userID,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+    FRAccount4 byAccountId(
+            @Param("accountId") String accountId,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions);
+
+    List<FRAccount4> byAccountIds(
+            @Param("accountId") List<String> accountIds,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions);
+
+    List<String> getUserIds(DateTime from, DateTime to);
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/accounts/FRAccount4RepositoryImpl.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/accounts/FRAccount4RepositoryImpl.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.accounts;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRAccount4;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
+import uk.org.openbanking.datamodel.account.OBAccount3Account;
+import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification3Code;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregation;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.project;
+
+@Repository
+public class FRAccount4RepositoryImpl implements FRAccount4RepositoryCustom {
+    @Autowired
+    @Lazy
+    private FRAccount4Repository accountsRepository;
+
+    private MongoTemplate mongoTemplate;
+
+    public FRAccount4RepositoryImpl(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public Collection<FRAccount4> byUserIDWithPermissions(String userID, List<OBExternalPermissions1Code> permissions, Pageable
+            pageable) {
+        Collection<FRAccount4> accounts = accountsRepository.findByUserID(userID);
+        try {
+            for (FRAccount4 account : accounts) {
+                filterAccount(account, permissions);
+            }
+            return accounts;
+        } catch (IllegalArgumentException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public FRAccount4 byAccountId(String accountId, List<OBExternalPermissions1Code> permissions) {
+        Optional<FRAccount4> isAccount = accountsRepository.findById(accountId);
+        if (!isAccount.isPresent()) {
+            return null;
+        }
+        FRAccount4 account = isAccount.get();
+        try {
+            filterAccount(account, permissions);
+            return account;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public List<FRAccount4> byAccountIds(List<String> accountIds, List<OBExternalPermissions1Code> permissions) {
+        Iterable<FRAccount4> accounts = accountsRepository.findAllById(accountIds);
+        try {
+            for (FRAccount4 account : accounts) {
+                filterAccount(account, permissions);
+            }
+            return StreamSupport.stream(accounts.spliterator(), false).collect(Collectors.toList());
+        } catch (IllegalArgumentException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private void filterAccount(FRAccount4 account, List<OBExternalPermissions1Code> permissions) {
+        for (OBExternalPermissions1Code permission: permissions) {
+            switch (permission) {
+
+                case READACCOUNTSBASIC:
+                    account.getAccount().setAccount(null);
+                    account.getAccount().setServicer(null);
+                    break;
+                case READACCOUNTSDETAIL:
+                    if (!CollectionUtils.isEmpty(account.getAccount().getAccount())) {
+                        for (OBAccount3Account subAccount : account.getAccount().getAccount()) {
+                            if (!permissions.contains(OBExternalPermissions1Code.READPAN)
+                                    && OBExternalAccountIdentification3Code.PAN.toString().equals(subAccount.getSchemeName()))
+                            {
+                                subAccount.setIdentification("xxx");
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+
+
+    @Override
+    public List<String> getUserIds(DateTime from, DateTime to) {
+        Aggregation aggregation = newAggregation(
+                Aggregation.match(
+                        Criteria.where("created").gt(from)),
+                Aggregation.match(
+                        Criteria.where("created").lt(to)),
+                Aggregation.group("userID")
+                .first("userID").as("userID"),
+                project("userID")
+        );
+        //Convert the aggregation result into a List
+        AggregationResults<UserIds> groupResults
+                = mongoTemplate.aggregate(aggregation, FRAccount4.class, UserIds.class);
+        return groupResults.getMappedResults().stream().map(UserIds::getUserID).collect(Collectors.toList());
+    }
+
+    @Builder
+    @Data
+    @EqualsAndHashCode
+    public static class UserIds {
+        private String userID;
+
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/beneficiaries/FRBeneficiary4Repository.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/beneficiaries/FRBeneficiary4Repository.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.beneficiaries;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRBeneficiary4;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+
+public interface FRBeneficiary4Repository extends MongoRepository<FRBeneficiary4, String>, FRBeneficiary4RepositoryCustom {
+
+    Page<FRBeneficiary4> findByAccountId(@Param("accountId") String accountId, Pageable pageable);
+    Page<FRBeneficiary4> findByAccountIdIn(@Param("accountIds") List<String> accountIds, Pageable pageable);
+
+    Long deleteBeneficiaryByAccountId(@Param("accountId") String accountId);
+
+    Long countByAccountIdIn(Set<String> accountIds);
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/beneficiaries/FRBeneficiary4RepositoryCustom.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/beneficiaries/FRBeneficiary4RepositoryCustom.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.beneficiaries;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRBeneficiary4;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+public interface FRBeneficiary4RepositoryCustom {
+    Page<FRBeneficiary4> byAccountIdWithPermissions(
+            @Param("accountId") String accountId,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+    Page<FRBeneficiary4> byAccountIdInWithPermissions(List<String> accountIds, List<OBExternalPermissions1Code> permissions,
+                                                      Pageable pageable);
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/beneficiaries/FRBeneficiary4RepositoryImpl.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/beneficiaries/FRBeneficiary4RepositoryImpl.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.beneficiaries;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRBeneficiary4;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+@Repository
+public class FRBeneficiary4RepositoryImpl implements FRBeneficiary4RepositoryCustom {
+    @Autowired
+    @Lazy
+    private FRBeneficiary4Repository beneficiaryRepository;
+
+    @Override
+    public Page<FRBeneficiary4> byAccountIdWithPermissions(String accountId, List<OBExternalPermissions1Code> permissions,
+                                                           Pageable pageable) {
+        return filter(beneficiaryRepository.findByAccountId(accountId, pageable), permissions);
+    }
+
+    @Override
+    public Page<FRBeneficiary4> byAccountIdInWithPermissions(List<String> accountIds, List<OBExternalPermissions1Code> permissions,
+                                                            Pageable pageable) {
+        return filter(beneficiaryRepository.findByAccountIdIn(accountIds, pageable), permissions);
+    }
+
+    private Page<FRBeneficiary4> filter(Page<FRBeneficiary4> beneficiaries, List<OBExternalPermissions1Code> permissions) {
+        for (OBExternalPermissions1Code permission : permissions) {
+            switch (permission) {
+
+                case READBENEFICIARIESBASIC:
+                    for (FRBeneficiary4 beneficiary: beneficiaries) {
+                        beneficiary.getBeneficiary().creditorAccount(null);
+                    }
+                    break;
+            }
+        }
+        return beneficiaries;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/directdebits/FRDirectDebit4Repository.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/directdebits/FRDirectDebit4Repository.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.directdebits;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRDirectDebit4;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+
+public interface FRDirectDebit4Repository extends MongoRepository<FRDirectDebit4, String>, FRDirectDebit4RepositoryCustom {
+
+    Page<FRDirectDebit4> findByAccountId(@Param("accountId") String accountId, Pageable pageable);
+    Page<FRDirectDebit4> findByAccountIdIn(@Param("accountIds") List<String> accountIds, Pageable pageable);
+
+    Long deleteDirectDebitByAccountId(@Param("accountId") String accountId);
+
+    Long countByAccountIdIn(Set<String> accountIds);
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/directdebits/FRDirectDebit4RepositoryCustom.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/directdebits/FRDirectDebit4RepositoryCustom.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.directdebits;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRDirectDebit4;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+public interface FRDirectDebit4RepositoryCustom {
+
+    Page<FRDirectDebit4> byAccountIdWithPermissions(
+            @Param("accountId") String accountId,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+    Page<FRDirectDebit4> byAccountIdInWithPermissions(
+            @Param("accountIds") List<String> accountIds,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/directdebits/FRDirectDebit4RepositoryImpl.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/directdebits/FRDirectDebit4RepositoryImpl.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.directdebits;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRDirectDebit4;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+public class FRDirectDebit4RepositoryImpl implements FRDirectDebit4RepositoryCustom {
+
+    @Autowired
+    @Lazy
+    private FRDirectDebit4Repository directDebitRepository;
+
+    @Override
+    public Page<FRDirectDebit4> byAccountIdWithPermissions(String accountId, List<OBExternalPermissions1Code> permissions,
+                                                           Pageable pageable) {
+        return filter(directDebitRepository.findByAccountId(accountId, pageable), permissions);
+    }
+
+    @Override
+    public Page<FRDirectDebit4> byAccountIdInWithPermissions(List<String> accountIds, List<OBExternalPermissions1Code> permissions, Pageable pageable) {
+        return filter(directDebitRepository.findByAccountIdIn(accountIds, pageable), permissions);
+    }
+
+    private Page<FRDirectDebit4> filter(Page<FRDirectDebit4> directDebits, List<OBExternalPermissions1Code> permissions) {
+        return directDebits;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/scheduledpayments/FRScheduledPayment4Repository.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/scheduledpayments/FRScheduledPayment4Repository.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.scheduledpayments;
+
+import com.forgerock.openbanking.common.model.openbanking.status.ScheduledPaymentStatus;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRScheduledPayment4;
+import org.joda.time.DateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface FRScheduledPayment4Repository extends MongoRepository<FRScheduledPayment4, String>, FRScheduledPayment4RepositoryCustom {
+
+    Page<FRScheduledPayment4> findByAccountId(@Param("accountId") String accountId, Pageable pageable);
+    Page<FRScheduledPayment4> findByAccountIdIn(@Param("accountIds") List<String> accountIds, Pageable pageable);
+
+    Long deleteFRScheduledPayment1ByAccountId(@Param("accountId") String accountId);
+
+    @Query("{ 'status' : ?0 }, { 'scheduledPayment.ScheduledPaymentDateTime' : { $lt: ?1 } }")
+    List<FRScheduledPayment4> findByStatus(@Param("status") ScheduledPaymentStatus status, @Param("scheduledPayment.ScheduledPaymentDateTime") DateTime maxDateTime);
+
+    Long countByAccountIdIn(Set<String> accountIds);
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/scheduledpayments/FRScheduledPayment4RepositoryCustom.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/scheduledpayments/FRScheduledPayment4RepositoryCustom.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.scheduledpayments;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRScheduledPayment4;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+public interface FRScheduledPayment4RepositoryCustom {
+
+    Page<FRScheduledPayment4> byAccountIdWithPermissions(
+            @Param("accountId") String accountId,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+    Page<FRScheduledPayment4> byAccountIdInWithPermissions(
+            @Param("accountIds") List<String> accountIds,
+            @Param("permissions") List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/scheduledpayments/FRScheduledPayment4RepositoryImpl.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/scheduledpayments/FRScheduledPayment4RepositoryImpl.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.scheduledpayments;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRScheduledPayment4;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+public class FRScheduledPayment4RepositoryImpl implements FRScheduledPayment4RepositoryCustom {
+
+    @Autowired
+    @Lazy
+    private FRScheduledPayment4Repository scheduledPayment1Repository;
+
+    @Override
+    public Page<FRScheduledPayment4> byAccountIdWithPermissions(String accountId, List<OBExternalPermissions1Code> permissions, Pageable pageable) {
+        return filter(scheduledPayment1Repository.findByAccountId(accountId, pageable), permissions);
+    }
+
+    @Override
+    public Page<FRScheduledPayment4> byAccountIdInWithPermissions(List<String> accountIds, List<OBExternalPermissions1Code> permissions, Pageable pageable) {
+        return filter(scheduledPayment1Repository.findByAccountIdIn(accountIds, pageable), permissions);
+    }
+
+
+    private Page<FRScheduledPayment4> filter(Page<FRScheduledPayment4> scheduledPayments, List<OBExternalPermissions1Code> permissions) {
+
+        for (FRScheduledPayment4 scheduledPayment: scheduledPayments) {
+            for (OBExternalPermissions1Code permission : permissions) {
+                switch (permission) {
+                    case READSCHEDULEDPAYMENTSBASIC:
+                        scheduledPayment.getScheduledPayment().setCreditorAccount(null);
+                        scheduledPayment.getScheduledPayment().setCreditorAgent(null);
+                        break;
+                }
+            }
+        }
+        return scheduledPayments;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/statements/FRStatement4Repository.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/statements/FRStatement4Repository.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.statements;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRStatement4;
+import org.joda.time.DateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Set;
+
+
+public interface FRStatement4Repository extends MongoRepository<FRStatement4, String>, FRStatement4RepositoryCustom {
+
+    Page<FRStatement4> findByAccountIdAndStartDateTimeBetweenAndEndDateTimeBetween(
+            String accountId,
+            DateTime fromStartDateTime,
+            DateTime toStartDateTime,
+            DateTime fromEndDateTime,
+            DateTime toEndDateTime,
+            Pageable pageable
+    );
+
+    Page<FRStatement4> findByAccountId(
+            String accountId,
+            Pageable pageable
+    );
+
+    List<FRStatement4> findByAccountIdAndId(
+            String accountId,
+            String id
+    );
+
+    Page<FRStatement4> findByAccountIdIn(
+            List<String> accountIds,
+            Pageable pageable
+    );
+
+    Long deleteFRStatement4ByAccountId(
+            String accountId
+    );
+
+    Long countByAccountIdIn(Set<String> accountIds);
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/statements/FRStatement4RepositoryCustom.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/statements/FRStatement4RepositoryCustom.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.statements;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRStatement4;
+import org.joda.time.DateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+public interface FRStatement4RepositoryCustom {
+
+    Page<FRStatement4> byAccountIdWithPermissions(
+            String accountId,
+            DateTime fromStatementDateTime,
+            DateTime toStatementDateTime,
+            List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+    List<FRStatement4> byAccountIdAndStatementIdWithPermissions(
+            String accountId,
+            String statementId,
+            List<OBExternalPermissions1Code> permissions
+    );
+
+    Page<FRStatement4> byAccountIdInWithPermissions(
+            List<String> accountIds,
+            List<OBExternalPermissions1Code> permissions,
+            Pageable pageable);
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/statements/FRStatement4RepositoryImpl.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/v3_1_3/accounts/statements/FRStatement4RepositoryImpl.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_3.accounts.statements;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRStatement4;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+
+import java.util.List;
+
+public class FRStatement4RepositoryImpl implements FRStatement4RepositoryCustom {
+
+    @Autowired
+    @Lazy
+    private FRStatement4Repository statement1Repository;
+
+    @Override
+    public Page<FRStatement4> byAccountIdWithPermissions(
+            String accountId,
+            DateTime fromStatementDateTime,
+            DateTime toStatementDateTime,
+            List<OBExternalPermissions1Code> permissions, Pageable pageable) {
+
+        if (fromStatementDateTime == null && toStatementDateTime == null) {
+            return filter(statement1Repository.findByAccountId(accountId, pageable), permissions);
+        } else {
+            return filter(statement1Repository.findByAccountIdAndStartDateTimeBetweenAndEndDateTimeBetween(accountId, fromStatementDateTime, toStatementDateTime, fromStatementDateTime, toStatementDateTime, pageable), permissions);
+        }
+    }
+
+    @Override
+    public List<FRStatement4> byAccountIdAndStatementIdWithPermissions(
+            String accountId,
+            String statementId,
+            List<OBExternalPermissions1Code> permissions) {
+
+        return filter(statement1Repository.findByAccountIdAndId(accountId, statementId), permissions);
+    }
+
+    @Override
+    public Page<FRStatement4> byAccountIdInWithPermissions(List<String> accountIds, List<OBExternalPermissions1Code> permissions, Pageable pageable) {
+        return filter(statement1Repository.findByAccountIdIn(accountIds, pageable), permissions);
+    }
+
+    private Page<FRStatement4> filter(Page<FRStatement4> statements, List<OBExternalPermissions1Code> permissions) {
+        for (OBExternalPermissions1Code permission : permissions) {
+            for (FRStatement4 statement : statements) {
+                switch (permission) {
+                    case READSTATEMENTSBASIC:
+                        statement.getStatement().setStatementAmount(null);
+                        break;
+                }
+            }
+        }
+        return statements;
+    }
+
+    private List<FRStatement4> filter(List<FRStatement4> statements, List<OBExternalPermissions1Code> permissions) {
+        for (OBExternalPermissions1Code permission : permissions) {
+            for (FRStatement4 statement : statements) {
+                switch (permission) {
+                    case READSTATEMENTSBASIC:
+                        statement.getStatement().setStatementAmount(null);
+                        break;
+                }
+            }
+        }
+        return statements;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/utils/AccountDataInternalIdFilter.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/utils/AccountDataInternalIdFilter.java
@@ -37,21 +37,43 @@ public class AccountDataInternalIdFilter {
         this.showAccountDataInternalIds = showAccountDataInternalIds;
     }
 
-    public OBTransaction1 apply(final OBTransaction1 data) { return apply(data, data::setTransactionId); }
+    public OBTransaction1 apply(final OBTransaction1 data) {
+        return apply(data, data::setTransactionId);
+    }
 
-    public OBTransaction2 apply(final OBTransaction2 data) { return apply(data, data::setTransactionId); }
+    public OBTransaction2 apply(final OBTransaction2 data) {
+        return apply(data, data::setTransactionId);
+    }
 
-    public OBTransaction3 apply(final OBTransaction3 data) { return apply(data, data::setTransactionId); }
+    public OBTransaction3 apply(final OBTransaction3 data) {
+        return apply(data, data::setTransactionId);
+    }
 
-    public OBTransaction4 apply(final OBTransaction4 data) { return apply(data, data::setTransactionId); }
+    public OBTransaction4 apply(final OBTransaction4 data) {
+        return apply(data, data::setTransactionId);
+    }
 
-    public OBTransaction5 apply(final OBTransaction5 data) { return apply(data, data::setTransactionId); }
+    public OBTransaction5 apply(final OBTransaction5 data) {
+        return apply(data, data::setTransactionId);
+    }
 
-    public OBBeneficiary2 apply(final OBBeneficiary2 data) { return apply(data, data::setBeneficiaryId); }
+    public OBBeneficiary2 apply(final OBBeneficiary2 data) {
+        return apply(data, data::setBeneficiaryId);
+    }
 
-    public OBBeneficiary3 apply(final OBBeneficiary3 data) { return apply(data, data::setBeneficiaryId); }
+    public OBBeneficiary3 apply(final OBBeneficiary3 data) {
+        return apply(data, data::setBeneficiaryId);
+    }
+
+    public OBBeneficiary4 apply(final OBBeneficiary4 data) {
+        return apply(data, data::setBeneficiaryId);
+    }
 
     public OBDirectDebit1 apply(OBDirectDebit1 data) {
+        return apply(data, data::setDirectDebitId);
+    }
+
+    public OBReadDirectDebit2DataDirectDebit apply(OBReadDirectDebit2DataDirectDebit data) {
         return apply(data, data::setDirectDebitId);
     }
 
@@ -59,9 +81,17 @@ public class AccountDataInternalIdFilter {
         return apply(data, data::setOfferId);
     }
 
-    public OBScheduledPayment1 apply(OBScheduledPayment1 data) { return apply(data, data::setScheduledPaymentId); }
+    public OBScheduledPayment1 apply(OBScheduledPayment1 data) {
+        return apply(data, data::setScheduledPaymentId);
+    }
 
-    public OBScheduledPayment2 apply(OBScheduledPayment2 data) { return apply(data, data::setScheduledPaymentId); }
+    public OBScheduledPayment2 apply(OBScheduledPayment2 data) {
+        return apply(data, data::setScheduledPaymentId);
+    }
+
+    public OBScheduledPayment3 apply(OBScheduledPayment3 data) {
+        return apply(data, data::setScheduledPaymentId);
+    }
 
     public OBStandingOrder1 apply(OBStandingOrder1 data) {
         return apply(data, data::setStandingOrderId);
@@ -79,13 +109,19 @@ public class AccountDataInternalIdFilter {
         return apply(data, data::setStandingOrderId);
     }
 
-    public OBStandingOrder5 apply(OBStandingOrder5 data) { return apply(data, data::setStandingOrderId); }
+    public OBStandingOrder5 apply(OBStandingOrder5 data) {
+        return apply(data, data::setStandingOrderId);
+    }
 
     public OBStatement1 apply(OBStatement1 data) {
         return apply(data, data::setStatementId);
     }
 
-    private  <T> T apply(final T data, Consumer<String> setIdFunction) {
+    public OBStatement2 apply(OBStatement2 data) {
+        return apply(data, data::setStatementId);
+    }
+
+    private <T> T apply(final T data, Consumer<String> setIdFunction) {
         if (showAccountDataInternalIds) {
             log.debug("Show Account Data Internal Ids is 'ON'. Data response will contain internal ids");
             return data;


### PR DESCRIPTION
Added repositories and 'FR' document classes for new objects introduced in v3.1.3 of the Accounts API (#252).

Note that the functional tests (which mostly point at v3.1.1 of the API) run successfully against these changes. A new v3.1.3 branch (feature/232-accounts-api) of the functional tests also run successfully, but I have more tests to add.