### PR TITLE
Release/1.0.98

### DIFF
--- a/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-server/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-server/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-as/forgerock-openbanking-cdr-aspsp-as-gateway/forgerock-openbanking-cdr-aspsp-as-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-gateway/forgerock-openbanking-cdr-aspsp-rs-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-mock-store/forgerock-openbanking-cdr-aspsp-rs-mock-store-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/pom.xml
+++ b/forgerock-openbanking-cdr-aspsp-rs/forgerock-openbanking-cdr-aspsp-rs-model/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98-SNAPSHOT</version>
+		<version>1.0.98</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98</version>
+		<version>1.0.99-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98-SNAPSHOT</version>
+		<version>1.0.98</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98</version>
+		<version>1.0.99-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98-SNAPSHOT</version>
+		<version>1.0.98</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98</version>
+		<version>1.0.99-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98-SNAPSHOT</version>
+		<version>1.0.98</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98</version>
+		<version>1.0.99-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98-SNAPSHOT</version>
+		<version>1.0.98</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98</version>
+		<version>1.0.99-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98-SNAPSHOT</version>
+		<version>1.0.98</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>1.0.98</version>
+		<version>1.0.99-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
         <relativePath>../../../</relativePath>
     </parent>
 

--- a/integration-test-support/pom.xml
+++ b/integration-test-support/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98-SNAPSHOT</version>
+        <version>1.0.98</version>
     </parent>
 
     <repositories>

--- a/integration-test-support/pom.xml
+++ b/integration-test-support/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>1.0.98</version>
+        <version>1.0.99-SNAPSHOT</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>1.0.98-SNAPSHOT</version>
+    <version>1.0.98</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -156,7 +156,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-aspsp.git</url>
-        <tag>HEAD</tag>
+        <tag>1.0.98</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>1.0.98</version>
+    <version>1.0.99-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -156,7 +156,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-aspsp.git</url>
-        <tag>1.0.98</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
1.0.98 release. Using mongobee to migrate existing v3.1.2 data within mongo to v3.1.6.