### PR TITLE
Changes to migrate mongo documents from v3.1.2 to v3.1.6 (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+[e66b49e5c8c8eb5](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e66b49e5c8c8eb5) Matt Wills *2020-09-01 14:31:13*
+Release candidate: prepare for next development iteration
+## 1.0.97
 [389c96e83405f2a](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/389c96e83405f2a) Matt Wills *2020-08-26 14:43:24*
 Validation of b64 header if version if 3.1.3 or lower. Moved generation and verification of detached JWS into separate classes (#272)
+[183df0b0c098b2d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/183df0b0c098b2d) Matt Wills *2020-09-01 10:22:10*
+Ensured detached JWS headers containing a b64 claim are rejected from 3.1.4 onwards (#280)
+[e1243b3125b9dfc](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e1243b3125b9dfc) Matt Wills *2020-09-01 14:31:03*
+Release candidate: prepare release 1.0.97
 [d154dbe73395342](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d154dbe73395342) Matt Wills *2020-08-25 10:46:22*
 Release candidate: prepare for next development iteration
 ## 1.0.96

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountConverter.java
@@ -24,6 +24,7 @@ import com.forgerock.openbanking.common.model.openbanking.v1_1.account.FRAccount
 import com.forgerock.openbanking.common.model.openbanking.v2_0.account.FRAccount2;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRAccount3;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRAccount4;
+import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 import uk.org.openbanking.datamodel.account.OBAccount1;
 import uk.org.openbanking.datamodel.account.OBAccount2;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification2;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification4;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification50;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount1;
 import static java.util.Collections.emptyList;
 
@@ -98,6 +100,17 @@ public class FRAccountConverter {
         frAccount3.setUpdated(account2.getUpdated());
         frAccount3.setLatestStatementId(account2.getLatestStatementId());
         return frAccount3;
+    }
+
+    public static FRAccount4 toAccount4(FRAccount3 account3) {
+        FRAccount4 frAccount4 = new FRAccount4();
+        frAccount4.setId(account3.getId());
+        frAccount4.setUserID(account3.getUserID());
+        frAccount4.setAccount(toOBAccount6(account3.getAccount()));
+        frAccount4.setCreated(account3.getCreated());
+        frAccount4.setUpdated(account3.getUpdated());
+        frAccount4.setLatestStatementId(account3.getLatestStatementId());
+        return frAccount4;
     }
 
     public static OBAccount1 toOBAccount1(OBAccount3 obAccount3) {
@@ -175,6 +188,22 @@ public class FRAccountConverter {
                 .servicer(toOBBranchAndFinancialInstitutionIdentification5(obAccount6.getServicer()));
     }
 
+    public static OBAccount6 toOBAccount6(OBAccount3 obAccount3) {
+        return obAccount3 == null ? null : (new OBAccount6())
+                .accountId(obAccount3.getAccountId())
+                .status(null)
+                .statusUpdateDateTime(DateTime.now())
+                .currency(obAccount3.getCurrency())
+                .accountType(obAccount3.getAccountType())
+                .accountSubType(obAccount3.getAccountSubType())
+                .description(obAccount3.getDescription())
+                .nickname(obAccount3.getNickname())
+                .openingDate(null)
+                .maturityDate(null)
+                .account(fromOBAccount3AccountToOBCashAccount6List(obAccount3.getAccount()))
+                .servicer(toOBBranchAndFinancialInstitutionIdentification50(obAccount3.getServicer()));
+    }
+
     private static List<OBCashAccount3> fromOBAccount3AccountToOBCashAccount3List(List<OBAccount3Account> accounts) {
         if (accounts == null) {
             return emptyList();
@@ -208,6 +237,15 @@ public class FRAccountConverter {
         }
         return accounts.stream()
                 .map(OBCashAccountConverter::toOBCashAccount5)
+                .collect(Collectors.toList());
+    }
+
+    private static List<OBAccount3Account> fromOBAccount3AccountToOBCashAccount6List(List<OBCashAccount5> accounts) {
+        if (accounts == null) {
+            return emptyList();
+        }
+        return accounts.stream()
+                .map(OBCashAccountConverter::toOBAccount3Account)
                 .collect(Collectors.toList());
     }
 

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountConverter.java
@@ -200,7 +200,7 @@ public class FRAccountConverter {
                 .nickname(obAccount3.getNickname())
                 .openingDate(null)
                 .maturityDate(null)
-                .account(fromOBAccount3AccountToOBCashAccount6List(obAccount3.getAccount()))
+                .account(fromOBCashAccount5ListToOBAccount3Account(obAccount3.getAccount()))
                 .servicer(toOBBranchAndFinancialInstitutionIdentification50(obAccount3.getServicer()));
     }
 
@@ -240,7 +240,7 @@ public class FRAccountConverter {
                 .collect(Collectors.toList());
     }
 
-    private static List<OBAccount3Account> fromOBAccount3AccountToOBCashAccount6List(List<OBCashAccount5> accounts) {
+    private static List<OBAccount3Account> fromOBCashAccount5ListToOBAccount3Account(List<OBCashAccount5> accounts) {
         if (accounts == null) {
             return emptyList();
         }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRBeneficiaryConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRBeneficiaryConverter.java
@@ -21,14 +21,18 @@
 package com.forgerock.openbanking.common.services.openbanking.converter.account;
 
 import com.forgerock.openbanking.common.model.openbanking.v1_1.account.FRBeneficiary1;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRBeneficiary3;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRBeneficiary4;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_5.account.FRBeneficiary5;
 import org.springframework.stereotype.Service;
 import uk.org.openbanking.datamodel.account.OBBeneficiary1;
+import uk.org.openbanking.datamodel.account.OBBeneficiary3;
 import uk.org.openbanking.datamodel.account.OBBeneficiary5;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification2;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification60;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount1;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount50;
 
 @Service
 public class FRBeneficiaryConverter {
@@ -56,13 +60,35 @@ public class FRBeneficiaryConverter {
         return frBeneficiary1;
     }
 
-    private static OBBeneficiary1 toOBBeneficiary1(OBBeneficiary5 obBeneficiary5) {
+    public static FRBeneficiary5 toFRBeneficiary5(FRBeneficiary3 frBeneficiary3) {
+        if (frBeneficiary3 == null) return null;
+        FRBeneficiary5 frBeneficiary5 = new FRBeneficiary5();
+        frBeneficiary5.setAccountId(frBeneficiary3.getAccountId());
+        frBeneficiary5.setBeneficiary(toOBBeneficiary5(frBeneficiary3.getBeneficiary()));
+        frBeneficiary5.setId(frBeneficiary3.getId());
+        frBeneficiary5.setCreated(frBeneficiary3.getCreated());
+        frBeneficiary5.setUpdated(frBeneficiary3.getUpdated());
+        return frBeneficiary5;
+    }
+
+    public static OBBeneficiary1 toOBBeneficiary1(OBBeneficiary5 obBeneficiary5) {
         return obBeneficiary5 == null ? null : (new OBBeneficiary1())
                 .accountId(obBeneficiary5.getAccountId())
                 .beneficiaryId(obBeneficiary5.getBeneficiaryId())
                 .reference(obBeneficiary5.getReference())
                 .servicer(toOBBranchAndFinancialInstitutionIdentification2(obBeneficiary5.getCreditorAgent()))
                 .creditorAccount(toOBCashAccount1(obBeneficiary5.getCreditorAccount()));
+    }
+
+    public static OBBeneficiary5 toOBBeneficiary5(OBBeneficiary3 obBeneficiary3) {
+        return obBeneficiary3 == null ? null : (new OBBeneficiary5())
+                .accountId(obBeneficiary3.getAccountId())
+                .beneficiaryId(obBeneficiary3.getBeneficiaryId())
+                .beneficiaryType(null) // TODO #279 - should this be defaulted?
+                .reference(obBeneficiary3.getReference())
+                .supplementaryData(null)
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification60(obBeneficiary3.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount50(obBeneficiary3.getCreditorAccount()));
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRDirectDebitConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRDirectDebitConverter.java
@@ -20,15 +20,28 @@
  */
 package com.forgerock.openbanking.common.services.openbanking.converter.account;
 
-import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount0;
+import com.forgerock.openbanking.common.model.openbanking.v1_1.account.FRDirectDebit1;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRDirectDebit4;
 import uk.org.openbanking.datamodel.account.OBDirectDebit1;
 import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebit;
-import uk.org.openbanking.datamodel.payment.OBActiveOrHistoricCurrencyAndAmount;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount0;
 
 /**
  * Converter for 'OBDirectDebit' model objects.
  */
 public class FRDirectDebitConverter {
+
+    public static FRDirectDebit4 toFRDirectDebit4(FRDirectDebit1 frDirectDebit1) {
+        return frDirectDebit1 == null ? null : FRDirectDebit4.builder()
+                .id(frDirectDebit1.getId())
+                .accountId(frDirectDebit1.getAccountId())
+                .directDebit(toOBReadDirectDebit2DataDirectDebit(frDirectDebit1.getDirectDebit()))
+                .created(frDirectDebit1.getCreated())
+                .updated(frDirectDebit1.getUpdated())
+                .build();
+    }
 
     public static OBDirectDebit1 toOBDirectDebit1(OBReadDirectDebit2DataDirectDebit obReadDirectDebit2DataDirectDebit) {
         return obReadDirectDebit2DataDirectDebit == null ? null : (new OBDirectDebit1())
@@ -41,9 +54,15 @@ public class FRDirectDebitConverter {
                 .previousPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(obReadDirectDebit2DataDirectDebit.getPreviousPaymentAmount()));
     }
 
-    private static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBActiveOrHistoricCurrencyAndAmount0 amount) {
-        return amount == null ? null : (new OBActiveOrHistoricCurrencyAndAmount())
-                .currency(amount.getCurrency())
-                .amount(amount.getAmount());
+    public static OBReadDirectDebit2DataDirectDebit toOBReadDirectDebit2DataDirectDebit(OBDirectDebit1 obDirectDebit1) {
+        return obDirectDebit1 == null ? null : (new OBReadDirectDebit2DataDirectDebit())
+                .accountId(obDirectDebit1.getAccountId())
+                .directDebitId(obDirectDebit1.getDirectDebitId())
+                .mandateIdentification(obDirectDebit1.getMandateIdentification())
+                .directDebitStatusCode(obDirectDebit1.getDirectDebitStatusCode())
+                .name(obDirectDebit1.getName())
+                .previousPaymentDateTime(obDirectDebit1.getPreviousPaymentDateTime())
+                .frequency(null)
+                .previousPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount0(obDirectDebit1.getPreviousPaymentAmount()));
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRPartyConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRPartyConverter.java
@@ -56,7 +56,7 @@ public class FRPartyConverter {
         return frParty2;
     }
 
-    private static OBParty2 toOBParty2(OBParty1 party) {
+    public static OBParty2 toOBParty2(OBParty1 party) {
         if (party==null) return null;
 
         return new OBParty2()

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRScheduledPaymentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRScheduledPaymentConverter.java
@@ -22,6 +22,7 @@ package com.forgerock.openbanking.common.services.openbanking.converter.account;
 
 import com.forgerock.openbanking.common.model.openbanking.v2_0.account.FRScheduledPayment1;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRScheduledPayment2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRScheduledPayment4;
 import org.joda.time.DateTime;
 import uk.org.openbanking.datamodel.account.OBScheduledPayment1;
 import uk.org.openbanking.datamodel.account.OBScheduledPayment2;
@@ -29,14 +30,17 @@ import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.toAccountOBActiveOrHistoricCurrencyAndAmount;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount1;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification4;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification51;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount3;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount51;
 
 public class FRScheduledPaymentConverter {
 
-    public static FRScheduledPayment2 toScheduledPayment2(FRScheduledPayment1 frScheduledPayment1) {
+    public static FRScheduledPayment2 toFRScheduledPayment2(FRScheduledPayment1 frScheduledPayment1) {
         FRScheduledPayment2 frScheduledPayment2 = FRScheduledPayment2.builder()
                 .accountId(frScheduledPayment1.getAccountId())
                 .created(frScheduledPayment1.getCreated())
@@ -50,6 +54,19 @@ public class FRScheduledPaymentConverter {
 
         frScheduledPayment2.setScheduledPayment(toOBScheduledPayment2(frScheduledPayment1.getScheduledPayment()));
         return frScheduledPayment2;
+    }
+
+    public static FRScheduledPayment4 toFRScheduledPayment4(FRScheduledPayment2 frScheduledPayment2) {
+        return frScheduledPayment2 == null ? null : FRScheduledPayment4.builder()
+                .id(frScheduledPayment2.getId())
+                .accountId(frScheduledPayment2.getAccountId())
+                .scheduledPayment(toOBScheduledPayment3(frScheduledPayment2.getScheduledPayment()))
+                .pispId(frScheduledPayment2.getPispId())
+                .created(frScheduledPayment2.getCreated())
+                .updated(frScheduledPayment2.getUpdated())
+                .rejectionReason(frScheduledPayment2.getRejectionReason())
+                .status(frScheduledPayment2.getStatus())
+                .build();
     }
 
     public static OBScheduledPayment1 toOBScheduledPayment1(OBScheduledPayment2 obScheduledPayment2) {
@@ -140,4 +157,16 @@ public class FRScheduledPaymentConverter {
         return obScheduledPayment2;
     }
 
+    public static OBScheduledPayment3 toOBScheduledPayment3(OBScheduledPayment2 obScheduledPayment2) {
+        return obScheduledPayment2 == null ? null : (new OBScheduledPayment3())
+                .accountId(obScheduledPayment2.getAccountId())
+                .scheduledPaymentId(obScheduledPayment2.getScheduledPaymentId())
+                .scheduledPaymentDateTime(obScheduledPayment2.getScheduledPaymentDateTime())
+                .scheduledType(obScheduledPayment2.getScheduledType())
+                .reference(obScheduledPayment2.getReference())
+                .debtorReference(null)
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount1(obScheduledPayment2.getInstructedAmount()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification51(obScheduledPayment2.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount51(obScheduledPayment2.getCreditorAccount()));
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStandingOrderConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStandingOrderConverter.java
@@ -24,6 +24,7 @@ import com.forgerock.openbanking.common.model.openbanking.v1_1.account.FRStandin
 import com.forgerock.openbanking.common.model.openbanking.v2_0.account.FRStandingOrder2;
 import com.forgerock.openbanking.common.model.openbanking.v3_0.account.FRStandingOrder3;
 import com.forgerock.openbanking.common.model.openbanking.v3_1.account.FRStandingOrder4;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRStandingOrder5;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_5.account.FRStandingOrder6;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBStandingOrderConverter.toOBStandingOrder1;
@@ -85,6 +86,16 @@ public class FRStandingOrderConverter {
         standingOrder6.setCreated(frStandingOrder4.getCreated());
         standingOrder6.setUpdated(frStandingOrder4.getUpdated());
         standingOrder6.setStandingOrder(toOBStandingOrder6(frStandingOrder4.getStandingOrder()));
+        return standingOrder6;
+    }
+
+    public static FRStandingOrder6 toFRStandingOrder6(FRStandingOrder5 frStandingOrder5) {
+        FRStandingOrder6 standingOrder6 = new FRStandingOrder6();
+        standingOrder6.setAccountId(frStandingOrder5.getAccountId());
+        standingOrder6.setId(frStandingOrder5.getId());
+        standingOrder6.setCreated(frStandingOrder5.getCreated());
+        standingOrder6.setUpdated(frStandingOrder5.getUpdated());
+        standingOrder6.setStandingOrder(toOBStandingOrder6(frStandingOrder5.getStandingOrder()));
         return standingOrder6;
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStatementConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStatementConverter.java
@@ -20,6 +20,8 @@
  */
 package com.forgerock.openbanking.common.services.openbanking.converter.account;
 
+import com.forgerock.openbanking.common.model.openbanking.v2_0.account.FRStatement1;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.account.FRStatement4;
 import uk.org.openbanking.datamodel.account.OBCreditDebitCode;
 import uk.org.openbanking.datamodel.account.OBStatement1;
 import uk.org.openbanking.datamodel.account.OBStatement2;
@@ -31,12 +33,23 @@ import uk.org.openbanking.datamodel.account.OBStatementInterest2;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.forgerock.openbanking.common.services.openbanking.converter.OBActiveOrHistoricCurrencyAndAmountConverter.toAccountOBActiveOrHistoricCurrencyAndAmount;
 import static com.forgerock.openbanking.common.services.openbanking.converter.OBActiveOrHistoricCurrencyAndAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
 
 /**
  * Converter for 'FRStatement' documents.
  */
 public class FRStatementConverter {
+
+    public static FRStatement4 toFRStatement4(FRStatement1 frStatement1) {
+        return frStatement1 == null ? null : FRStatement4.builder()
+                .id(frStatement1.getId())
+                .accountId(frStatement1.getAccountId())
+                .statement(toOBStatement2(frStatement1.getStatement()))
+                .created(frStatement1.getCreated())
+                .updated(frStatement1.getUpdated())
+                .build();
+    }
 
     public static OBStatement1 toOBStatement1(OBStatement2 obStatement2) {
         return obStatement2 == null ? null : (new OBStatement1())
@@ -57,12 +70,40 @@ public class FRStatementConverter {
                 .statementAmount(obStatement2.getStatementAmount());
     }
 
+    public static OBStatement2 toOBStatement2(OBStatement1 obStatement1) {
+        return obStatement1 == null ? null : (new OBStatement2())
+                .accountId(obStatement1.getAccountId())
+                .statementId(obStatement1.getStatementId())
+                .statementReference(obStatement1.getStatementReference())
+                .type(obStatement1.getType())
+                .startDateTime(obStatement1.getStartDateTime())
+                .endDateTime(obStatement1.getEndDateTime())
+                .creationDateTime(obStatement1.getCreationDateTime())
+                .statementDescription(obStatement1.getStatementDescription())
+                .statementBenefit(obStatement1.getStatementBenefit())
+                .statementFee(toOBStatementFee2List(obStatement1.getStatementFee()))
+                .statementInterest(toOBStatementInterest2List(obStatement1.getStatementInterest()))
+                .statementDateTime(obStatement1.getStatementDateTime())
+                .statementRate(obStatement1.getStatementRate())
+                .statementValue(obStatement1.getStatementValue())
+                .statementAmount(obStatement1.getStatementAmount());
+    }
+
     public static List<OBStatementFee1> toOBStatementFee1List(List<OBStatementFee2> obStatementFee2s) {
         if (obStatementFee2s == null) {
             return null;
         }
         return obStatementFee2s.stream()
                 .map(FRStatementConverter::toOBStatementFee1)
+                .collect(Collectors.toList());
+    }
+
+    public static List<OBStatementFee2> toOBStatementFee2List(List<OBStatementFee1> obStatementFee1s) {
+        if (obStatementFee1s == null) {
+            return null;
+        }
+        return obStatementFee1s.stream()
+                .map(FRStatementConverter::toOBStatementFee2)
                 .collect(Collectors.toList());
     }
 
@@ -75,6 +116,15 @@ public class FRStatementConverter {
                 .collect(Collectors.toList());
     }
 
+    public static List<OBStatementInterest2> toOBStatementInterest2List(List<OBStatementInterest1> obStatementInterest1s) {
+        if (obStatementInterest1s == null) {
+            return null;
+        }
+        return obStatementInterest1s.stream()
+                .map(FRStatementConverter::toOBStatementInterest2)
+                .collect(Collectors.toList());
+    }
+
     public static OBStatementFee1 toOBStatementFee1(OBStatementFee2 obStatementFee2) {
         return obStatementFee2 == null ? null : (new OBStatementFee1())
                 .creditDebitIndicator(OBCreditDebitCode.valueOf(obStatementFee2.getCreditDebitIndicator().name()))
@@ -82,10 +132,24 @@ public class FRStatementConverter {
                 .amount(toOBActiveOrHistoricCurrencyAndAmount(obStatementFee2.getAmount()));
     }
 
+    public static OBStatementFee2 toOBStatementFee2(OBStatementFee1 obStatementFee1) {
+        return obStatementFee1 == null ? null : (new OBStatementFee2())
+                .creditDebitIndicator(OBStatementFee2.CreditDebitIndicatorEnum.valueOf(obStatementFee1.getCreditDebitIndicator().name()))
+                .type(obStatementFee1.getType())
+                .amount(toAccountOBActiveOrHistoricCurrencyAndAmount(obStatementFee1.getAmount()));
+    }
+
     public static OBStatementInterest1 toOBStatementInterest1(OBStatementInterest2 obStatementInterest2) {
         return obStatementInterest2 == null ? null : (new OBStatementInterest1())
                 .creditDebitIndicator(OBCreditDebitCode.valueOf(obStatementInterest2.getCreditDebitIndicator().name()))
                 .type(obStatementInterest2.getType())
                 .amount(toOBActiveOrHistoricCurrencyAndAmount(obStatementInterest2.getAmount()));
+    }
+
+    public static OBStatementInterest2 toOBStatementInterest2(OBStatementInterest1 obStatementInterest1) {
+        return obStatementInterest1 == null ? null : (new OBStatementInterest2())
+                .creditDebitIndicator(OBStatementInterest2.CreditDebitIndicatorEnum.valueOf(obStatementInterest1.getCreditDebitIndicator().name()))
+                .type(obStatementInterest1.getType())
+                .amount(toAccountOBActiveOrHistoricCurrencyAndAmount(obStatementInterest1.getAmount()));
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRTransactionConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRTransactionConverter.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.services.openbanking.converter.account;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRTransaction5;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.account.FRTransaction6;
+import uk.org.openbanking.datamodel.account.*;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount10;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount9;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification61;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification62;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount60;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBCashAccountConverter.toOBCashAccount61;
+
+public class FRTransactionConverter {
+
+    public static FRTransaction6 toFRTransaction6(FRTransaction5 frTransaction5) {
+        return frTransaction5 == null ? null : FRTransaction6.builder()
+                .id(frTransaction5.getId())
+                .accountId(frTransaction5.getAccountId())
+                .statementIds(frTransaction5.getStatementIds())
+                .transaction(toOBTransaction6(frTransaction5.getTransaction()))
+                .created(frTransaction5.getCreated())
+                .updated(frTransaction5.getUpdated())
+                .build();
+    }
+
+    public static OBTransaction6 toOBTransaction6(OBTransaction5 obTransaction5) {
+        return obTransaction5 == null ? null : (new OBTransaction6())
+                .accountId(obTransaction5.getAccountId())
+                .transactionId(obTransaction5.getTransactionId())
+                .transactionReference(obTransaction5.getTransactionReference())
+                .statementReference(obTransaction5.getStatementReference())
+                .creditDebitIndicator(OBCreditDebitCode1.valueOf(obTransaction5.getCreditDebitIndicator().name()))
+                .status(obTransaction5.getStatus())
+                .transactionMutability(OBTransactionMutability1Code.IMMUTABLE) // TODO #279 - is this right?
+                .bookingDateTime(obTransaction5.getBookingDateTime())
+                .valueDateTime(obTransaction5.getValueDateTime())
+                .transactionInformation(obTransaction5.getTransactionInformation())
+                .addressLine(obTransaction5.getAddressLine())
+                .amount(toOBActiveOrHistoricCurrencyAndAmount9(obTransaction5.getAmount()))
+                .chargeAmount(toOBActiveOrHistoricCurrencyAndAmount10(obTransaction5.getChargeAmount()))
+                .currencyExchange(obTransaction5.getCurrencyExchange())
+                .bankTransactionCode(obTransaction5.getBankTransactionCode())
+                .proprietaryBankTransactionCode(toOBTransaction5ProprietaryBankTransactionCode(obTransaction5.getProprietaryBankTransactionCode()))
+                .balance(obTransaction5.getBalance())
+                .merchantDetails(obTransaction5.getMerchantDetails())
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification61(obTransaction5.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount60(obTransaction5.getCreditorAccount()))
+                .debtorAgent(toOBBranchAndFinancialInstitutionIdentification62(obTransaction5.getDebtorAgent()))
+                .debtorAccount(toOBCashAccount61(obTransaction5.getDebtorAccount()))
+                .cardInstrument(obTransaction5.getCardInstrument())
+                .supplementaryData(obTransaction5.getSupplementaryData());
+    }
+
+    public static ProprietaryBankTransactionCodeStructure1 toOBTransaction5ProprietaryBankTransactionCode(OBTransaction5ProprietaryBankTransactionCode proprietaryBankTransactionCode) {
+        return proprietaryBankTransactionCode == null ? null : (new ProprietaryBankTransactionCodeStructure1())
+                .code(proprietaryBankTransactionCode.getCode())
+                .issuer(proprietaryBankTransactionCode.getIssuer());
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBAmountConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBAmountConverter.java
@@ -21,6 +21,7 @@
 package com.forgerock.openbanking.common.services.openbanking.converter.account;
 
 import com.forgerock.openbanking.common.services.openbanking.converter.FRModelMapper;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount0;
 import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount1;
 import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount10;
 import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount2;
@@ -34,6 +35,10 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataIni
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
 
 public class OBAmountConverter {
+
+    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBActiveOrHistoricCurrencyAndAmount0 amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount.class);
+    }
 
     public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBActiveOrHistoricCurrencyAndAmount1 amount) {
         return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount.class);
@@ -61,6 +66,10 @@ public class OBAmountConverter {
 
     public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBActiveOrHistoricCurrencyAndAmount4 amount) {
         return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount.class);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount0 toOBActiveOrHistoricCurrencyAndAmount0(OBActiveOrHistoricCurrencyAndAmount amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount0.class);
     }
 
     public static OBActiveOrHistoricCurrencyAndAmount2 toOBActiveOrHistoricCurrencyAndAmount2(OBActiveOrHistoricCurrencyAndAmount amount) {
@@ -129,5 +138,29 @@ public class OBAmountConverter {
 
     public static uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount toAccountOBActiveOrHistoricCurrencyAndAmount(OBActiveOrHistoricCurrencyAndAmount2 amount) {
         return FRModelMapper.map(amount, uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount.class);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount1 toOBActiveOrHistoricCurrencyAndAmount1(uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount1.class);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount2 toOBActiveOrHistoricCurrencyAndAmount2(uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount2.class);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount3 toOBActiveOrHistoricCurrencyAndAmount3(uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount3.class);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount4 toOBActiveOrHistoricCurrencyAndAmount4(uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount4.class);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount9 toOBActiveOrHistoricCurrencyAndAmount9(uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount9.class);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount10 toOBActiveOrHistoricCurrencyAndAmount10(uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount amount) {
+        return FRModelMapper.map(amount, OBActiveOrHistoricCurrencyAndAmount10.class);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBBranchAndFinancialInstitutionIdentificationConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBBranchAndFinancialInstitutionIdentificationConverter.java
@@ -178,9 +178,45 @@ public final class OBBranchAndFinancialInstitutionIdentificationConverter {
                 .postalAddress(institutionIdentification.getPostalAddress());
     }
 
+    public static OBBranchAndFinancialInstitutionIdentification50 toOBBranchAndFinancialInstitutionIdentification50(OBBranchAndFinancialInstitutionIdentification5 institutionIdentification) {
+        return institutionIdentification == null ? null : (new OBBranchAndFinancialInstitutionIdentification50())
+                .schemeName(institutionIdentification.getSchemeName())
+                .identification(institutionIdentification.getIdentification());
+    }
+
     public static OBBranchAndFinancialInstitutionIdentification51 toOBBranchAndFinancialInstitutionIdentification51(OBBranchAndFinancialInstitutionIdentification4 institutionIdentification) {
         return institutionIdentification == null ? null : (new OBBranchAndFinancialInstitutionIdentification51())
                 .schemeName(institutionIdentification.getSchemeName())
                 .identification(institutionIdentification.getIdentification());
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification51 toOBBranchAndFinancialInstitutionIdentification51(OBBranchAndFinancialInstitutionIdentification5 institutionIdentification) {
+        return institutionIdentification == null ? null : (new OBBranchAndFinancialInstitutionIdentification51())
+                .schemeName(institutionIdentification.getSchemeName())
+                .identification(institutionIdentification.getIdentification());
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification60 toOBBranchAndFinancialInstitutionIdentification60(OBBranchAndFinancialInstitutionIdentification6 institutionIdentification) {
+        return institutionIdentification == null ? null : (new OBBranchAndFinancialInstitutionIdentification60())
+                .schemeName(institutionIdentification.getSchemeName())
+                .identification(institutionIdentification.getIdentification())
+                .name(institutionIdentification.getName())
+                .postalAddress(institutionIdentification.getPostalAddress());
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification61 toOBBranchAndFinancialInstitutionIdentification61(OBBranchAndFinancialInstitutionIdentification6 institutionIdentification) {
+        return institutionIdentification == null ? null : (new OBBranchAndFinancialInstitutionIdentification61())
+                .schemeName(institutionIdentification.getSchemeName())
+                .identification(institutionIdentification.getIdentification())
+                .name(institutionIdentification.getName())
+                .postalAddress(institutionIdentification.getPostalAddress());
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification62 toOBBranchAndFinancialInstitutionIdentification62(OBBranchAndFinancialInstitutionIdentification6 institutionIdentification) {
+        return institutionIdentification == null ? null : (new OBBranchAndFinancialInstitutionIdentification62())
+                .schemeName(institutionIdentification.getSchemeName())
+                .identification(institutionIdentification.getIdentification())
+                .name(institutionIdentification.getName())
+                .postalAddress(institutionIdentification.getPostalAddress());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBCashAccountConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBCashAccountConverter.java
@@ -129,6 +129,22 @@ public class OBCashAccountConverter {
         return FRModelMapper.map(creditorAccount, OBCashAccount51.class);
     }
 
+    public static OBCashAccount50 toOBCashAccount50(OBCashAccount5 creditorAccount) {
+        return FRModelMapper.map(creditorAccount, OBCashAccount50.class);
+    }
+
+    public static OBCashAccount51 toOBCashAccount51(OBCashAccount5 creditorAccount) {
+        return FRModelMapper.map(creditorAccount, OBCashAccount51.class);
+    }
+
+    public static OBCashAccount60 toOBCashAccount60(OBCashAccount6 creditorAccount) {
+        return FRModelMapper.map(creditorAccount, OBCashAccount60.class);
+    }
+
+    public static OBCashAccount61 toOBCashAccount61(OBCashAccount6 debtorAccount) {
+        return FRModelMapper.map(debtorAccount, OBCashAccount61.class);
+    }
+
     // cannot use model mapper due to OBExternalAccountIdentification2Code
     public static OBCashAccount1 toOBCashAccount1(OBCashAccount5 obCashAccount5) {
         return obCashAccount5 == null ? null : (new OBCashAccount1())
@@ -160,5 +176,13 @@ public class OBCashAccountConverter {
                 .identification(obAccount3Account.getIdentification())
                 .name(obAccount3Account.getName())
                 .secondaryIdentification(obAccount3Account.getSecondaryIdentification());
+    }
+
+    public static OBAccount3Account toOBAccount3Account(OBCashAccount5 obCashAccount5) {
+        return obCashAccount5 == null ? null : (new OBAccount3Account())
+                .schemeName(obCashAccount5.getSchemeName())
+                .identification(obCashAccount5.getIdentification())
+                .name(obCashAccount5.getName())
+                .secondaryIdentification(obCashAccount5.getSecondaryIdentification());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBStandingOrderConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/OBStandingOrderConverter.java
@@ -20,12 +20,7 @@
  */
 package com.forgerock.openbanking.common.services.openbanking.converter.account;
 
-import uk.org.openbanking.datamodel.account.OBStandingOrder1;
-import uk.org.openbanking.datamodel.account.OBStandingOrder2;
-import uk.org.openbanking.datamodel.account.OBStandingOrder3;
-import uk.org.openbanking.datamodel.account.OBStandingOrder4;
-import uk.org.openbanking.datamodel.account.OBStandingOrder5;
-import uk.org.openbanking.datamodel.account.OBStandingOrder6;
+import uk.org.openbanking.datamodel.account.*;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBAmountConverter.*;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.OBBranchAndFinancialInstitutionIdentificationConverter.toOBBranchAndFinancialInstitutionIdentification2;
@@ -146,4 +141,24 @@ public class OBStandingOrderConverter {
                 .nextPaymentDateTime(obStandingOrder.getNextPaymentDateTime())
                 .reference(obStandingOrder.getReference());
     }
+
+    public static OBStandingOrder6 toOBStandingOrder6(OBStandingOrder5 obStandingOrder) {
+        return obStandingOrder == null ? null : (new OBStandingOrder6())
+                .accountId(obStandingOrder.getAccountId())
+                .frequency(obStandingOrder.getFrequency())
+                .nextPaymentDateTime((obStandingOrder.getNextPaymentDateTime()))
+                .nextPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount3(obStandingOrder.getNextPaymentAmount()))
+                .standingOrderId(obStandingOrder.getStandingOrderId())
+                .standingOrderStatusCode(obStandingOrder.getStandingOrderStatusCode())
+                .creditorAccount(toOBCashAccount51(obStandingOrder.getCreditorAccount()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification51(obStandingOrder.getCreditorAgent()))
+                .finalPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount4(obStandingOrder.getFinalPaymentAmount()))
+                .finalPaymentDateTime(obStandingOrder.getFirstPaymentDateTime())
+                .firstPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount2(obStandingOrder.getFirstPaymentAmount()))
+                .firstPaymentDateTime(obStandingOrder.getFirstPaymentDateTime())
+                .nextPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount3(obStandingOrder.getNextPaymentAmount()))
+                .nextPaymentDateTime(obStandingOrder.getNextPaymentDateTime())
+                .reference(obStandingOrder.getReference());
+    }
+
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticConsentConverter.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent4;
 
 @Service
 public class FRDomesticConsentConverter {
@@ -77,6 +78,22 @@ public class FRDomesticConsentConverter {
         frDomesticConsent1.setStatusUpdate(frDomesticConsent5.getStatusUpdate());
 
         return frDomesticConsent1;
+    }
+
+    public static FRDomesticConsent5 toFRDomesticConsent5(FRDomesticConsent2 frDomesticConsent2) {
+        FRDomesticConsent5 frDomesticConsent5 = new FRDomesticConsent5();
+
+        frDomesticConsent5.setId(frDomesticConsent5.getId());
+        frDomesticConsent5.setStatus(frDomesticConsent5.getStatus());
+        frDomesticConsent5.setUserId(frDomesticConsent5.getUserId());
+        frDomesticConsent5.setAccountId(frDomesticConsent5.getAccountId());
+        frDomesticConsent5.setCreated(frDomesticConsent5.getCreated());
+        frDomesticConsent5.setDomesticConsent(toOBWriteDomesticConsent4(frDomesticConsent2.getDomesticConsent()));
+        frDomesticConsent5.setPispId(frDomesticConsent5.getPispId());
+        frDomesticConsent5.setPispName(frDomesticConsent5.getPispName());
+        frDomesticConsent5.setStatusUpdate(frDomesticConsent5.getStatusUpdate());
+
+        return frDomesticConsent5;
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticScheduledConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticScheduledConsentConverter.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent4;
 
 @Service
 public class FRDomesticScheduledConsentConverter {
@@ -91,5 +92,20 @@ public class FRDomesticScheduledConsentConverter {
         frDomesticScheduledConsent1.setStatusUpdate(frDomesticScheduledConsent5.getStatusUpdate());
         frDomesticScheduledConsent1.setUpdated(frDomesticScheduledConsent5.getUpdated());
         return frDomesticScheduledConsent1;
+    }
+
+    public static FRDomesticScheduledConsent5 toFRDomesticScheduledConsent5(FRDomesticScheduledConsent2 frDomesticScheduledConsent2) {
+        FRDomesticScheduledConsent5 frDomesticScheduledConsent5 = new FRDomesticScheduledConsent5();
+        frDomesticScheduledConsent5.setStatus(frDomesticScheduledConsent2.getStatus());
+        frDomesticScheduledConsent5.setId(frDomesticScheduledConsent2.getId());
+        frDomesticScheduledConsent5.setUserId(frDomesticScheduledConsent2.getUserId());
+        frDomesticScheduledConsent5.setAccountId(frDomesticScheduledConsent2.getAccountId());
+        frDomesticScheduledConsent5.setCreated(frDomesticScheduledConsent2.getCreated());
+        frDomesticScheduledConsent5.setDomesticScheduledConsent(toOBWriteDomesticScheduledConsent4(frDomesticScheduledConsent2.getDomesticScheduledConsent()));
+        frDomesticScheduledConsent5.setPispId(frDomesticScheduledConsent2.getPispId());
+        frDomesticScheduledConsent5.setPispName(frDomesticScheduledConsent2.getPispName());
+        frDomesticScheduledConsent5.setStatusUpdate(frDomesticScheduledConsent2.getStatusUpdate());
+        frDomesticScheduledConsent5.setUpdated(frDomesticScheduledConsent2.getUpdated());
+        return frDomesticScheduledConsent5;
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticStandingOrderConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRDomesticStandingOrderConsentConverter.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent5;
 
 @Service
 public class FRDomesticStandingOrderConsentConverter {
@@ -121,5 +122,20 @@ public class FRDomesticStandingOrderConsentConverter {
         frDomesticScheduledConsent2.setStatusUpdate(frDomesticStandingOrderConsent5.getStatusUpdate());
         frDomesticScheduledConsent2.setUpdated(frDomesticStandingOrderConsent5.getUpdated());
         return frDomesticScheduledConsent2;
+    }
+
+    public static FRDomesticStandingOrderConsent5 toFRDomesticStandingOrderConsent5(FRDomesticStandingOrderConsent3 frDomesticStandingOrderConsent3) {
+        FRDomesticStandingOrderConsent5 frDomesticScheduledConsent5 = new FRDomesticStandingOrderConsent5();
+        frDomesticScheduledConsent5.setStatus(frDomesticStandingOrderConsent3.getStatus());
+        frDomesticScheduledConsent5.setId(frDomesticStandingOrderConsent3.getId());
+        frDomesticScheduledConsent5.setUserId(frDomesticStandingOrderConsent3.getUserId());
+        frDomesticScheduledConsent5.setAccountId(frDomesticStandingOrderConsent3.getAccountId());
+        frDomesticScheduledConsent5.setCreated(frDomesticStandingOrderConsent3.getCreated());
+        frDomesticScheduledConsent5.setDomesticStandingOrderConsent(toOBWriteDomesticStandingOrderConsent5(frDomesticStandingOrderConsent3.getDomesticStandingOrderConsent()));
+        frDomesticScheduledConsent5.setPispId(frDomesticStandingOrderConsent3.getPispId());
+        frDomesticScheduledConsent5.setPispName(frDomesticStandingOrderConsent3.getPispName());
+        frDomesticScheduledConsent5.setStatusUpdate(frDomesticStandingOrderConsent3.getStatusUpdate());
+        frDomesticScheduledConsent5.setUpdated(frDomesticStandingOrderConsent3.getUpdated());
+        return frDomesticScheduledConsent5;
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRFileConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRFileConsentConverter.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent3;
 
 @Service
 public class FRFileConsentConverter {
@@ -66,40 +67,59 @@ public class FRFileConsentConverter {
         return frFileConsent1;
     }
 
-    public static FRFileConsent2 toFRFileConsent2(FRFileConsent5 consent) {
+    public static FRFileConsent2 toFRFileConsent2(FRFileConsent5 frFileConsent5) {
         return FRFileConsent2.builder()
-                .id(consent.getId())
-                .status(consent.getStatus())
-                .writeFileConsent(toOBWriteFileConsent2(consent.getWriteFileConsent()))
-                .accountId(consent.getAccountId())
-                .userId(consent.getUserId())
-                .pispId(consent.getPispId())
-                .pispName(consent.getPispName())
-                .idempotencyKey(consent.getIdempotencyKey())
-                .created(consent.getCreated())
-                .statusUpdate(consent.getStatusUpdate())
-                .updated(consent.getUpdated())
-                .payments(consent.getPayments())
-                .fileContent(consent.getFileContent())
-                .obVersion(consent.getObVersion())
+                .id(frFileConsent5.getId())
+                .status(frFileConsent5.getStatus())
+                .writeFileConsent(toOBWriteFileConsent2(frFileConsent5.getWriteFileConsent()))
+                .accountId(frFileConsent5.getAccountId())
+                .userId(frFileConsent5.getUserId())
+                .pispId(frFileConsent5.getPispId())
+                .pispName(frFileConsent5.getPispName())
+                .idempotencyKey(frFileConsent5.getIdempotencyKey())
+                .created(frFileConsent5.getCreated())
+                .statusUpdate(frFileConsent5.getStatusUpdate())
+                .updated(frFileConsent5.getUpdated())
+                .payments(frFileConsent5.getPayments())
+                .fileContent(frFileConsent5.getFileContent())
+                .obVersion(frFileConsent5.getObVersion())
                 .build();
     }
 
-    public FRFileConsent1 toFRFileConsent1(FRFileConsent5 consent) {
+    public FRFileConsent1 toFRFileConsent1(FRFileConsent5 frFileConsent5) {
         return FRFileConsent1.builder()
-                .id(consent.getId())
-                .status(consent.getStatus())
-                .writeFileConsent(toOBWriteFileConsent1(consent.getWriteFileConsent()))
-                .accountId(consent.getAccountId())
-                .userId(consent.getUserId())
-                .pispId(consent.getPispId())
-                .pispName(consent.getPispName())
-                .created(consent.getCreated())
-                .statusUpdate(consent.getStatusUpdate())
-                .updated(consent.getUpdated())
-                .payments(consent.getPayments())
-                .fileContent(consent.getFileContent())
-                .version(consent.getObVersion())
+                .id(frFileConsent5.getId())
+                .status(frFileConsent5.getStatus())
+                .writeFileConsent(toOBWriteFileConsent1(frFileConsent5.getWriteFileConsent()))
+                .accountId(frFileConsent5.getAccountId())
+                .userId(frFileConsent5.getUserId())
+                .pispId(frFileConsent5.getPispId())
+                .pispName(frFileConsent5.getPispName())
+                .created(frFileConsent5.getCreated())
+                .statusUpdate(frFileConsent5.getStatusUpdate())
+                .updated(frFileConsent5.getUpdated())
+                .payments(frFileConsent5.getPayments())
+                .fileContent(frFileConsent5.getFileContent())
+                .version(frFileConsent5.getObVersion())
+                .build();
+    }
+
+    public static FRFileConsent5 toFRFileConsent5(FRFileConsent2 frFileConsent2) {
+        return FRFileConsent5.builder()
+                .id(frFileConsent2.getId())
+                .status(frFileConsent2.getStatus())
+                .writeFileConsent(toOBWriteFileConsent3(frFileConsent2.getWriteFileConsent()))
+                .accountId(frFileConsent2.getAccountId())
+                .userId(frFileConsent2.getUserId())
+                .pispId(frFileConsent2.getPispId())
+                .pispName(frFileConsent2.getPispName())
+                .idempotencyKey(frFileConsent2.getIdempotencyKey())
+                .created(frFileConsent2.getCreated())
+                .statusUpdate(frFileConsent2.getStatusUpdate())
+                .updated(frFileConsent2.getUpdated())
+                .payments(frFileConsent2.getPayments())
+                .fileContent(frFileConsent2.getFileContent())
+                .obVersion(frFileConsent2.getObVersion())
                 .build();
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalConsentConverter.java
@@ -22,10 +22,12 @@ package com.forgerock.openbanking.common.services.openbanking.converter.payment;
 
 import com.forgerock.openbanking.common.model.openbanking.v3_0.payment.FRInternationalConsent1;
 import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRInternationalConsent5;
 import org.springframework.stereotype.Service;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternationalConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternationalConsent2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternationalConsent5;
 
 @Service
 public class FRInternationalConsentConverter {
@@ -60,5 +62,21 @@ public class FRInternationalConsentConverter {
         frInternationalConsent1.setStatusUpdate(frInternationalConsent2.getStatusUpdate());
 
         return frInternationalConsent1;
+    }
+
+    public static FRInternationalConsent5 toFRInternationalConsent5(FRInternationalConsent2 frInternationalConsent2) {
+        FRInternationalConsent5 frInternationalConsent5 = new FRInternationalConsent5();
+
+        frInternationalConsent5.setId(frInternationalConsent2.getId());
+        frInternationalConsent5.setStatus(frInternationalConsent2.getStatus());
+        frInternationalConsent5.setUserId(frInternationalConsent2.getUserId());
+        frInternationalConsent5.setAccountId(frInternationalConsent2.getAccountId());
+        frInternationalConsent5.setCreated(frInternationalConsent2.getCreated());
+        frInternationalConsent5.setInternationalConsent(toOBWriteInternationalConsent5(frInternationalConsent2.getInternationalConsent()));
+        frInternationalConsent5.setPispId(frInternationalConsent2.getPispId());
+        frInternationalConsent5.setPispName(frInternationalConsent2.getPispName());
+        frInternationalConsent5.setStatusUpdate(frInternationalConsent2.getStatusUpdate());
+
+        return frInternationalConsent5;
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalPaymentSubmissionConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalPaymentSubmissionConverter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.services.openbanking.converter.payment;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalPaymentSubmission2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.payment.FRInternationalPaymentSubmission4;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternational2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBWriteInternational3DataInitiation;
+
+public class FRInternationalPaymentSubmissionConverter {
+
+    public static FRInternationalPaymentSubmission4 toFRInternationalPaymentSubmission4(FRInternationalPaymentSubmission2 frInternationalPaymentSubmission2) {
+        return frInternationalPaymentSubmission2 == null ? null : FRInternationalPaymentSubmission4.builder()
+                .id(frInternationalPaymentSubmission2.getId())
+                .internationalPayment(toOBWriteInternational3(frInternationalPaymentSubmission2.getInternationalPayment()))
+                .created(frInternationalPaymentSubmission2.getCreated())
+                .updated(frInternationalPaymentSubmission2.getUpdated())
+                .idempotencyKey(frInternationalPaymentSubmission2.getIdempotencyKey())
+                .obVersion(frInternationalPaymentSubmission2.getObVersion())
+                .build();
+    }
+
+    public static OBWriteInternational3 toOBWriteInternational3(OBWriteInternational2 obWriteInternational2) {
+        return obWriteInternational2 == null ? null : (new OBWriteInternational3())
+                .data(toOBWriteInternational3Data(obWriteInternational2.getData()))
+                .risk(obWriteInternational2.getRisk());
+    }
+
+    public static OBWriteInternational3Data toOBWriteInternational3Data(OBWriteDataInternational2 data) {
+        return data == null ? null : (new OBWriteInternational3Data())
+                .consentId(data.getConsentId())
+                .initiation(toOBWriteInternational3DataInitiation(data.getInitiation()));
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalScheduledConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalScheduledConsentConverter.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent5;
 
 @Service
 public class FRInternationalScheduledConsentConverter {
@@ -90,5 +91,20 @@ public class FRInternationalScheduledConsentConverter {
         frInternationalScheduledConsent1.setStatusUpdate(frInternationalScheduledConsent5.getStatusUpdate());
         frInternationalScheduledConsent1.setUpdated(frInternationalScheduledConsent5.getUpdated());
         return frInternationalScheduledConsent1;
+    }
+
+    public static FRInternationalScheduledConsent5 toFRInternationalScheduledConsent5(FRInternationalScheduledConsent2 frInternationalScheduledConsent2) {
+        FRInternationalScheduledConsent5 frInternationalScheduledConsent5 = new FRInternationalScheduledConsent5();
+        frInternationalScheduledConsent5.setStatus(frInternationalScheduledConsent2.getStatus());
+        frInternationalScheduledConsent5.setId(frInternationalScheduledConsent2.getId());
+        frInternationalScheduledConsent5.setUserId(frInternationalScheduledConsent2.getUserId());
+        frInternationalScheduledConsent5.setAccountId(frInternationalScheduledConsent2.getAccountId());
+        frInternationalScheduledConsent5.setCreated(frInternationalScheduledConsent2.getCreated());
+        frInternationalScheduledConsent5.setInternationalScheduledConsent(toOBWriteInternationalScheduledConsent5(frInternationalScheduledConsent2.getInternationalScheduledConsent()));
+        frInternationalScheduledConsent5.setPispId(frInternationalScheduledConsent2.getPispId());
+        frInternationalScheduledConsent5.setPispName(frInternationalScheduledConsent2.getPispName());
+        frInternationalScheduledConsent5.setStatusUpdate(frInternationalScheduledConsent2.getStatusUpdate());
+        frInternationalScheduledConsent5.setUpdated(frInternationalScheduledConsent2.getUpdated());
+        return frInternationalScheduledConsent5;
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalScheduledPaymentSubmissionConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalScheduledPaymentSubmissionConverter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.services.openbanking.converter.payment;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalScheduledPaymentSubmission2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.payment.FRInternationalScheduledPaymentSubmission4;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduled2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBWriteInternationalScheduled3DataInitiation;
+
+public class FRInternationalScheduledPaymentSubmissionConverter {
+
+    public static FRInternationalScheduledPaymentSubmission4 toFRInternationalScheduledPaymentSubmission4(FRInternationalScheduledPaymentSubmission2 frInternationalScheduledPaymentSubmission2) {
+        return frInternationalScheduledPaymentSubmission2 == null ? null : FRInternationalScheduledPaymentSubmission4.builder()
+                .id(frInternationalScheduledPaymentSubmission2.getId())
+                .internationalScheduledPayment(toOBWriteInternationalScheduled3(frInternationalScheduledPaymentSubmission2.getInternationalScheduledPayment()))
+                .created(frInternationalScheduledPaymentSubmission2.getCreated())
+                .updated(frInternationalScheduledPaymentSubmission2.getUpdated())
+                .idempotencyKey(frInternationalScheduledPaymentSubmission2.getIdempotencyKey())
+                .obVersion(frInternationalScheduledPaymentSubmission2.getObVersion())
+                .build();
+    }
+
+    public static OBWriteInternationalScheduled3 toOBWriteInternationalScheduled3(OBWriteInternationalScheduled2 obWriteInternationalScheduled2) {
+        return obWriteInternationalScheduled2 == null ? null : (new OBWriteInternationalScheduled3())
+                .data(toOBWriteInternationalScheduled3Data(obWriteInternationalScheduled2.getData()))
+                .risk(obWriteInternationalScheduled2.getRisk());
+    }
+
+    public static OBWriteInternationalScheduled3Data toOBWriteInternationalScheduled3Data(OBWriteDataInternationalScheduled2 data) {
+        return data == null ? null : new OBWriteInternationalScheduled3Data()
+                .consentId(data.getConsentId())
+                .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()));
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalStandingOrderConsentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalStandingOrderConsentConverter.java
@@ -23,10 +23,12 @@ package com.forgerock.openbanking.common.services.openbanking.converter.payment;
 import com.forgerock.openbanking.common.model.openbanking.v3_0.payment.FRInternationalStandingOrderConsent1;
 import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalStandingOrderConsent2;
 import com.forgerock.openbanking.common.model.openbanking.v3_1_1.payment.FRInternationalStandingOrderConsent3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRInternationalStandingOrderConsent5;
 import org.springframework.stereotype.Service;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent6;
 
 @Service
 public class FRInternationalStandingOrderConsentConverter {
@@ -89,6 +91,21 @@ public class FRInternationalStandingOrderConsentConverter {
         frInternationalScheduledConsent2.setStatusUpdate(frInternationalStandingOrderConsent2.getStatusUpdate());
         frInternationalScheduledConsent2.setUpdated(frInternationalStandingOrderConsent2.getUpdated());
         return frInternationalScheduledConsent2;
+    }
+
+    public static FRInternationalStandingOrderConsent5 toFRInternationalStandingOrderConsent5(FRInternationalStandingOrderConsent3 frInternationalStandingOrderConsent3) {
+        FRInternationalStandingOrderConsent5 frInternationalScheduledConsent5 = new FRInternationalStandingOrderConsent5();
+        frInternationalScheduledConsent5.setStatus(frInternationalStandingOrderConsent3.getStatus());
+        frInternationalScheduledConsent5.setId(frInternationalStandingOrderConsent3.getId());
+        frInternationalScheduledConsent5.setUserId(frInternationalStandingOrderConsent3.getUserId());
+        frInternationalScheduledConsent5.setAccountId(frInternationalStandingOrderConsent3.getAccountId());
+        frInternationalScheduledConsent5.setCreated(frInternationalStandingOrderConsent3.getCreated());
+        frInternationalScheduledConsent5.setInternationalStandingOrderConsent(toOBWriteInternationalStandingOrderConsent6(frInternationalStandingOrderConsent3.getInternationalStandingOrderConsent()));
+        frInternationalScheduledConsent5.setPispId(frInternationalStandingOrderConsent3.getPispId());
+        frInternationalScheduledConsent5.setPispName(frInternationalStandingOrderConsent3.getPispName());
+        frInternationalScheduledConsent5.setStatusUpdate(frInternationalStandingOrderConsent3.getStatusUpdate());
+        frInternationalScheduledConsent5.setUpdated(frInternationalStandingOrderConsent3.getUpdated());
+        return frInternationalScheduledConsent5;
     }
 
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalStandingOrderPaymentSubmissionConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/payment/FRInternationalStandingOrderPaymentSubmissionConverter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.services.openbanking.converter.payment;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.payment.FRInternationalStandingOrderPaymentSubmission3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_3.payment.FRInternationalStandingOrderPaymentSubmission4;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrder3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBWriteInternationalStandingOrder4DataInitiation;
+
+public class FRInternationalStandingOrderPaymentSubmissionConverter {
+
+    public static FRInternationalStandingOrderPaymentSubmission4 toFRInternationalStandingOrderPaymentSubmission4(FRInternationalStandingOrderPaymentSubmission3 frInternationalStandingOrderPaymentSubmission3) {
+        return frInternationalStandingOrderPaymentSubmission3 == null ? null : FRInternationalStandingOrderPaymentSubmission4.builder()
+                .id(frInternationalStandingOrderPaymentSubmission3.getId())
+                .internationalStandingOrder(toOBWriteInternationalStandingOrder4(frInternationalStandingOrderPaymentSubmission3.getInternationalStandingOrder()))
+                .created(frInternationalStandingOrderPaymentSubmission3.getCreated())
+                .updated(frInternationalStandingOrderPaymentSubmission3.getUpdated())
+                .idempotencyKey(frInternationalStandingOrderPaymentSubmission3.getIdempotencyKey())
+                .version(frInternationalStandingOrderPaymentSubmission3.obVersion)
+                .build();
+    }
+
+    public static OBWriteInternationalStandingOrder4 toOBWriteInternationalStandingOrder4(OBWriteInternationalStandingOrder3 obWriteInternationalStandingOrder3) {
+        return obWriteInternationalStandingOrder3 == null ? null : (new OBWriteInternationalStandingOrder4())
+                .data(toOBWriteInternationalStandingOrder4Data(obWriteInternationalStandingOrder3.getData()))
+                .risk(obWriteInternationalStandingOrder3.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrder4Data toOBWriteInternationalStandingOrder4Data(OBWriteDataInternationalStandingOrder3 data) {
+        return data == null ? null : (new OBWriteInternationalStandingOrder4Data())
+                .consentId(data.getConsentId())
+                .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()));
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
@@ -107,6 +107,11 @@
             <artifactId>spring-boot-admin-starter-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.mongobee</groupId>
+            <artifactId>mongobee</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.jsonzou</groupId>
             <artifactId>jmockdata</artifactId>
             <scope>test</scope>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/MigrationHelper.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/MigrationHelper.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.util.CloseableIterator;
+
+@Slf4j
+public class MigrationHelper {
+
+    public static <T> CloseableIterator<T> getLegacyDocuments(MongoTemplate mongoTemplate, Class<T> originatingDocumentClass) {
+        long count = mongoTemplate.count(new Query(), originatingDocumentClass);
+        log.info("Retrieving {} {} documents for conversion", count, originatingDocumentClass.getCanonicalName());
+        return mongoTemplate.stream(new Query(), originatingDocumentClass);
+    }
+
+    public static <T, U> void migrate(MongoTemplate mongoTemplate, T originatingDocument, U newDocument) {
+        mongoTemplate.remove(originatingDocument);
+        mongoTemplate.save(newDocument);
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbAccountsChangeLog.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbAccountsChangeLog.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+
+import com.forgerock.openbanking.common.model.openbanking.v1_1.account.FRDirectDebit1;
+import com.forgerock.openbanking.common.model.openbanking.v2_0.account.FRStatement1;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRAccount3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRBeneficiary3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRScheduledPayment2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRStandingOrder5;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.account.FRTransaction5;
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeSet;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.util.CloseableIterator;
+
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.getLegacyDocuments;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.migrate;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRAccountConverter.toAccount4;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRBeneficiaryConverter.toFRBeneficiary5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRDirectDebitConverter.toFRDirectDebit4;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRScheduledPaymentConverter.toFRScheduledPayment4;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRStandingOrderConverter.toFRStandingOrder6;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRStatementConverter.toFRStatement4;
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRTransactionConverter.toFRTransaction6;
+
+@ChangeLog
+@Slf4j
+public class MongoDbAccountsChangeLog {
+
+    @ChangeSet(order = "002", id = "accounts-v3.1.2-to-v3.1.6", author = "Matt Wills")
+    public void migrateAccountDocuments(MongoTemplate mongoTemplate) {
+        log.info("Migrating accounts API data from v3.1.2 to v3.1.6...");
+
+        CloseableIterator<FRAccount3> frAccounts = getLegacyDocuments(mongoTemplate, FRAccount3.class);
+        frAccounts.forEachRemaining(f -> migrate(mongoTemplate, f, toAccount4(f)));
+
+        CloseableIterator<FRBeneficiary3> frBeneficiaries = getLegacyDocuments(mongoTemplate, FRBeneficiary3.class);
+        frBeneficiaries.forEachRemaining(f -> migrate(mongoTemplate, f, toFRBeneficiary5(f)));
+
+        CloseableIterator<FRStandingOrder5> frStandingOrders = getLegacyDocuments(mongoTemplate, FRStandingOrder5.class);
+        frStandingOrders.forEachRemaining(f -> migrate(mongoTemplate, f, toFRStandingOrder6(f)));
+
+        CloseableIterator<FRTransaction5> frTransactionsIterator = getLegacyDocuments(mongoTemplate, FRTransaction5.class);
+        frTransactionsIterator.forEachRemaining(f -> migrate(mongoTemplate, f, toFRTransaction6(f)));
+
+        CloseableIterator<FRStatement1> frStatements = getLegacyDocuments(mongoTemplate, FRStatement1.class);
+        frStatements.forEachRemaining(f -> migrate(mongoTemplate, f, toFRStatement4(f)));
+
+        CloseableIterator<FRScheduledPayment2> frScheduledPayments = getLegacyDocuments(mongoTemplate, FRScheduledPayment2.class);
+        frScheduledPayments.forEachRemaining(f -> migrate(mongoTemplate, f, toFRScheduledPayment4(f)));
+
+        CloseableIterator<FRDirectDebit1> frDirectDebits = getLegacyDocuments(mongoTemplate, FRDirectDebit1.class);
+        frDirectDebits.forEachRemaining(f -> migrate(mongoTemplate, f, toFRDirectDebit4(f)));
+
+        log.info("Finished migrating accounts API data from v3.1.2 to v3.1.6");
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbPaymentsChangeLog.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbPaymentsChangeLog.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRDomesticConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRDomesticScheduledConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalPaymentSubmission2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalScheduledConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRInternationalScheduledPaymentSubmission2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.payment.FRDomesticStandingOrderConsent3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.payment.FRInternationalStandingOrderConsent3;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_1.payment.FRInternationalStandingOrderPaymentSubmission3;
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeSet;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.util.CloseableIterator;
+
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.getLegacyDocuments;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.migrate;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticConsentConverter.toFRDomesticConsent5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticScheduledConsentConverter.toFRDomesticScheduledConsent5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRDomesticStandingOrderConsentConverter.toFRDomesticStandingOrderConsent5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRFileConsentConverter.toFRFileConsent5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRInternationalConsentConverter.toFRInternationalConsent5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRInternationalPaymentSubmissionConverter.toFRInternationalPaymentSubmission4;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRInternationalScheduledConsentConverter.toFRInternationalScheduledConsent5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRInternationalScheduledPaymentSubmissionConverter.toFRInternationalScheduledPaymentSubmission4;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRInternationalStandingOrderConsentConverter.toFRInternationalStandingOrderConsent5;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRInternationalStandingOrderPaymentSubmissionConverter.toFRInternationalStandingOrderPaymentSubmission4;
+
+@ChangeLog
+@Slf4j
+public class MongoDbPaymentsChangeLog {
+
+    @ChangeSet(order = "001", id = "payments-v3.1.2-to-v3.1.6", author = "Matt Wills")
+    public void migratePaymentDocuments(MongoTemplate mongoTemplate) {
+        log.info("Migrating payments API data from v3.1.2 to v3.1.6...");
+
+        migrateDomesticPayments(mongoTemplate);
+        migrateInternationalPayments(mongoTemplate);
+
+        log.info("Finished migrating payments API data from v3.1.2 to v3.1.6");
+    }
+
+    private void migrateDomesticPayments(MongoTemplate mongoTemplate) {
+        CloseableIterator<FRDomesticConsent2> frDomesticConsents = getLegacyDocuments(mongoTemplate, FRDomesticConsent2.class);
+        frDomesticConsents.forEachRemaining(f -> migrate(mongoTemplate, f, toFRDomesticConsent5(f)));
+
+        CloseableIterator<FRDomesticScheduledConsent2> frDomesticScheduledConsents = getLegacyDocuments(mongoTemplate, FRDomesticScheduledConsent2.class);
+        frDomesticScheduledConsents.forEachRemaining(f -> migrate(mongoTemplate, f, toFRDomesticScheduledConsent5(f)));
+
+        CloseableIterator<FRDomesticStandingOrderConsent3> frDomesticStandingOrderConsents = getLegacyDocuments(mongoTemplate, FRDomesticStandingOrderConsent3.class);
+        frDomesticStandingOrderConsents.forEachRemaining(f -> migrate(mongoTemplate, f, toFRDomesticStandingOrderConsent5(f)));
+
+        CloseableIterator<FRFileConsent2> frFileConsents = getLegacyDocuments(mongoTemplate, FRFileConsent2.class);
+        frFileConsents.forEachRemaining(f -> migrate(mongoTemplate, f, toFRFileConsent5(f)));
+    }
+
+    private void migrateInternationalPayments(MongoTemplate mongoTemplate) {
+        CloseableIterator<FRInternationalConsent2> frInternationalConsents = getLegacyDocuments(mongoTemplate, FRInternationalConsent2.class);
+        frInternationalConsents.forEachRemaining(f -> migrate(mongoTemplate, f, toFRInternationalConsent5(f)));
+
+        CloseableIterator<FRInternationalPaymentSubmission2> frInternationalPaymentSubmissions = getLegacyDocuments(mongoTemplate, FRInternationalPaymentSubmission2.class);
+        frInternationalPaymentSubmissions.forEachRemaining(f -> migrate(mongoTemplate, f, toFRInternationalPaymentSubmission4(f)));
+
+        CloseableIterator<FRInternationalScheduledConsent2> frInternationalScheduledConsents = getLegacyDocuments(mongoTemplate, FRInternationalScheduledConsent2.class);
+        frInternationalScheduledConsents.forEachRemaining(f -> migrate(mongoTemplate, f, toFRInternationalScheduledConsent5(f)));
+
+        CloseableIterator<FRInternationalScheduledPaymentSubmission2> frInternationalScheduledPaymentSubmissions = getLegacyDocuments(mongoTemplate, FRInternationalScheduledPaymentSubmission2.class);
+        frInternationalScheduledPaymentSubmissions.forEachRemaining(f -> migrate(mongoTemplate, f, toFRInternationalScheduledPaymentSubmission4(f)));
+
+        CloseableIterator<FRInternationalStandingOrderConsent3> frInternationalStandingOrderConsents = getLegacyDocuments(mongoTemplate, FRInternationalStandingOrderConsent3.class);
+        frInternationalStandingOrderConsents.forEachRemaining(f -> migrate(mongoTemplate, f, toFRInternationalStandingOrderConsent5(f)));
+
+        CloseableIterator<FRInternationalStandingOrderPaymentSubmission3> frInternationalStandingOrderPaymentSubmissions = getLegacyDocuments(mongoTemplate, FRInternationalStandingOrderPaymentSubmission3.class);
+        frInternationalStandingOrderPaymentSubmissions.forEachRemaining(f -> migrate(mongoTemplate, f, toFRInternationalStandingOrderPaymentSubmission4(f)));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.78</version>
+        <version>1.0.79-SNAPSHOT</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.79-SNAPSHOT</version>
+        <version>1.0.79</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Changes to migrate any mongo documents containing OB model objects from v3.1.2 to v3.1.6.

This PR introduces [Mongobee](https://github.com/mongobee/mongobee), which is essentially a Mongo equivalent of Liquibase. The idea is that when SpringBoot starts up, Mongobee will run any "change sets" that haven't been run before (Mongobee keeps a record of which changesets have been run).