### PR TITLE
Switched to converters in uk-datamodel (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ Release/1.0.91 (#233)
 * Release candidate: prepare for next development iteration
 
 * changelog updated
+[993af400372191d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/993af400372191d) Matt Wills *2020-08-04 10:14:39*
+Added controllers and their (mostly) generated interfaces to the rs-store and rs-gateway modules for 3.1.5 of the payment API. Added new repository and FR documents for new model objects (#272)
+[70514dd73e1bff1](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/70514dd73e1bff1) dependabot-preview[bot] *2020-08-03 19:26:53*
+Bump forgerock-openbanking-starter-parent from 1.0.74 to 1.0.75
+
+Bumps [forgerock-openbanking-starter-parent](https://github.com/OpenBankingToolkit/openbanking-parent) from 1.0.74 to 1.0.75.
+- [Release notes](https://github.com/OpenBankingToolkit/openbanking-parent/releases)
+- [Commits](https://github.com/OpenBankingToolkit/openbanking-parent/compare/1.0.74...1.0.75)
+
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
+
+Added new repositories and document classes for v3.1.5. Migrated controllers and services to new repositories (#272)
 [0b001c4e8833477](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0b001c4e8833477) Matt Wills *2020-07-29 18:26:26*
 Added controllers and their (mostly) generated interfaces to the rs-store and rs-gateway modules for 3.1.5 of the payment API. Added new repository and FR documents for new model objects (#272)
 [961727b0f223e9a](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/961727b0f223e9a) dependabot-preview[bot] *2020-07-27 08:41:17*

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticConsentConverter.java
@@ -24,18 +24,8 @@ import com.forgerock.openbanking.common.model.openbanking.v3_0.payment.FRDomesti
 import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRDomesticConsent2;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRDomesticConsent5;
 import org.springframework.stereotype.Service;
-import uk.org.openbanking.datamodel.payment.OBDomestic1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
-import uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter;
 
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent2;
 
 @Service
@@ -65,7 +55,7 @@ public class FRDomesticConsentConverter {
         frDomesticConsent1.setUserId(frDomesticConsent2.getUserId());
         frDomesticConsent1.setAccountId(frDomesticConsent2.getAccountId());
         frDomesticConsent1.setCreated(frDomesticConsent2.getCreated());
-        frDomesticConsent1.setDomesticConsent(OBWriteDomesticConsentConverter.toOBWriteDomesticConsent1(frDomesticConsent2.getDomesticConsent()));
+        frDomesticConsent1.setDomesticConsent(toOBWriteDomesticConsent1(frDomesticConsent2.getDomesticConsent()));
         frDomesticConsent1.setPispId(frDomesticConsent2.getPispId());
         frDomesticConsent1.setPispName(frDomesticConsent2.getPispName());
         frDomesticConsent1.setStatusUpdate(frDomesticConsent2.getStatusUpdate());
@@ -89,28 +79,4 @@ public class FRDomesticConsentConverter {
         return frDomesticConsent1;
     }
 
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticConsent1 toOBWriteDomesticConsent1(OBWriteDomesticConsent4 domesticConsent4) {
-        return domesticConsent4 == null ? null : (new OBWriteDomesticConsent1())
-                .data(toOBWriteDataDomesticConsent1(domesticConsent4.getData()))
-                .risk(domesticConsent4.getRisk());
-    }
-
-    public static OBWriteDataDomesticConsent1 toOBWriteDataDomesticConsent1(OBWriteDomesticConsent4Data data) {
-        return data == null ? null : (new OBWriteDataDomesticConsent1())
-                .initiation(toOBDomestic1(data.getInitiation()))
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
-    }
-
-    public static OBDomestic1 toOBDomestic1(OBWriteDomestic2DataInitiation initiation) {
-        return initiation == null ? null : (new OBDomestic1())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
-                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
-                .creditorPostalAddress(initiation.getCreditorPostalAddress())
-                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
-    }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticScheduledConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticScheduledConsentConverter.java
@@ -26,15 +26,8 @@ import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRDomesti
 import com.forgerock.openbanking.common.model.openbanking.v3_1_3.payment.FRDomesticScheduledConsent4;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRDomesticScheduledConsent5;
 import org.springframework.stereotype.Service;
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
-import uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter;
 
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBDomesticScheduled1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent2;
 
 @Service
@@ -62,7 +55,7 @@ public class FRDomesticScheduledConsentConverter {
         frDomesticScheduledConsent1.setUserId(frDomesticScheduledConsent2.getUserId());
         frDomesticScheduledConsent1.setAccountId(frDomesticScheduledConsent2.getAccountId());
         frDomesticScheduledConsent1.setCreated(frDomesticScheduledConsent2.getCreated());
-        frDomesticScheduledConsent1.setDomesticScheduledConsent(OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent1(frDomesticScheduledConsent2.getDomesticScheduledConsent()));
+        frDomesticScheduledConsent1.setDomesticScheduledConsent(toOBWriteDomesticScheduledConsent1(frDomesticScheduledConsent2.getDomesticScheduledConsent()));
         frDomesticScheduledConsent1.setPispId(frDomesticScheduledConsent2.getPispId());
         frDomesticScheduledConsent1.setPispName(frDomesticScheduledConsent2.getPispName());
         frDomesticScheduledConsent1.setStatusUpdate(frDomesticScheduledConsent2.getStatusUpdate());
@@ -77,7 +70,7 @@ public class FRDomesticScheduledConsentConverter {
         frDomesticScheduledConsent1.setUserId(frDomesticScheduledConsent4.getUserId());
         frDomesticScheduledConsent1.setAccountId(frDomesticScheduledConsent4.getAccountId());
         frDomesticScheduledConsent1.setCreated(frDomesticScheduledConsent4.getCreated());
-        frDomesticScheduledConsent1.setDomesticScheduledConsent(OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent1(frDomesticScheduledConsent4.getDomesticScheduledConsent()));
+        frDomesticScheduledConsent1.setDomesticScheduledConsent(toOBWriteDomesticScheduledConsent1(frDomesticScheduledConsent4.getDomesticScheduledConsent()));
         frDomesticScheduledConsent1.setPispId(frDomesticScheduledConsent4.getPispId());
         frDomesticScheduledConsent1.setPispName(frDomesticScheduledConsent4.getPispName());
         frDomesticScheduledConsent1.setStatusUpdate(frDomesticScheduledConsent4.getStatusUpdate());
@@ -98,19 +91,5 @@ public class FRDomesticScheduledConsentConverter {
         frDomesticScheduledConsent1.setStatusUpdate(frDomesticScheduledConsent5.getStatusUpdate());
         frDomesticScheduledConsent1.setUpdated(frDomesticScheduledConsent5.getUpdated());
         return frDomesticScheduledConsent1;
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticScheduledConsent1 toOBWriteDomesticScheduledConsent1(OBWriteDomesticScheduledConsent4 domesticScheduledConsent4) {
-        return domesticScheduledConsent4 == null ? null : (new OBWriteDomesticScheduledConsent1())
-                .data(toOBWriteDataDomesticScheduledConsent1(domesticScheduledConsent4.getData()))
-                .risk(domesticScheduledConsent4.getRisk());
-    }
-
-    public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDomesticScheduledConsent4Data data) {
-        return data == null ? null : (new OBWriteDataDomesticScheduledConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
-                .initiation(toOBDomesticScheduled1(data.getInitiation()))
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticStandingOrderConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticStandingOrderConsentConverter.java
@@ -25,10 +25,9 @@ import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRDomesti
 import com.forgerock.openbanking.common.model.openbanking.v3_1_1.payment.FRDomesticStandingOrderConsent3;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRDomesticStandingOrderConsent5;
 import org.springframework.stereotype.Service;
-import uk.org.openbanking.datamodel.account.OBCashAccount3;
-import uk.org.openbanking.datamodel.payment.*;
-import uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter;
-import uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent2;
 
 @Service
 public class FRDomesticStandingOrderConsentConverter {
@@ -40,7 +39,7 @@ public class FRDomesticStandingOrderConsentConverter {
         frDomesticScheduledConsent2.setUserId(frDomesticStandingOrderConsent1.getUserId());
         frDomesticScheduledConsent2.setAccountId(frDomesticStandingOrderConsent1.getAccountId());
         frDomesticScheduledConsent2.setCreated(frDomesticStandingOrderConsent1.getCreated());
-        frDomesticScheduledConsent2.setDomesticStandingOrderConsent(OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent2(frDomesticStandingOrderConsent1.getDomesticStandingOrderConsent()));
+        frDomesticScheduledConsent2.setDomesticStandingOrderConsent(toOBWriteDomesticStandingOrderConsent2(frDomesticStandingOrderConsent1.getDomesticStandingOrderConsent()));
         frDomesticScheduledConsent2.setPispId(frDomesticStandingOrderConsent1.getPispId());
         frDomesticScheduledConsent2.setPispName(frDomesticStandingOrderConsent1.getPispName());
         frDomesticScheduledConsent2.setStatusUpdate(frDomesticStandingOrderConsent1.getStatusUpdate());
@@ -55,7 +54,7 @@ public class FRDomesticStandingOrderConsentConverter {
         frDomesticScheduledConsent1.setUserId(frDomesticStandingOrderConsent2.getUserId());
         frDomesticScheduledConsent1.setAccountId(frDomesticStandingOrderConsent2.getAccountId());
         frDomesticScheduledConsent1.setCreated(frDomesticStandingOrderConsent2.getCreated());
-        frDomesticScheduledConsent1.setDomesticStandingOrderConsent(OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent1(frDomesticStandingOrderConsent2.getDomesticStandingOrderConsent()));
+        frDomesticScheduledConsent1.setDomesticStandingOrderConsent(toOBWriteDomesticStandingOrderConsent1(frDomesticStandingOrderConsent2.getDomesticStandingOrderConsent()));
         frDomesticScheduledConsent1.setPispId(frDomesticStandingOrderConsent2.getPispId());
         frDomesticScheduledConsent1.setPispName(frDomesticStandingOrderConsent2.getPispName());
         frDomesticScheduledConsent1.setStatusUpdate(frDomesticStandingOrderConsent2.getStatusUpdate());
@@ -70,7 +69,7 @@ public class FRDomesticStandingOrderConsentConverter {
         frDomesticScheduledConsent2.setUserId(frDomesticStandingOrderConsent3.getUserId());
         frDomesticScheduledConsent2.setAccountId(frDomesticStandingOrderConsent3.getAccountId());
         frDomesticScheduledConsent2.setCreated(frDomesticStandingOrderConsent3.getCreated());
-        frDomesticScheduledConsent2.setDomesticStandingOrderConsent(OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent2(frDomesticStandingOrderConsent3.getDomesticStandingOrderConsent()));
+        frDomesticScheduledConsent2.setDomesticStandingOrderConsent(toOBWriteDomesticStandingOrderConsent2(frDomesticStandingOrderConsent3.getDomesticStandingOrderConsent()));
         frDomesticScheduledConsent2.setPispId(frDomesticStandingOrderConsent3.getPispId());
         frDomesticScheduledConsent2.setPispName(frDomesticStandingOrderConsent3.getPispName());
         frDomesticScheduledConsent2.setStatusUpdate(frDomesticStandingOrderConsent3.getStatusUpdate());
@@ -86,7 +85,7 @@ public class FRDomesticStandingOrderConsentConverter {
         frDomesticScheduledConsent2.setUserId(frDomesticStandingOrderConsent3.getUserId());
         frDomesticScheduledConsent2.setAccountId(frDomesticStandingOrderConsent3.getAccountId());
         frDomesticScheduledConsent2.setCreated(frDomesticStandingOrderConsent3.getCreated());
-        frDomesticScheduledConsent2.setDomesticStandingOrderConsent(OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent1(frDomesticStandingOrderConsent3.getDomesticStandingOrderConsent()));
+        frDomesticScheduledConsent2.setDomesticStandingOrderConsent(toOBWriteDomesticStandingOrderConsent1(frDomesticStandingOrderConsent3.getDomesticStandingOrderConsent()));
         frDomesticScheduledConsent2.setPispId(frDomesticStandingOrderConsent3.getPispId());
         frDomesticScheduledConsent2.setPispName(frDomesticStandingOrderConsent3.getPispName());
         frDomesticScheduledConsent2.setStatusUpdate(frDomesticStandingOrderConsent3.getStatusUpdate());
@@ -122,95 +121,5 @@ public class FRDomesticStandingOrderConsentConverter {
         frDomesticScheduledConsent2.setStatusUpdate(frDomesticStandingOrderConsent5.getStatusUpdate());
         frDomesticScheduledConsent2.setUpdated(frDomesticStandingOrderConsent5.getUpdated());
         return frDomesticScheduledConsent2;
-    }
-
-    // TODO #272 move to uk datamodel
-    public static OBWriteDomesticStandingOrderConsent1 toOBWriteDomesticStandingOrderConsent1(OBWriteDomesticStandingOrderConsent5 domesticStandingOrderConsent) {
-        return (new OBWriteDomesticStandingOrderConsent1())
-                .data(toOBWriteDataDomesticStandingOrderConsent1(domesticStandingOrderConsent.getData()))
-                .risk(domesticStandingOrderConsent.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrderConsent2 toOBWriteDomesticStandingOrderConsent2(OBWriteDomesticStandingOrderConsent5 domesticStandingOrderConsent) {
-        return (new OBWriteDomesticStandingOrderConsent2())
-                .data(toOBWriteDataDomesticStandingOrderConsent2(domesticStandingOrderConsent.getData()))
-                .risk(domesticStandingOrderConsent.getRisk());
-    }
-
-    public static OBWriteDataDomesticStandingOrderConsent1 toOBWriteDataDomesticStandingOrderConsent1(OBWriteDomesticStandingOrderConsent5Data data) {
-        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
-                .initiation(toOBDomesticStandingOrder1(data.getInitiation()))
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
-    }
-
-    public static OBWriteDataDomesticStandingOrderConsent2 toOBWriteDataDomesticStandingOrderConsent2(OBWriteDomesticStandingOrderConsent5Data data) {
-        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent2())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
-                .initiation(toOBDomesticStandingOrder2(data.getInitiation()))
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
-    }
-
-    public static OBDomesticStandingOrder1 toOBDomesticStandingOrder1(OBWriteDomesticStandingOrder3DataInitiation initiation) {
-        return initiation == null ? null : (new OBDomesticStandingOrder1())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .firstPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getFirstPaymentAmount()))
-                .recurringPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getRecurringPaymentAmount()))
-                .finalPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getFinalPaymentAmount()))
-                .debtorAccount(OBAccountConverter.toOBCashAccount3(initiation.getDebtorAccount()))
-                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()));
-    }
-
-    public static OBDomesticStandingOrder2 toOBDomesticStandingOrder2(OBWriteDomesticStandingOrder3DataInitiation initiation) {
-        return initiation == null ? null : (new OBDomesticStandingOrder2())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .firstPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getFirstPaymentAmount()))
-                .recurringPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getRecurringPaymentAmount()))
-                .finalPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getFinalPaymentAmount()))
-                .debtorAccount(OBAccountConverter.toOBCashAccount3(initiation.getDebtorAccount()))
-                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
-                .supplementaryData(initiation.getSupplementaryData());
-    }
-
-    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount amount) {
-        return amount == null ? null : (new OBActiveOrHistoricCurrencyAndAmount())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
-    }
-
-    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount amount) {
-        return amount == null ? null : (new OBActiveOrHistoricCurrencyAndAmount())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
-    }
-
-    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount amount) {
-        return amount == null ? null : (new OBActiveOrHistoricCurrencyAndAmount())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
-    }
-
-    public static OBCashAccount3 toOBCashAccount3(OBWriteDomesticStandingOrder3DataInitiationCreditorAccount creditorAccount) {
-        return creditorAccount == null ? null : (new OBCashAccount3())
-                .schemeName(creditorAccount.getSchemeName())
-                .identification(creditorAccount.getIdentification())
-                .name(creditorAccount.getName())
-                .secondaryIdentification(creditorAccount.getSecondaryIdentification());
-    }
-
-    public static OBAuthorisation1 toOBAuthorisation1(OBWriteDomesticConsent4DataAuthorisation authorisation) {
-        return authorisation == null ? null : (new OBAuthorisation1())
-                .authorisationType(OBExternalAuthorisation1Code.valueOf(authorisation.getAuthorisationType().name()))
-                .completionDateTime(authorisation.getCompletionDateTime());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRFileConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRFileConsentConverter.java
@@ -24,17 +24,8 @@ import com.forgerock.openbanking.common.model.openbanking.v3_0.payment.FRFileCon
 import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import org.springframework.stereotype.Service;
-import uk.org.openbanking.datamodel.payment.OBFile1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
-import uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter;
 
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent2;
 
 @Service
@@ -65,7 +56,7 @@ public class FRFileConsentConverter {
         frFileConsent1.setUserId(frFileConsent2.getUserId());
         frFileConsent1.setAccountId(frFileConsent2.getAccountId());
         frFileConsent1.setCreated(frFileConsent2.getCreated());
-        frFileConsent1.setWriteFileConsent(OBWriteFileConsentConverter.toOBWriteFileConsent1(frFileConsent2.getWriteFileConsent()));
+        frFileConsent1.setWriteFileConsent(toOBWriteFileConsent1(frFileConsent2.getWriteFileConsent()));
         frFileConsent1.setPispId(frFileConsent2.getPispId());
         frFileConsent1.setPispName(frFileConsent2.getPispName());
         frFileConsent1.setStatusUpdate(frFileConsent2.getStatusUpdate());
@@ -110,30 +101,5 @@ public class FRFileConsentConverter {
                 .fileContent(consent.getFileContent())
                 .version(consent.getObVersion())
                 .build();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteFileConsent1 toOBWriteFileConsent1(OBWriteFileConsent3 writeFileConsent) {
-        return (new OBWriteFileConsent1())
-                .data(toOBWriteDataFileConsent1(writeFileConsent.getData()));
-    }
-
-    public static OBWriteDataFileConsent1 toOBWriteDataFileConsent1(OBWriteFileConsent3Data data) {
-        return data == null ? null : (new OBWriteDataFileConsent1())
-                .initiation(toOBFile1(data.getInitiation()))
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
-    }
-
-    public static OBFile1 toOBFile1(OBWriteFile2DataInitiation initiation) {
-        return initiation == null ? null : (new OBFile1())
-                .fileType(initiation.getFileType())
-                .fileHash(initiation.getFileHash())
-                .fileReference(initiation.getFileReference())
-                .numberOfTransactions(initiation.getNumberOfTransactions())
-                .controlSum(initiation.getControlSum())
-                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
-                .localInstrument(initiation.getLocalInstrument())
-                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
-                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalScheduledConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalScheduledConsentConverter.java
@@ -25,15 +25,9 @@ import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInterna
 import com.forgerock.openbanking.common.model.openbanking.v3_1_3.payment.FRInternationalScheduledConsent4;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRInternationalScheduledConsent5;
 import org.springframework.stereotype.Service;
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
 import uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter;
 
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBInternationalScheduled1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent1;
 
 @Service
 public class FRInternationalScheduledConsentConverter {
@@ -60,7 +54,7 @@ public class FRInternationalScheduledConsentConverter {
         frInternationalScheduledConsent1.setUserId(frInternationalScheduledConsent2.getUserId());
         frInternationalScheduledConsent1.setAccountId(frInternationalScheduledConsent2.getAccountId());
         frInternationalScheduledConsent1.setCreated(frInternationalScheduledConsent2.getCreated());
-        frInternationalScheduledConsent1.setInternationalScheduledConsent(OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent1(frInternationalScheduledConsent2.getInternationalScheduledConsent()));
+        frInternationalScheduledConsent1.setInternationalScheduledConsent(toOBWriteInternationalScheduledConsent1(frInternationalScheduledConsent2.getInternationalScheduledConsent()));
         frInternationalScheduledConsent1.setPispId(frInternationalScheduledConsent2.getPispId());
         frInternationalScheduledConsent1.setPispName(frInternationalScheduledConsent2.getPispName());
         frInternationalScheduledConsent1.setStatusUpdate(frInternationalScheduledConsent2.getStatusUpdate());
@@ -75,7 +69,7 @@ public class FRInternationalScheduledConsentConverter {
         frInternationalScheduledConsent1.setUserId(frInternationalScheduledConsent4.getUserId());
         frInternationalScheduledConsent1.setAccountId(frInternationalScheduledConsent4.getAccountId());
         frInternationalScheduledConsent1.setCreated(frInternationalScheduledConsent4.getCreated());
-        frInternationalScheduledConsent1.setInternationalScheduledConsent(OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent1(frInternationalScheduledConsent4.getInternationalScheduledConsent()));
+        frInternationalScheduledConsent1.setInternationalScheduledConsent(toOBWriteInternationalScheduledConsent1(frInternationalScheduledConsent4.getInternationalScheduledConsent()));
         frInternationalScheduledConsent1.setPispId(frInternationalScheduledConsent4.getPispId());
         frInternationalScheduledConsent1.setPispName(frInternationalScheduledConsent4.getPispName());
         frInternationalScheduledConsent1.setStatusUpdate(frInternationalScheduledConsent4.getStatusUpdate());
@@ -96,19 +90,5 @@ public class FRInternationalScheduledConsentConverter {
         frInternationalScheduledConsent1.setStatusUpdate(frInternationalScheduledConsent5.getStatusUpdate());
         frInternationalScheduledConsent1.setUpdated(frInternationalScheduledConsent5.getUpdated());
         return frInternationalScheduledConsent1;
-    }
-
-    // TODO #272 move to uk-datamodel
-    public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent5 obWriteInternationalScheduledConsent5) {
-        return obWriteInternationalScheduledConsent5 == null ? null : (new OBWriteInternationalScheduledConsent1())
-                .data(toOBWriteDataInternationalScheduledConsent1(obWriteInternationalScheduledConsent5.getData()))
-                .risk(obWriteInternationalScheduledConsent5.getRisk());
-    }
-
-    public static OBWriteDataInternationalScheduledConsent1 toOBWriteDataInternationalScheduledConsent1(OBWriteInternationalScheduledConsent5Data data) {
-        return data == null ? null : (new OBWriteDataInternationalScheduledConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
-                .initiation(toOBInternationalScheduled1(data.getInitiation()))
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_0/file/FilePaymentsApiController.java
@@ -49,6 +49,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBWriteFile2DataInitiation;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
 
@@ -71,7 +72,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
     public ResponseEntity<OBWriteFileResponse1> createFilePayments(
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestBody OBWriteFile1 obWriteFile1Param,
+            @RequestBody OBWriteFile1 obWriteFile1,
 
             @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
             @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
@@ -101,7 +102,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             HttpServletRequest request,
 
             Principal principal) throws OBErrorResponseException {
-        String consentId = obWriteFile1Param.getData().getConsentId();
+        String consentId = obWriteFile1.getData().getConsentId();
         FRFileConsent5 payment = paymentsService.getPayment(consentId);
 
         return rsEndpointWrapperService.paymentSubmissionEndpoint()
@@ -113,7 +114,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyInitiation(obWriteFile1Param.getData().getInitiation());
+                    f.verifyInitiation(toOBWriteFile2DataInitiation(obWriteFile1.getData().getInitiation()));
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                 })
                 .execute(
@@ -127,7 +128,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
 
                             HttpHeaders additionalHttpHeaders = new HttpHeaders();
                             additionalHttpHeaders.add("x-ob-payment-id", consentId);
-                            return rsStoreGateway.toRsStore(request, additionalHttpHeaders, Collections.emptyMap(), OBWriteFileResponse1.class, obWriteFile1Param);
+                            return rsStoreGateway.toRsStore(request, additionalHttpHeaders, Collections.emptyMap(), OBWriteFileResponse1.class, obWriteFile1);
                         }
                 );
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentsApiController.java
@@ -47,6 +47,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBWriteDomestic2DataInitiation;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
 
@@ -118,7 +119,7 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyRiskAndInitiation(obWriteDomestic2Param.getData().getInitiation(), obWriteDomestic2Param.getRisk());
+                    f.verifyRiskAndInitiation(toOBWriteDomestic2DataInitiation(obWriteDomestic2Param.getData().getInitiation()), obWriteDomestic2Param.getRisk());
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                     f.verifyRisk(obWriteDomestic2Param.getRisk());
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/file/FilePaymentsApiController.java
@@ -48,6 +48,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBWriteFile2DataInitiation;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
 
@@ -68,7 +69,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
     public ResponseEntity<OBWriteFileResponse2> createFilePayments(
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestBody OBWriteFile2 obWriteFile2Param,
+            @RequestBody OBWriteFile2 obWriteFile2,
 
             @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
             @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
@@ -98,7 +99,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             HttpServletRequest request,
 
             Principal principal) throws OBErrorResponseException {
-        String consentId = obWriteFile2Param.getData().getConsentId();
+        String consentId = obWriteFile2.getData().getConsentId();
         FRFileConsent5 payment = paymentsService.getPayment(consentId);
 
         return rsEndpointWrapperService.paymentSubmissionEndpoint()
@@ -110,7 +111,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyInitiation(obWriteFile2Param.getData().getInitiation());
+                    f.verifyInitiation(toOBWriteFile2DataInitiation(obWriteFile2.getData().getInitiation()));
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                 })
                 .execute(
@@ -124,7 +125,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
 
                             HttpHeaders additionalHttpHeaders = new HttpHeaders();
                             additionalHttpHeaders.add("x-ob-payment-id", consentId);
-                            return rsStoreGateway.toRsStore(request, additionalHttpHeaders, Collections.emptyMap(), OBWriteFileResponse2.class, obWriteFile2Param);
+                            return rsStoreGateway.toRsStore(request, additionalHttpHeaders, Collections.emptyMap(), OBWriteFileResponse2.class, obWriteFile2);
                         }
                 );
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -54,6 +54,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBWriteDomesticStandingOrder3DataInitiation;
 
 
 @Controller("DomesticStandingOrdersApiV3.1.1")
@@ -81,7 +82,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
     public ResponseEntity<OBWriteDomesticStandingOrderResponse3> createDomesticStandingOrders(
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestBody OBWriteDomesticStandingOrder3 obWriteDomesticStandingOrder3Param,
+            @RequestBody OBWriteDomesticStandingOrder3 obWriteDomesticStandingOrder3,
 
             @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
             @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
@@ -112,7 +113,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
 
             Principal principal
     ) throws OBErrorResponseException {
-        String consentId = obWriteDomesticStandingOrder3Param.getData().getConsentId();
+        String consentId = obWriteDomesticStandingOrder3.getData().getConsentId();
         FRDomesticStandingOrderConsent5 payment = paymentsService.getPayment(consentId);
 
         return rsEndpointWrapperService.paymentSubmissionEndpoint()
@@ -124,7 +125,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyRiskAndInitiation(obWriteDomesticStandingOrder3Param.getData().getInitiation(), obWriteDomesticStandingOrder3Param.getRisk());
+                    f.verifyRiskAndInitiation(toOBWriteDomesticStandingOrder3DataInitiation(obWriteDomesticStandingOrder3.getData().getInitiation()), obWriteDomesticStandingOrder3.getRisk());
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                 })
                 .execute(
@@ -159,7 +160,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
 
                             HttpHeaders additionalHttpHeaders = new HttpHeaders();
                             additionalHttpHeaders.add("x-ob-payment-id", consentId);
-                            return rsStoreGateway.toRsStore(request, additionalHttpHeaders, Collections.emptyMap(), OBWriteDomesticStandingOrderResponse3.class, obWriteDomesticStandingOrder3Param);
+                            return rsStoreGateway.toRsStore(request, additionalHttpHeaders, Collections.emptyMap(), OBWriteDomesticStandingOrderResponse3.class, obWriteDomesticStandingOrder3);
                         }
                 );
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/domesticpayments/DomesticPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/domesticpayments/DomesticPaymentsApiController.java
@@ -47,6 +47,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.aspsp.rs.api.payment.ApiVersionMatcher.getOBVersion;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBWriteDomestic2DataInitiation;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 
@@ -89,7 +90,7 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyRiskAndInitiation(obWriteDomestic2.getData().getInitiation(), obWriteDomestic2.getRisk());
+                    f.verifyRiskAndInitiation(toOBWriteDomestic2DataInitiation(obWriteDomestic2.getData().getInitiation()), obWriteDomestic2.getRisk());
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                 })
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/file/FilePaymentsApiController.java
@@ -48,6 +48,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.aspsp.rs.api.payment.ApiVersionMatcher.getOBVersion;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBWriteFile2DataInitiation;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 
@@ -90,7 +91,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyInitiation(obWriteFile2.getData().getInitiation());
+                    f.verifyInitiation(toOBWriteFile2DataInitiation(obWriteFile2.getData().getInitiation()));
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                 })
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
@@ -46,6 +46,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.aspsp.rs.api.payment.ApiVersionMatcher.getOBVersion;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBWriteDomestic2DataInitiation;
 
 @Controller("DomesticPaymentsApiV3.1.5")
 @Slf4j
@@ -86,7 +87,7 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyRiskAndInitiation(obWriteDomestic2.getData().getInitiation(), obWriteDomestic2.getRisk());
+                    f.verifyRiskAndInitiation(toOBWriteDomestic2DataInitiation(obWriteDomestic2.getData().getInitiation()), obWriteDomestic2.getRisk());
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                 })
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/file/FilePaymentsApiController.java
@@ -48,6 +48,7 @@ import java.security.Principal;
 import java.util.Collections;
 
 import static com.forgerock.openbanking.aspsp.rs.api.payment.ApiVersionMatcher.getOBVersion;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBWriteFile2DataInitiation;
 
 @Controller("FilePaymentsApiV3.1.5")
 @Slf4j
@@ -88,7 +89,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                     f.verifyPaymentIdWithAccessToken();
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                     f.verifyPaymentStatus();
-                    f.verifyInitiation(obWriteFile2.getData().getInitiation());
+                    f.verifyInitiation(toOBWriteFile2DataInitiation(obWriteFile2.getData().getInitiation()));
                     f.verifyJwsDetachedSignature(xJwsSignature, request);
                 })
                 .execute(

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/src/main/java/com/forgerock/openbanking/aspsp/rs/simulator/scheduler/AcceptInternationalPaymentTask.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/src/main/java/com/forgerock/openbanking/aspsp/rs/simulator/scheduler/AcceptInternationalPaymentTask.java
@@ -50,7 +50,6 @@ import uk.org.openbanking.datamodel.payment.OBActiveOrHistoricCurrencyAndAmount;
 import uk.org.openbanking.datamodel.payment.OBExchangeRate1;
 import uk.org.openbanking.datamodel.payment.OBExchangeRate2;
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6DataExchangeRateInformation;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -60,6 +59,7 @@ import java.util.UUID;
 import static com.forgerock.openbanking.aspsp.rs.simulator.constants.SimulatorConstants.RUN_SCHEDULED_TASK_PROPERTY;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.BOOKED_TIME_DATE_FORMAT;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 
 @Slf4j
 @Component
@@ -188,15 +188,5 @@ public class AcceptInternationalPaymentTask {
                 .unitCurrency(exchangeRateInformation.getUnitCurrency())
                 .instructedAmount(amount)
                 .contractIdentification(exchangeRateInformation.getContractIdentification());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBExchangeRate2 toOBExchangeRate2(OBWriteInternationalConsentResponse6DataExchangeRateInformation calculatedExchangeRate) {
-        return calculatedExchangeRate == null ? null : (new OBExchangeRate2())
-                .unitCurrency(calculatedExchangeRate.getUnitCurrency())
-                .exchangeRate(calculatedExchangeRate.getExchangeRate())
-                .rateType(OBExchangeRateType2Code.valueOf(calculatedExchangeRate.getRateType().name()))
-                .contractIdentification(calculatedExchangeRate.getContractIdentification())
-                .expirationDateTime(calculatedExchangeRate.getExpirationDateTime());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -42,13 +42,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBDomestic1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsentResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse1;
 
 import javax.servlet.http.HttpServletRequest;
@@ -56,17 +52,11 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationCreditorAccount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomestic2DataInitiationInstructedAmount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBDomestic1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent4;
 
 @Controller("DomesticPaymentConsentsApiV3.0")
 @Slf4j
@@ -204,45 +194,4 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
                 .risk(domesticConsent.getRisk())
                 .meta(new Meta());
     }
-
-    // TODO #272 move to uk-datamodel
-    public static OBWriteDomesticConsent4 toOBWriteDomesticConsent4(OBWriteDomesticConsent1 obWriteDomesticConsent1) {
-        return (new OBWriteDomesticConsent4())
-                .data(toOBWriteDomesticConsent4Data(obWriteDomesticConsent1.getData()))
-                .risk(obWriteDomesticConsent1.getRisk());
-    }
-
-    public static OBWriteDomesticConsent4Data toOBWriteDomesticConsent4Data(OBWriteDataDomesticConsent1 data) {
-        return data == null ? null : (new OBWriteDomesticConsent4Data())
-                .readRefundAccount(null)
-                .initiation(toOBWriteDomestic2DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
-    public static OBWriteDomestic2DataInitiation toOBWriteDomestic2DataInitiation(OBDomestic1 initiation) {
-        return initiation == null ? null : (new OBWriteDomestic2DataInitiation())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .creditorPostalAddress(initiation.getCreditorPostalAddress())
-                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
-                .supplementaryData(null);
-    }
-
-    public static OBDomestic1 toOBDomestic1(OBWriteDomestic2DataInitiation initiation) {
-        return initiation == null ? null : (new OBDomestic1())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
-                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
-                .creditorPostalAddress(initiation.getCreditorPostalAddress())
-                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -43,11 +43,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsentResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse1;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,12 +53,11 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBDomesticScheduled1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBWriteDomesticScheduled2DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent4;
 
 @Controller("DomesticScheduledPaymentConsentsApiV3.0")
 @Slf4j
@@ -202,21 +199,4 @@ public class DomesticScheduledPaymentConsentsApiController implements DomesticSc
                 .risk(domesticScheduledConsent.getRisk())
                 .meta(new Meta());
     }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticScheduledConsent4 toOBWriteDomesticScheduledConsent4(OBWriteDomesticScheduledConsent1 obWriteDomesticScheduledConsent1) {
-        return (new OBWriteDomesticScheduledConsent4())
-                .data(toOBWriteDomesticScheduledConsent4Data(obWriteDomesticScheduledConsent1.getData()))
-                .risk(obWriteDomesticScheduledConsent1.getRisk());
-    }
-
-    public static OBWriteDomesticScheduledConsent4Data toOBWriteDomesticScheduledConsent4Data(OBWriteDataDomesticScheduledConsent1 data) {
-        return data == null ? null : (new OBWriteDomesticScheduledConsent4Data())
-                .permission(OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -43,14 +43,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder1;
 import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderConsentResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse1;
 
 import javax.servlet.http.HttpServletRequest;
@@ -58,16 +54,11 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBDomesticStandingOrder1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent5;
 
 @Controller("DomesticStandingOrderConsentsApiV3.0")
 @Slf4j
@@ -207,37 +198,4 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                 .risk(domesticStandingOrderConsent.getRisk())
                 .meta(new Meta());
     }
-
-    // TODO #272 move to uk-datamodel
-    public static OBWriteDomesticStandingOrderConsent5 toOBWriteDomesticStandingOrderConsent5(OBWriteDomesticStandingOrderConsent1 obWriteDomesticStandingOrderConsent1) {
-        return (new OBWriteDomesticStandingOrderConsent5())
-                .data(toOBWriteDomesticStandingOrderConsent5Data(obWriteDomesticStandingOrderConsent1.getData()))
-                .risk(obWriteDomesticStandingOrderConsent1.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDataDomesticStandingOrderConsent1 data) {
-        return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteDomesticStandingOrder3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
-    public static OBWriteDomesticStandingOrder3DataInitiation toOBWriteDomesticStandingOrder3DataInitiation(OBDomesticStandingOrder1 initiation) {
-        return initiation == null ? null : (new OBWriteDomesticStandingOrder3DataInitiation())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .firstPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(initiation.getFirstPaymentAmount()))
-                .recurringPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(initiation.getRecurringPaymentAmount()))
-                .finalPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(initiation.getFinalPaymentAmount()))
-                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditorAccount(toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .supplementaryData(null);
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -42,8 +42,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrder1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrder3;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3;
@@ -57,7 +55,7 @@ import java.util.Optional;
 
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrder3;
 
 @Controller("DomesticStandingOrdersApiV3.0")
 @Slf4j
@@ -188,18 +186,4 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
                 .links(resourceLinkService.toSelfLink(frPaymentSubmission, discovery -> discovery.getV_3_0().getGetDomesticStandingOrder()))
                 .meta(new Meta());
     }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticStandingOrder3 toOBWriteDomesticStandingOrder3(OBWriteDomesticStandingOrder1 obWriteDomesticStandingOrder1) {
-        return (new OBWriteDomesticStandingOrder3())
-                .data(toOBWriteDataDomesticStandingOrder3(obWriteDomesticStandingOrder1.getData()))
-                .risk(obWriteDomesticStandingOrder1.getRisk());
-    }
-
-    public static OBWriteDataDomesticStandingOrder3 toOBWriteDataDomesticStandingOrder3(OBWriteDataDomesticStandingOrder1 data) {
-        return data == null ? null : (new OBWriteDataDomesticStandingOrder3())
-                .consentId(data.getConsentId())
-                .initiation(toOBDomesticStandingOrder3(data.getInitiation()));
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/file/FilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/file/FilePaymentConsentsApiController.java
@@ -52,13 +52,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBFile1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsentResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse1;
 
 import javax.servlet.http.HttpServletRequest;
@@ -70,12 +66,9 @@ import java.util.Optional;
 
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBFile1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent3;
 
 @Controller("FilePaymentConsentsApiV3.0")
 @Slf4j
@@ -346,45 +339,4 @@ public class FilePaymentConsentsApiController implements FilePaymentConsentsApi 
                 .links(resourceLinkService.toSelfLink(fileConsent, discovery -> discovery.getV_3_0().getGetFilePaymentConsent()))
                 .meta(new Meta());
     }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteFileConsent3 toOBWriteFileConsent3(OBWriteFileConsent1 obWriteFileConsent1) {
-        return obWriteFileConsent1 == null ? null : (new OBWriteFileConsent3())
-                .data(toOBWriteFileConsent3Data(obWriteFileConsent1.getData()));
-    }
-
-    public static OBWriteFileConsent3Data toOBWriteFileConsent3Data(OBWriteDataFileConsent1 data) {
-        return data == null ? null : (new OBWriteFileConsent3Data())
-                .initiation(toOBWriteFile2DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
-    public static OBWriteFile2DataInitiation toOBWriteFile2DataInitiation(OBFile1 initiation) {
-        return initiation == null ? null : (new OBWriteFile2DataInitiation())
-                .fileType(initiation.getFileType())
-                .fileHash(initiation.getFileHash())
-                .fileReference(initiation.getFileReference())
-                .numberOfTransactions(initiation.getNumberOfTransactions())
-                .controlSum(initiation.getControlSum())
-                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
-                .localInstrument(initiation.getLocalInstrument())
-                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
-                .supplementaryData(null);
-    }
-
-    public static OBFile1 toOBFile1(OBWriteFile2DataInitiation initiation) {
-        return initiation == null ? null : (new OBFile1())
-                .fileType(initiation.getFileType())
-                .fileHash(initiation.getFileHash())
-                .fileReference(initiation.getFileReference())
-                .numberOfTransactions(initiation.getNumberOfTransactions())
-                .controlSum(initiation.getControlSum())
-                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
-                .localInstrument(initiation.getLocalInstrument())
-                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
-                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -42,11 +42,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalConsentResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse1;
 
 import javax.servlet.http.HttpServletRequest;
@@ -54,13 +52,12 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController.toOBExchangeRate2;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBInternational1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBWriteInternational3DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternationalConsent5;
 
 @Controller("InternationalPaymentConsentsApiV3.0")
 @Slf4j
@@ -198,20 +195,5 @@ public class InternationalPaymentConsentsApiController implements InternationalP
                 .risk(internationalConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalConsent, discovery -> discovery.getV_3_0().getGetInternationalPaymentConsent()))
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalConsent5 toOBWriteInternationalConsent5(OBWriteInternationalConsent1 obWriteInternationalConsent1) {
-        return new OBWriteInternationalConsent5()
-                .data(toOBWriteInternationalConsent5Data(obWriteInternationalConsent1.getData()))
-                .risk(obWriteInternationalConsent1.getRisk());
-    }
-
-    public static OBWriteInternationalConsent5Data toOBWriteInternationalConsent5Data(OBWriteDataInternationalConsent1 data) {
-        return data == null ? null : (new OBWriteInternationalConsent5Data())
-                .readRefundAccount(null)
-                .initiation(toOBWriteInternational3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalpayments/InternationalPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalpayments/InternationalPaymentsApiController.java
@@ -53,8 +53,8 @@ import java.security.Principal;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController.toOBExchangeRate2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternational2;
 
 @Controller("InternationalPaymentsApiV3.0")

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -42,13 +42,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsentResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse1;
 
 import javax.servlet.http.HttpServletRequest;
@@ -56,14 +53,13 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController.toOBExchangeRate2;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBInternationalScheduled1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBWriteInternationalScheduled3DataInitiation;
-
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBExternalPermissions2Code;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent5;
 
 @Controller("InternationalScheduledPaymentConsentsApiV3.0")
 @Slf4j
@@ -204,24 +200,5 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .risk(internationalScheduledConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalScheduledConsent, discovery -> discovery.getV_3_0().getGetInternationalScheduledPaymentConsent()))
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalScheduledConsent5 toOBWriteInternationalScheduledConsent5(OBWriteInternationalScheduledConsent1 obWriteInternationalScheduledConsent1) {
-        return (new OBWriteInternationalScheduledConsent5())
-                .data(toOBWriteInternationalScheduledConsent5Data(obWriteInternationalScheduledConsent1.getData()))
-                .risk(obWriteInternationalScheduledConsent1.getRisk());
-    }
-    public static OBWriteInternationalScheduledConsent5Data toOBWriteInternationalScheduledConsent5Data(OBWriteDataInternationalScheduledConsent1 data) {
-        return data == null ? null : (new OBWriteInternationalScheduledConsent5Data())
-                .permission(OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
-    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteInternationalScheduledConsent5Data.PermissionEnum permission) {
-        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -53,8 +53,8 @@ import java.security.Principal;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController.toOBExchangeRate2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduled2;
 
 @Controller("InternationalScheduledPaymentsApiV3.0")

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -42,11 +42,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsentResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse1;
 
 import javax.servlet.http.HttpServletRequest;
@@ -54,13 +52,12 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalstandingorders.InternationalStandingOrderConsentsApiController.toOBExternalPermissions2Code;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder1;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBWriteInternationalStandingOrder4DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBExternalPermissions2Code;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent6;
 
 @Controller("InternationalStandingOrderConsentsApiV3.0")
 @Slf4j
@@ -198,21 +195,5 @@ public class InternationalStandingOrderConsentsApiController implements Internat
                 .risk(internationalStandingOrderConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalStandingOrderConsent, discovery -> discovery.getV_3_0().getGetInternationalStandingOrderConsent()))
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalStandingOrderConsent6 toOBWriteInternationalStandingOrderConsent6(OBWriteInternationalStandingOrderConsent1 obWriteInternationalStandingOrderConsent1) {
-        return (new OBWriteInternationalStandingOrderConsent6())
-                .data(toOBWriteInternationalStandingOrderConsent6Data(obWriteInternationalStandingOrderConsent1.getData()))
-                .risk(obWriteInternationalStandingOrderConsent1.getRisk());
-    }
-
-    public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteDataInternationalStandingOrderConsent1 data) {
-        return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -41,10 +41,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder1;
-import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder3;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrder1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrder3;
 import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder3;
@@ -57,11 +53,8 @@ import java.util.Date;
 import java.util.Optional;
 
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountCreditor3;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountDebtor4;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBDomestic2InstructedAmount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBBranchAndFinancialInstitutionIdentification6;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrder3;
 
 @Controller("InternationalStandingOrdersApiV3.0")
 @Slf4j
@@ -176,7 +169,6 @@ public class InternationalStandingOrdersApiController implements InternationalSt
         return ResponseEntity.ok(packagePayment(frPaymentSubmission, frPaymentSetup));
     }
 
-
     private OBWriteInternationalStandingOrderResponse1 packagePayment(FRInternationalStandingOrderPaymentSubmission3 frPaymentSubmission, FRInternationalStandingOrderConsent5 FRInternationalStandingOrderConsent5) {
         return new OBWriteInternationalStandingOrderResponse1()
                 .data(new OBWriteDataInternationalStandingOrderResponse1()
@@ -189,36 +181,5 @@ public class InternationalStandingOrdersApiController implements InternationalSt
                 )
                 .links(resourceLinkService.toSelfLink(frPaymentSubmission, discovery -> discovery.getV_3_0().getGetInternationalStandingOrder()))
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalStandingOrder3 toOBWriteInternationalStandingOrder3(OBWriteInternationalStandingOrder1 obWriteInternationalStandingOrder1) {
-        return (new OBWriteInternationalStandingOrder3())
-                .data(toOBWriteDataInternationalStandingOrder3(obWriteInternationalStandingOrder1.getData()))
-                .risk(obWriteInternationalStandingOrder1.getRisk());
-    }
-
-    public static OBWriteDataInternationalStandingOrder3 toOBWriteDataInternationalStandingOrder3(OBWriteDataInternationalStandingOrder1 data) {
-        return data == null ? null : (new OBWriteDataInternationalStandingOrder3())
-                .consentId(data.getConsentId())
-                .initiation(toOBInternationalStandingOrder3(data.getInitiation()));
-    }
-
-    public static OBInternationalStandingOrder3 toOBInternationalStandingOrder3(OBInternationalStandingOrder1 initiation) {
-        return initiation == null ? null : (new OBInternationalStandingOrder3())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .purpose(initiation.getPurpose())
-                .chargeBearer(initiation.getChargeBearer())
-                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
-                .instructedAmount(toOBDomestic2InstructedAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBCashAccountDebtor4(initiation.getDebtorAccount()))
-                .creditor(initiation.getCreditor())
-                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification6(initiation.getCreditorAgent()))
-                .creditorAccount(toOBCashAccountCreditor3(initiation.getCreditorAccount()))
-                .supplementaryData(null);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -45,12 +45,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.payment.OBFundsAvailableResult1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsentResponse2;
 import uk.org.openbanking.datamodel.payment.OBWriteDataFundsConfirmationResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse2;
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
 
@@ -59,12 +57,11 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBDomestic2;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBWriteDomestic2DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent4;
 
 @Controller("DomesticPaymentConsentsApiV3.1")
 @Slf4j
@@ -262,21 +259,6 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
                 .links(resourceLinkService.toSelfLink(domesticConsent, discovery -> discovery.getV_3_1().getGetDomesticPaymentConsent()))
                 .risk(domesticConsent.getRisk())
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticConsent4 toOBWriteDomesticConsent4(OBWriteDomesticConsent2 obWriteDomesticConsent2) {
-        return (new OBWriteDomesticConsent4())
-                .data(toOBWriteDomesticConsent4Data(obWriteDomesticConsent2.getData()))
-                .risk(obWriteDomesticConsent2.getRisk());
-    }
-
-    public static OBWriteDomesticConsent4Data toOBWriteDomesticConsent4Data(OBWriteDataDomesticConsent2 data) {
-        return data == null ? null : (new OBWriteDomesticConsent4Data())
-                .readRefundAccount(null)
-                .initiation(toOBWriteDomestic2DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -44,11 +44,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsentResponse2;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse2;
 
 import javax.servlet.http.HttpServletRequest;
@@ -56,12 +54,11 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBDomesticScheduled2;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBWriteDomesticScheduled2DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent4;
 
 @Controller("DomesticScheduledPaymentConsentsApiV3.1")
 @Slf4j
@@ -200,22 +197,5 @@ public class DomesticScheduledPaymentConsentsApiController implements DomesticSc
                 .risk(domesticScheduledConsent.getRisk())
                 .meta(new Meta())
                 ;
-    }
-
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticScheduledConsent4 toOBWriteDomesticScheduledConsent4(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
-        return (new OBWriteDomesticScheduledConsent4())
-                .data(toOBWriteDomesticScheduledConsent4Data(obWriteDomesticScheduledConsent2.getData()))
-                .risk(obWriteDomesticScheduledConsent2.getRisk());
-    }
-
-    public static OBWriteDomesticScheduledConsent4Data toOBWriteDomesticScheduledConsent4Data(OBWriteDataDomesticScheduledConsent2 data) {
-        return data == null ? null : (new OBWriteDomesticScheduledConsent4Data())
-                .permission(OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -43,20 +43,22 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.account.OBCashAccount3;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderConsentResponse2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse2;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBDomesticStandingOrder2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent5;
 
 @Controller("DomesticStandingOrderConsentsApiV3.1")
 @Slf4j
@@ -193,63 +195,5 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                 .links(resourceLinkService.toSelfLink(domesticStandingOrderConsent, discovery -> discovery.getV_3_1().getGetDomesticStandingOrderConsent()))
                 .risk(domesticStandingOrderConsent.getRisk())
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticStandingOrderConsent5 toOBWriteDomesticStandingOrderConsent5(OBWriteDomesticStandingOrderConsent2 obWriteDomesticStandingOrderConsent2) {
-        return (new OBWriteDomesticStandingOrderConsent5())
-                .data(toOBWriteDomesticStandingOrderConsent5Data(obWriteDomesticStandingOrderConsent2.getData()))
-                .risk(obWriteDomesticStandingOrderConsent2.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDataDomesticStandingOrderConsent2 data) {
-        return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteDomesticStandingOrder3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
-    public static OBWriteDomesticStandingOrder3DataInitiation toOBWriteDomesticStandingOrder3DataInitiation(OBDomesticStandingOrder2 initiation) {
-        return initiation == null ? null : (new OBWriteDomesticStandingOrder3DataInitiation())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .firstPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(initiation.getFirstPaymentAmount()))
-                .recurringPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(initiation.getRecurringPaymentAmount()))
-                .finalPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(initiation.getFinalPaymentAmount()))
-                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditorAccount(toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .supplementaryData(initiation.getSupplementaryData());
-    }
-
-    public static OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
-        return amount == null ? null : (new OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
-    }
-
-    public static OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
-        return amount == null ? null : (new OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
-    }
-
-    public static OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
-        return amount == null ? null : (new OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
-    }
-
-    public static OBWriteDomesticStandingOrder3DataInitiationCreditorAccount toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(OBCashAccount3 creditorAccount) {
-        return creditorAccount == null ? null : (new OBWriteDomesticStandingOrder3DataInitiationCreditorAccount())
-                .schemeName(creditorAccount.getSchemeName())
-                .identification(creditorAccount.getIdentification())
-                .name(creditorAccount.getName())
-                .secondaryIdentification(creditorAccount.getSecondaryIdentification());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/file/FilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/file/FilePaymentConsentsApiController.java
@@ -67,7 +67,7 @@ import static com.forgerock.openbanking.common.services.openbanking.IdempotencyS
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBFile2;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent3Data;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent3;
 
 @Controller("FilePaymentConsentsApiV3.1")
 @Slf4j
@@ -336,11 +336,4 @@ public class FilePaymentConsentsApiController implements FilePaymentConsentsApi 
                 .links(resourceLinkService.toSelfLink(fileConsent, discovery -> discovery.getV_3_1().getGetFilePaymentConsent()))
                 .meta(new Meta());
     }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteFileConsent3 toOBWriteFileConsent3(OBWriteFileConsent2 obWriteFileConsent2) {
-        return (new OBWriteFileConsent3())
-                .data(toOBWriteFileConsent3Data(obWriteFileConsent2.getData()));
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -44,19 +44,25 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBFundsAvailableResult1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalConsentResponse2;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse2;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBInternational2;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBWriteInternational3DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternationalConsent5;
 
 @Controller("InternationalPaymentConsentsApiV3.1")
 @Slf4j
@@ -250,29 +256,5 @@ public class InternationalPaymentConsentsApiController implements InternationalP
                 .risk(internationalConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalConsent, discovery -> discovery.getV_3_1().getGetInternationalPaymentConsent()))
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalConsent5 toOBWriteInternationalConsent5(OBWriteInternationalConsent2 obWriteInternationalConsent2) {
-        return (new OBWriteInternationalConsent5())
-                .data(toOBWriteInternationalConsent5Data(obWriteInternationalConsent2.getData()))
-                .risk(obWriteInternationalConsent2.getRisk());
-    }
-
-    public static OBWriteInternationalConsent5Data toOBWriteInternationalConsent5Data(OBWriteDataInternationalConsent2 data) {
-        return data == null ? null : (new OBWriteInternationalConsent5Data())
-                .readRefundAccount(null)
-                .initiation(toOBWriteInternational3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
-    public static OBExchangeRate2 toOBExchangeRate2(OBWriteInternationalConsentResponse6DataExchangeRateInformation calculatedExchangeRate) {
-        return calculatedExchangeRate == null ? null : (new OBExchangeRate2())
-                .unitCurrency(calculatedExchangeRate.getUnitCurrency())
-                .exchangeRate(calculatedExchangeRate.getExchangeRate())
-                .rateType(OBExchangeRateType2Code.valueOf(calculatedExchangeRate.getRateType().name()))
-                .contractIdentification(calculatedExchangeRate.getContractIdentification())
-                .expirationDateTime(calculatedExchangeRate.getExpirationDateTime());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalpayments/InternationalPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalpayments/InternationalPaymentsApiController.java
@@ -51,8 +51,8 @@ import java.security.Principal;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController.toOBExchangeRate2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 
 @Controller("InternationalPaymentsApiV3.1")
 @Slf4j

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -44,20 +44,27 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBFundsAvailableResult1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsentResponse2;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse2;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController.toOBExchangeRate2;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBInternationalScheduled2;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBWriteInternationalScheduled3DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent5;
 
 @Controller("InternationalScheduledPaymentConsentsApiV3.1")
 @Slf4j
@@ -256,20 +263,4 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .links(resourceLinkService.toSelfLink(internationalScheduledConsent, discovery -> discovery.getV_3_1().getGetInternationalScheduledPaymentConsent()))
                 .meta(new Meta());
     }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalScheduledConsent5 toOBWriteInternationalScheduledConsent5(OBWriteInternationalScheduledConsent2 obWriteInternationalScheduledConsent2) {
-        return (new OBWriteInternationalScheduledConsent5())
-                .data(toOBWriteInternationalScheduledConsent5Data(obWriteInternationalScheduledConsent2.getData()))
-                .risk(obWriteInternationalScheduledConsent2.getRisk());
-    }
-    public static OBWriteInternationalScheduledConsent5Data toOBWriteInternationalScheduledConsent5Data(OBWriteDataInternationalScheduledConsent2 data) {
-        return data == null ? null : (new OBWriteInternationalScheduledConsent5Data())
-                .permission(OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -51,8 +51,8 @@ import java.security.Principal;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.internationalpayments.InternationalPaymentConsentsApiController.toOBExchangeRate2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
 
 @Controller("InternationalScheduledPaymentsApiV3.1")
 @Slf4j

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -42,12 +42,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsentResponse2;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse2;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,12 +52,12 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder2;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBWriteInternationalStandingOrder4DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBExternalPermissions2Code;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent6;
 
 @Controller("InternationalStandingOrderConsentsApiV3.1")
 @Slf4j
@@ -197,25 +194,5 @@ public class InternationalStandingOrderConsentsApiController implements Internat
                 ).risk(internationalStandingOrderConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalStandingOrderConsent, discovery -> discovery.getV_3_1().getGetInternationalStandingOrderConsent()))
                 .meta(new Meta());
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalStandingOrderConsent6 toOBWriteInternationalStandingOrderConsent6(OBWriteInternationalStandingOrderConsent2 obWriteInternationalStandingOrderConsent2) {
-        return (new OBWriteInternationalStandingOrderConsent6())
-                .data(toOBWriteInternationalStandingOrderConsent6Data(obWriteInternationalStandingOrderConsent2.getData()))
-                .risk(obWriteInternationalStandingOrderConsent2.getRisk());
-    }
-
-    public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteDataInternationalStandingOrderConsent2 data) {
-        return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
-    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum permission) {
-        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_1/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -43,14 +43,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.OBAuthorisation1;
 import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderConsent3;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderConsentResponse3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4DataAuthorisation;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse3;
 
 import javax.servlet.http.HttpServletRequest;
@@ -59,10 +54,10 @@ import java.security.Principal;
 import java.util.Optional;
 
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder3;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBWriteDomesticStandingOrder3DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent5;
 
 @Controller("DomesticStandingOrderConsentsApiV3.1.1")
 @Slf4j
@@ -197,27 +192,5 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                 .links(resourceLinkService.toSelfLink(domesticStandingOrderConsent, discovery -> discovery.getV_3_1_1().getGetDomesticStandingOrderConsent()))
                 .risk(domesticStandingOrderConsent.getRisk())
                 .meta(new Meta());
-    }
-
-    // TODO #272 move to uk-datamodel
-    public static OBWriteDomesticStandingOrderConsent5 toOBWriteDomesticStandingOrderConsent5(OBWriteDomesticStandingOrderConsent3 obWriteDomesticStandingOrderConsent3) {
-        return (new OBWriteDomesticStandingOrderConsent5())
-                .data(toOBWriteDomesticStandingOrderConsent5Data(obWriteDomesticStandingOrderConsent3.getData()))
-                .risk(obWriteDomesticStandingOrderConsent3.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDataDomesticStandingOrderConsent3 data) {
-        return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteDomesticStandingOrder3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                . scASupportData(null);
-    }
-
-    public static OBWriteDomesticConsent4DataAuthorisation toOBWriteDomesticConsent4DataAuthorisation(OBAuthorisation1 authorisation) {
-        return authorisation == null ? null : (new OBWriteDomesticConsent4DataAuthorisation())
-                .authorisationType(OBWriteDomesticConsent4DataAuthorisation.AuthorisationTypeEnum.valueOf(authorisation.getAuthorisationType().name()))
-                .completionDateTime(authorisation.getCompletionDateTime());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_1/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -42,19 +42,22 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.org.openbanking.datamodel.account.Meta;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsentResponse3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse3;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toOBAuthorisation1;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder3;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBWriteInternationalStandingOrder4DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent6;
 
 @Controller("InternationalStandingOrderConsentsApiV3.1.1")
 @Slf4j
@@ -191,21 +194,4 @@ public class InternationalStandingOrderConsentsApiController implements Internat
                 .links(resourceLinkService.toSelfLink(internationalStandingOrderConsent, discovery -> discovery.getV_3_1_1().getGetInternationalStandingOrderConsent()))
                 .meta(new Meta());
     }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalStandingOrderConsent6 toOBWriteInternationalStandingOrderConsent6(OBWriteInternationalStandingOrderConsent3 obWriteInternationalStandingOrderConsent3) {
-        return (new OBWriteInternationalStandingOrderConsent6())
-                .data(toOBWriteInternationalStandingOrderConsent6Data(obWriteInternationalStandingOrderConsent3.getData()))
-                .risk(obWriteInternationalStandingOrderConsent3.getRisk());
-    }
-
-    public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteDataInternationalStandingOrderConsent3 data) {
-        return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(null);
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -46,15 +46,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBFundsAvailableResult1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse3Data;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_5.file.FilePaymentConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteDomesticConsentResponse3DataStatus;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent4;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
 
@@ -185,7 +192,7 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
     private OBWriteDomesticConsentResponse3 packageResponse(FRDomesticConsent5 domesticConsent) {
         return new OBWriteDomesticConsentResponse3()
                 .data(new OBWriteDomesticConsentResponse3Data()
-                        .initiation(toOBWriteDomestic2DataInitiation(domesticConsent.getInitiation()))
+                        .initiation(domesticConsent.getInitiation())
                         .status(toOBWriteDomesticConsentResponse3DataStatus(domesticConsent.getStatus()))
                         .creationDateTime(domesticConsent.getCreated())
                         .statusUpdateDateTime(domesticConsent.getStatusUpdate())
@@ -200,45 +207,4 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_3();
     }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomestic2DataInitiation toOBWriteDomestic2DataInitiation(OBWriteDomestic2DataInitiation initiation) {
-        return initiation == null ? null : (new OBWriteDomestic2DataInitiation())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .instructedAmount(initiation.getInstructedAmount())
-                .debtorAccount(initiation.getDebtorAccount())
-                .creditorAccount(initiation.getCreditorAccount())
-                .creditorPostalAddress(initiation.getCreditorPostalAddress())
-                .remittanceInformation(initiation.getRemittanceInformation())
-                .supplementaryData(initiation.getSupplementaryData());
-    }
-
-    public static OBWriteDomesticConsent4 toOBWriteDomesticConsent4(OBWriteDomesticConsent3 obWriteDomesticConsent3) {
-        return obWriteDomesticConsent3 == null ? null : (new OBWriteDomesticConsent4())
-                .data(toOBWriteDomesticConsent4Data(obWriteDomesticConsent3.getData()))
-                .risk(obWriteDomesticConsent3.getRisk());
-    }
-
-    public static OBWriteDomesticConsent4Data toOBWriteDomesticConsent4Data(OBWriteDomesticConsent3Data data) {
-        return data == null ? null : (new OBWriteDomesticConsent4Data())
-                .initiation(data.getInitiation())
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
-    }
-
-    public static OBWriteDomesticConsent3DataAuthorisation toOBWriteDomesticConsent3DataAuthorisation(OBWriteDomesticConsent4DataAuthorisation authorisation) {
-        return authorisation == null ? null : (new OBWriteDomesticConsent3DataAuthorisation())
-                .authorisationType(OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum.valueOf(authorisation.getAuthorisationType().name()))
-                .completionDateTime(authorisation.getCompletionDateTime());
-    }
-
-    public static OBWriteDomesticConsent4DataSCASupportData toOBWriteDomesticConsent4DataSCASupportData(OBWriteDomesticConsent3DataSCASupportData scASupportData) {
-        return scASupportData == null ? null : (new OBWriteDomesticConsent4DataSCASupportData())
-                .requestedSCAExemptionType(OBWriteDomesticConsent4DataSCASupportData.RequestedSCAExemptionTypeEnum.valueOf(scASupportData.getRequestedSCAExemptionType().name()))
-                .appliedAuthenticationApproach(OBWriteDomesticConsent4DataSCASupportData.AppliedAuthenticationApproachEnum.valueOf(scASupportData.getAppliedAuthenticationApproach().name()))
-                .referencePaymentOrderId(scASupportData.getReferencePaymentOrderId());
-    }
-
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -45,11 +45,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataSCASupportData;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4DataSCASupportData;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse3;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse3Data;
@@ -59,11 +55,11 @@ import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent3DataAuthorisation;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent4DataSCASupportData;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_5.file.FilePaymentConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteDomesticScheduledConsentResponse3DataStatus;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent3DataSCASupportData;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticScheduledConsent4;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 
@@ -153,7 +149,7 @@ public class DomesticScheduledPaymentConsentsApiController implements DomesticSc
                         .creationDateTime(domesticScheduledConsent.getCreated())
                         .statusUpdateDateTime(domesticScheduledConsent.getStatusUpdate())
                         .consentId(domesticScheduledConsent.getId())
-                        .permission(PermissionEnum.valueOf(domesticScheduledConsent.getDomesticScheduledConsent().getData().getPermission().name()))
+                        .permission(toPermission(domesticScheduledConsent.getDomesticScheduledConsent().getData().getPermission()))
                         .authorisation(toOBWriteDomesticConsent3DataAuthorisation(domesticScheduledConsent.getDomesticScheduledConsent().getData().getAuthorisation()))
                         .scASupportData(toOBWriteDomesticConsent3DataSCASupportData(domesticScheduledConsent.getDomesticScheduledConsent().getData().getScASupportData()))
                 )
@@ -162,30 +158,11 @@ public class DomesticScheduledPaymentConsentsApiController implements DomesticSc
                 .meta(new Meta());
     }
 
+    private PermissionEnum toPermission(OBWriteDomesticScheduledConsent4Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
+    }
+
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_3();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticScheduledConsent4 toOBWriteDomesticScheduledConsent4(OBWriteDomesticScheduledConsent3 obWriteDomesticScheduledConsent3) {
-        return obWriteDomesticScheduledConsent3 == null ? null : (new OBWriteDomesticScheduledConsent4())
-                .data(toOBWriteDomesticScheduledConsent4Data(obWriteDomesticScheduledConsent3.getData()))
-                .risk(obWriteDomesticScheduledConsent3.getRisk());
-    }
-
-    public static OBWriteDomesticScheduledConsent4Data toOBWriteDomesticScheduledConsent4Data(OBWriteDomesticScheduledConsent3Data data) {
-        return data == null ? null : (new OBWriteDomesticScheduledConsent4Data())
-                .permission(OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(data.getInitiation())
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
-    }
-
-    public static OBWriteDomesticConsent3DataSCASupportData toOBWriteDomesticConsent3DataSCASupportData(OBWriteDomesticConsent4DataSCASupportData scASupportData) {
-        return scASupportData == null ? null : (new OBWriteDomesticConsent3DataSCASupportData())
-                .requestedSCAExemptionType(OBWriteDomesticConsent3DataSCASupportData.RequestedSCAExemptionTypeEnum.valueOf(scASupportData.getRequestedSCAExemptionType().name()))
-                .appliedAuthenticationApproach(OBWriteDomesticConsent3DataSCASupportData.AppliedAuthenticationApproachEnum.valueOf(scASupportData.getAppliedAuthenticationApproach().name()))
-                .referencePaymentOrderId(scASupportData.getReferencePaymentOrderId());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -45,10 +45,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse4Data;
@@ -58,11 +55,10 @@ import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent3DataAuthorisation;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent4DataSCASupportData;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_5.file.FilePaymentConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteDomesticStandingOrderConsentResponse4DataStatus;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent5;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 
@@ -146,12 +142,12 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
     private OBWriteDomesticStandingOrderConsentResponse4 packageResponse(FRDomesticStandingOrderConsent5 domesticStandingOrderConsent) {
         return new OBWriteDomesticStandingOrderConsentResponse4()
                 .data(new OBWriteDomesticStandingOrderConsentResponse4Data()
-                        .initiation(toOBWriteDomesticStandingOrder3DataInitiation(domesticStandingOrderConsent.getInitiation()))
+                        .initiation(domesticStandingOrderConsent.getInitiation())
                         .status(toOBWriteDomesticStandingOrderConsentResponse4DataStatus(domesticStandingOrderConsent.getStatus()))
                         .creationDateTime(domesticStandingOrderConsent.getCreated())
                         .statusUpdateDateTime(domesticStandingOrderConsent.getStatusUpdate())
                         .consentId(domesticStandingOrderConsent.getId())
-                        .permission(PermissionEnum.valueOf(domesticStandingOrderConsent.getDomesticStandingOrderConsent().getData().getPermission().name()))
+                        .permission(toPermission(domesticStandingOrderConsent.getDomesticStandingOrderConsent().getData().getPermission()))
                         .authorisation(toOBWriteDomesticConsent3DataAuthorisation(domesticStandingOrderConsent.getDomesticStandingOrderConsent().getData().getAuthorisation()))
                 )
                 .links(resourceLinkService.toSelfLink(domesticStandingOrderConsent, discovery -> getVersion(discovery).getGetDomesticStandingOrderConsent()))
@@ -159,40 +155,12 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                 .meta(new Meta());
     }
 
+    private PermissionEnum toPermission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
+    }
+
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_3();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticStandingOrderConsent5 toOBWriteDomesticStandingOrderConsent5(OBWriteDomesticStandingOrderConsent4 obWriteDomesticStandingOrderConsent4) {
-        return (new OBWriteDomesticStandingOrderConsent5())
-                .data(toOBWriteDomesticStandingOrderConsent5Data(obWriteDomesticStandingOrderConsent4.getData()))
-                .risk(obWriteDomesticStandingOrderConsent4.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDomesticStandingOrderConsent4Data data) {
-        return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(data.getInitiation())
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
-    }
-
-    public static OBWriteDomesticStandingOrder3DataInitiation toOBWriteDomesticStandingOrder3DataInitiation(OBWriteDomesticStandingOrder3DataInitiation initiation) {
-        return initiation == null ? null : (new OBWriteDomesticStandingOrder3DataInitiation())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .firstPaymentAmount(initiation.getFirstPaymentAmount())
-                .recurringPaymentAmount(initiation.getRecurringPaymentAmount())
-                .finalPaymentAmount(initiation.getFinalPaymentAmount())
-                .debtorAccount(initiation.getDebtorAccount())
-                .creditorAccount(initiation.getCreditorAccount())
-                .supplementaryData(initiation.getSupplementaryData());
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentConsentsApiController.java
@@ -54,7 +54,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse3;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse3Data;
@@ -119,7 +118,7 @@ public class FilePaymentConsentsApiController implements FilePaymentConsentsApi 
 
         FRFileConsent5 fileConsent = FRFileConsent5.builder().id(IntentType.PAYMENT_FILE_CONSENT.generateIntentId())
                 .status(ConsentStatusCode.AWAITINGUPLOAD)
-                .writeFileConsent(toOBWriteFileConsent2(obWriteFileConsent3))
+                .writeFileConsent(obWriteFileConsent3)
                 .pispId(tpp.getId())
                 .pispName(tpp.getOfficialName())
                 .statusUpdate(DateTime.now())
@@ -245,7 +244,7 @@ public class FilePaymentConsentsApiController implements FilePaymentConsentsApi 
                         .status(toOBWriteFileConsentResponse3DataStatus(fileConsent.getStatus()))
                         .creationDateTime(fileConsent.getCreated())
                         .statusUpdateDateTime(fileConsent.getStatusUpdate())
-                        .initiation(toOBWriteFile2DataInitiation(fileConsent.getInitiation()))
+                        .initiation(fileConsent.getInitiation())
                         .authorisation(fileConsent.getWriteFileConsent().getData().getAuthorisation())
                 )
                 .links(resourceLinkService.toSelfLink(fileConsent, discovery -> getVersion(discovery).getGetFilePaymentConsent()))
@@ -254,26 +253,6 @@ public class FilePaymentConsentsApiController implements FilePaymentConsentsApi 
 
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_3();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteFileConsent3 toOBWriteFileConsent2(OBWriteFileConsent3 obWriteFileConsent3) {
-        return (new OBWriteFileConsent3())
-                .data(obWriteFileConsent3.getData());
-    }
-
-    public static OBWriteFile2DataInitiation toOBWriteFile2DataInitiation(OBWriteFile2DataInitiation initiation) {
-        return initiation == null ? null : (new OBWriteFile2DataInitiation())
-                .fileType(initiation.getFileType())
-                .fileHash(initiation.getFileHash())
-                .fileReference(initiation.getFileReference())
-                .numberOfTransactions(initiation.getNumberOfTransactions())
-                .controlSum(initiation.getControlSum())
-                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
-                .localInstrument(initiation.getLocalInstrument())
-                .debtorAccount(initiation.getDebtorAccount())
-                .remittanceInformation(initiation.getRemittanceInformation())
-                .supplementaryData(initiation.getSupplementaryData());
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -46,17 +46,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBFundsAvailableResult1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse4Data;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent3DataAuthorisation;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent4DataSCASupportData;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_5.file.FilePaymentConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteInternationalConsentResponse4DataStatus;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBWriteInternationalConsentResponse4DataExchangeRateInformation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternationalConsent5;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 
@@ -192,29 +197,5 @@ public class InternationalPaymentConsentsApiController implements InternationalP
 
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_3();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalConsent5 toOBWriteInternationalConsent5(OBWriteInternationalConsent4 obWriteInternationalConsent4) {
-        return (new OBWriteInternationalConsent5())
-                .data(toOBWriteInternationalConsent5Data(obWriteInternationalConsent4.getData()))
-                .risk(obWriteInternationalConsent4.getRisk());
-    }
-
-    public static OBWriteInternationalConsent5Data toOBWriteInternationalConsent5Data(OBWriteInternationalConsent4Data data) {
-        return data == null ? null : (new OBWriteInternationalConsent5Data())
-                .initiation(data.getInitiation())
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .readRefundAccount(null)
-                .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
-    }
-
-    public static OBWriteInternationalConsentResponse4DataExchangeRateInformation toOBWriteInternationalConsentResponse4DataExchangeRateInformation(OBWriteInternationalConsentResponse6DataExchangeRateInformation calculatedExchangeRate) {
-        return calculatedExchangeRate == null ? null : (new OBWriteInternationalConsentResponse4DataExchangeRateInformation())
-                .unitCurrency(calculatedExchangeRate.getUnitCurrency())
-                .exchangeRate(calculatedExchangeRate.getExchangeRate())
-                .rateType(OBWriteInternationalConsentResponse4DataExchangeRateInformation.RateTypeEnum.valueOf(calculatedExchangeRate.getRateType().name()))
-                .contractIdentification(calculatedExchangeRate.getContractIdentification())
-                .expirationDateTime(calculatedExchangeRate.getExpirationDateTime());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalpayments/InternationalPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalpayments/InternationalPaymentsApiController.java
@@ -53,8 +53,8 @@ import java.security.Principal;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.internationalpayments.InternationalPaymentConsentsApiController.toOBWriteInternationalConsentResponse4DataExchangeRateInformation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteInternationalResponse4DataStatus;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBWriteInternationalConsentResponse4DataExchangeRateInformation;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -46,18 +46,25 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBFundsAvailableResult1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse4Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse4Data.PermissionEnum;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent3DataAuthorisation;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent4DataSCASupportData;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.internationalpayments.InternationalPaymentConsentsApiController.toOBWriteInternationalConsentResponse4DataExchangeRateInformation;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_5.file.FilePaymentConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteInternationalScheduledConsentResponse4DataStatus;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBWriteInternationalConsentResponse4DataExchangeRateInformation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent5;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 
@@ -186,7 +193,7 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                         .statusUpdateDateTime(internationalScheduledConsent.getStatusUpdate())
                         .consentId(internationalScheduledConsent.getId())
                         .exchangeRateInformation(toOBWriteInternationalConsentResponse4DataExchangeRateInformation(internationalScheduledConsent.getCalculatedExchangeRate()))
-                        .permission(OBWriteInternationalScheduledConsentResponse4Data.PermissionEnum.valueOf(internationalScheduledConsent.internationalScheduledConsent.getData().getPermission().name()))
+                        .permission(toPermission(internationalScheduledConsent.internationalScheduledConsent.getData().getPermission()))
                         .expectedExecutionDateTime(initiation.getRequestedExecutionDateTime())
                         .authorisation(toOBWriteDomesticConsent3DataAuthorisation(internationalScheduledConsent.getInternationalScheduledConsent().getData().getAuthorisation()))
                 )
@@ -195,24 +202,12 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .meta(new Meta());
     }
 
+    private PermissionEnum toPermission(OBWriteInternationalScheduledConsent5Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
+    }
+
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_3();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalScheduledConsent5 toOBWriteInternationalScheduledConsent5(OBWriteInternationalScheduledConsent4 obWriteInternationalScheduledConsent4) {
-        return (new OBWriteInternationalScheduledConsent5())
-                .data(toOBWriteInternationalScheduledConsent5Data(obWriteInternationalScheduledConsent4.getData()))
-                .risk(obWriteInternationalScheduledConsent4.getRisk());
-    }
-
-    public static OBWriteInternationalScheduledConsent5Data toOBWriteInternationalScheduledConsent5Data(OBWriteInternationalScheduledConsent4Data data) {
-        return data == null ? null : (new OBWriteInternationalScheduledConsent5Data())
-                .permission(OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(data.getInitiation())
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -54,8 +54,8 @@ import java.security.Principal;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.internationalpayments.InternationalPaymentConsentsApiController.toOBWriteInternationalConsentResponse4DataExchangeRateInformation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteInternationalScheduledResponse4DataStatus;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBWriteInternationalConsentResponse4DataExchangeRateInformation;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -45,8 +45,6 @@ import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse5;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse5Data;
@@ -56,11 +54,10 @@ import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent3DataAuthorisation;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent4DataSCASupportData;
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_5.file.FilePaymentConsentsApiController.toOBWriteDomesticConsent4DataAuthorisation;
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_3.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteInternationalStandingOrderConsentResponse5DataStatus;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent6;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 
@@ -149,30 +146,18 @@ public class InternationalStandingOrderConsentsApiController implements Internat
                         .creationDateTime(internationalStandingOrderConsent.getCreated())
                         .statusUpdateDateTime(internationalStandingOrderConsent.getStatusUpdate())
                         .consentId(internationalStandingOrderConsent.getId())
-                        .permission(PermissionEnum.valueOf(internationalStandingOrderConsent.getInternationalStandingOrderConsent().getData().getPermission().name()))
+                        .permission(toPermission(internationalStandingOrderConsent.getInternationalStandingOrderConsent().getData().getPermission()))
                         .authorisation(toOBWriteDomesticConsent3DataAuthorisation(internationalStandingOrderConsent.getInternationalStandingOrderConsent().getData().getAuthorisation()))
                 ).risk(internationalStandingOrderConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalStandingOrderConsent, discovery -> getVersion(discovery).getGetInternationalStandingOrderConsent()))
                 .meta(new Meta());
     }
 
+    private PermissionEnum toPermission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
+    }
+
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_3();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteInternationalStandingOrderConsent6 toOBWriteInternationalStandingOrderConsent6(OBWriteInternationalStandingOrderConsent5 obWriteInternationalStandingOrderConsent5) {
-        return (new OBWriteInternationalStandingOrderConsent6())
-                .data(toOBWriteInternationalStandingOrderConsent6Data(obWriteInternationalStandingOrderConsent5.getData()))
-                .risk(obWriteInternationalStandingOrderConsent5.getRisk());
-    }
-
-    public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteInternationalStandingOrderConsent5Data data) {
-        return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
-                .readRefundAccount(null)
-                .initiation(data.getInitiation())
-                .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
-                .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data.PermissionEnum;
@@ -143,13 +144,17 @@ public class DomesticScheduledPaymentConsentsApiController implements DomesticSc
                         .creationDateTime(domesticScheduledConsent.getCreated())
                         .statusUpdateDateTime(domesticScheduledConsent.getStatusUpdate())
                         .consentId(domesticScheduledConsent.getId())
-                        .permission(PermissionEnum.valueOf(domesticScheduledConsent.getDomesticScheduledConsent().getData().getPermission().name()))
+                        .permission(toPermission(domesticScheduledConsent.getDomesticScheduledConsent().getData().getPermission()))
                         .authorisation(domesticScheduledConsent.getDomesticScheduledConsent().getData().getAuthorisation())
                         .scASupportData(domesticScheduledConsent.getDomesticScheduledConsent().getData().getScASupportData())
                 )
                 .links(resourceLinkService.toSelfLink(domesticScheduledConsent, discovery -> getVersion(discovery).getGetDomesticScheduledPaymentConsent()))
                 .risk(domesticScheduledConsent.getRisk())
                 .meta(new Meta());
+    }
+
+    private PermissionEnum toPermission(OBWriteDomesticScheduledConsent4Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
     }
 
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6Data.PermissionEnum;
@@ -142,12 +143,16 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                         .creationDateTime(domesticStandingOrderConsent.getCreated())
                         .statusUpdateDateTime(domesticStandingOrderConsent.getStatusUpdate())
                         .consentId(domesticStandingOrderConsent.getId())
-                        .permission(PermissionEnum.valueOf(domesticStandingOrderConsent.getDomesticStandingOrderConsent().getData().getPermission().name()))
+                        .permission(toPermission(domesticStandingOrderConsent.getDomesticStandingOrderConsent().getData().getPermission()))
                         .authorisation(domesticStandingOrderConsent.getDomesticStandingOrderConsent().getData().getAuthorisation())
                 )
                 .links(resourceLinkService.toSelfLink(domesticStandingOrderConsent, discovery -> getVersion(discovery).getGetDomesticStandingOrderConsent()))
                 .risk(domesticStandingOrderConsent.getRisk())
                 .meta(new Meta());
+    }
+
+    private PermissionEnum toPermission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
     }
 
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentConsentsApiController.java
@@ -54,8 +54,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4DataAuthorisation;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data;
@@ -68,6 +66,7 @@ import java.util.Optional;
 
 import static com.forgerock.openbanking.common.model.openbanking.v3_1_5.converter.payment.ConsentStatusCodeToResponseDataStatusConverter.toOBWriteFileConsentResponse4DataStatus;
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent4DataAuthorisation;
 
 @Controller("FilePaymentConsentsApiV3.1.5")
 @Slf4j
@@ -253,13 +252,6 @@ public class FilePaymentConsentsApiController implements FilePaymentConsentsApi 
 
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {
         return discovery.getV_3_1_5();
-    }
-
-    // TODO #272 - move to uk-datamodel
-    public static OBWriteDomesticConsent4DataAuthorisation toOBWriteDomesticConsent4DataAuthorisation(OBWriteDomesticConsent3DataAuthorisation authorisation) {
-        return authorisation == null ? null : (new OBWriteDomesticConsent4DataAuthorisation())
-                .authorisationType(OBWriteDomesticConsent4DataAuthorisation.AuthorisationTypeEnum.valueOf(authorisation.getAuthorisationType().name()))
-                .completionDateTime(authorisation.getCompletionDateTime());
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -51,8 +51,10 @@ import uk.org.openbanking.datamodel.payment.OBWriteDataFundsConfirmationResponse
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6Data.PermissionEnum;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
@@ -186,13 +188,17 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                         .statusUpdateDateTime(internationalScheduledConsent.getStatusUpdate())
                         .consentId(internationalScheduledConsent.getId())
                         .exchangeRateInformation(internationalScheduledConsent.getCalculatedExchangeRate())
-                        .permission(OBWriteInternationalScheduledConsentResponse6Data.PermissionEnum.valueOf(internationalScheduledConsent.internationalScheduledConsent.getData().getPermission().name()))
+                        .permission(toPermission(internationalScheduledConsent.internationalScheduledConsent.getData().getPermission()))
                         .expectedExecutionDateTime(initiation.getRequestedExecutionDateTime())
                         .authorisation(internationalScheduledConsent.getInternationalScheduledConsent().getData().getAuthorisation())
                 )
                 .risk(internationalScheduledConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalScheduledConsent, discovery -> getVersion(discovery).getGetInternationalScheduledPaymentConsent()))
                 .meta(new Meta());
+    }
+
+    private PermissionEnum toPermission(OBWriteInternationalScheduledConsent5Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
     }
 
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinksPayment4;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7Data;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7Data.PermissionEnum;
@@ -141,11 +142,15 @@ public class InternationalStandingOrderConsentsApiController implements Internat
                         .creationDateTime(internationalStandingOrderConsent.getCreated())
                         .statusUpdateDateTime(internationalStandingOrderConsent.getStatusUpdate())
                         .consentId(internationalStandingOrderConsent.getId())
-                        .permission(PermissionEnum.valueOf(internationalStandingOrderConsent.getInternationalStandingOrderConsent().getData().getPermission().name()))
+                        .permission(toPermission(internationalStandingOrderConsent.getInternationalStandingOrderConsent().getData().getPermission()))
                         .authorisation(internationalStandingOrderConsent.getInternationalStandingOrderConsent().getData().getAuthorisation())
                 ).risk(internationalStandingOrderConsent.getRisk())
                 .links(resourceLinkService.toSelfLink(internationalStandingOrderConsent, discovery -> getVersion(discovery).getGetInternationalStandingOrderConsent()))
                 .meta(new Meta());
+    }
+
+    private PermissionEnum toPermission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
     }
 
     protected OBDiscoveryAPILinksPayment4 getVersion(DiscoveryConfigurationProperties.PaymentApis discovery) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticpayments/DomesticPaymentConsentsApiControllerIT.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/domesticpayments/DomesticPaymentConsentsApiControllerIT.java
@@ -61,7 +61,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
-import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_0.domesticpayments.DomesticPaymentConsentsApiController.toOBWriteDomesticConsent4;
 import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.PaymentTestHelper.MOCK_CLIENT_ID;
 import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.PaymentTestHelper.MOCK_PISP_ID;
 import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.PaymentTestHelper.MOCK_PISP_NAME;
@@ -71,6 +70,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBDomestic2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBWriteDomestic2DataInitiation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent4;
 
 /**
  * Spring Integration test for {@link com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.domesticpayments.DomesticPaymentConsentsApiController}.

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_1/domesticstandingorderpayments/DomesticStandingOrderPaymentConsentsApiControllerIT.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_1/domesticstandingorderpayments/DomesticStandingOrderPaymentConsentsApiControllerIT.java
@@ -61,11 +61,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBWriteDomesticStandingOrder3DataInitiation;
 
 /**
  * Integration test for {@link com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_1.domesticstandingorders.DomesticStandingOrderConsentsApiController}.
@@ -248,23 +244,6 @@ public class DomesticStandingOrderPaymentConsentsApiControllerIT {
         initiation.supplementaryData(new OBSupplementaryData1());
         initiation.setDebtorAccount(new OBWriteDomesticStandingOrder3DataInitiationDebtorAccount().identification("123").name("test").schemeName("UK.OBIE.SortCodeAccountNumber"));
         initiation.setCreditorAccount(new OBWriteDomesticStandingOrder3DataInitiationCreditorAccount().identification("321").name("test2").schemeName("UK.OBIE.SortCodeAccountNumber"));
-    }
-
-    // TODO #277 - move to uk-datamodel
-    public static OBWriteDomesticStandingOrder3DataInitiation toOBWriteDomesticStandingOrder3DataInitiation(OBDomesticStandingOrder3 initiation) {
-        return new OBWriteDomesticStandingOrder3DataInitiation()
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .firstPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(initiation.getFirstPaymentAmount()))
-                .recurringPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(initiation.getRecurringPaymentAmount()))
-                .finalPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(initiation.getFinalPaymentAmount()))
-                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditorAccount(toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .supplementaryData(initiation.getSupplementaryData());
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.75</version>
+        <version>1.0.77</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Switched to newly added converters to the uk-datamodel project and applied a number of fixes.

This PR is addition to my previous one, which added the controllers and their (mostly) generated interfaces to the rs-store and rs-gateway modules for v3.1.5 of the payment API, plus a number of new document classes and repositories (#272)