### PR TITLE
Additional JWS b64 claim header validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+[389c96e83405f2a](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/389c96e83405f2a) Matt Wills *2020-08-26 14:43:24*
+Validation of b64 header if version if 3.1.3 or lower. Moved generation and verification of detached JWS into separate classes (#272)
 [d154dbe73395342](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d154dbe73395342) Matt Wills *2020-08-25 10:46:22*
 Release candidate: prepare for next development iteration
 ## 1.0.96

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/version/OBVersion.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/version/OBVersion.java
@@ -53,7 +53,11 @@ public enum OBVersion {
         return null;
     }
 
-    public boolean isBeforeVersion(OBVersion targetVersion) {
-        return this.ordinal() < targetVersion.ordinal();
+    public boolean isBeforeVersion(OBVersion version) {
+        return this.ordinal() < version.ordinal();
+    }
+
+    public boolean isAfterVersion(OBVersion version) {
+        return this.ordinal() > version.ordinal();
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/verifier/DetachedJwsVerifierTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/verifier/DetachedJwsVerifierTest.java
@@ -148,6 +148,20 @@ public class DetachedJwsVerifierTest {
         assertThat(exception).hasMessage("Invalid detached signature " + detachedJws + ". Reason: b64 claim header not set to false");
     }
 
+    @Test
+    public void shouldFailToVerifyB64HeaderGivenVersion3_1_4AndB64HeaderIsPresent() throws Exception {
+        // Given
+        String detachedJws = "eyJiNjQiOnRydWUsImh0dHA6XC9cL29wZW5iYW5raW5nLm9yZy51a1wvaWF0IjoxNTk4NDMwMDA4LCJodHRwOlwvXC9vcGVuYmFua2luZy5vcmcudWtcL3RhbiI6Im9wZW5iYW5raW5nLm9yZy51ayIsImNyaXQiOlsiYjY0IiwiaHR0cDpcL1wvb3BlbmJhbmtpbmcub3JnLnVrXC9pYXQiLCJodHRwOlwvXC9vcGVuYmFua2luZy5vcmcudWtcL3RhbiIsImh0dHA6XC9cL29wZW5iYW5raW5nLm9yZy51a1wvaXNzIl0sImtpZCI6InRfSXU2eFhZRXQyeGh3TUFzX3JsYWNHeGtFWSIsImh0dHA6XC9cL29wZW5iYW5raW5nLm9yZy51a1wvaXNzIjoiaHR0cDpcL1wvb3BlbmJhbmtpbmcub3JnLnVrXC9pYXQiLCJhbGciOiJQUzI1NiJ9..yfhofJGNJfseVOEhCKanjxHlxlnMCdBKOy9HQFvMf7ZmEpkp2DiKKHJeK1LzDHYOo6WtkImIWwuTS3VvzBPrn7-z83CqM-BHZRzI-_E2I7EzaOzr8We4PtBVDk4wgwSxZW5Q0MPM-WcKgAMPskqrCVXMHLce2AcVsK6bivpi8mdSlA0rVj5FXhXw75-_fuWz8-2GY4xNF0h5YH7Tk4qpQsdpFhgpiagT29ujDcX46g5rF9mA8hUWqtJQE5yoF64S_lBUf4c_R1K1NyG5IwT-GbIoECF-epK5ybNLuD_ZfTfLcWVLI8rav0dRpiI0rdg5-upuB94H-npx1k1KsRXqSA";
+        HttpServletRequest request = setupHttpServletRequestMock();
+        Authentication principal = mock(Authentication.class);
+
+        // When
+        OBErrorException exception = catchThrowableOfType(() -> detachedJwsVerifier.verifyDetachedJws(detachedJws, OBVersion.v3_1_4, request, principal), OBErrorException.class);
+
+        // Then
+        assertThat(exception).hasMessage("Invalid detached signature " + detachedJws + ". Reason: b64 claim header must not be present");
+    }
+
     private HttpServletRequest setupHttpServletRequestMock() throws IOException {
         HttpServletRequest request = mock(HttpServletRequest.class);
         ServletInputStream servletInputStream = new DelegatingServletInputStream(new ByteArrayInputStream("{}".getBytes()));


### PR DESCRIPTION
Ensured a detached JWS header containing a b64 claim is rejected from 3.1.4 onwards (#280)