### PR TITLE
Updated ui project version to updating-ui-version-to-3.1.6-rem-rc1

### DIFF
--- a/forgerock-openbanking-ui/package.json
+++ b/forgerock-openbanking-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ob-aspsp-forgerock-openbanking-ui",
-  "project_version": "3.1.2-queen-rc7",
+  "project_version": "3.1.6-rem-rc1",
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
This will roll through to the docker image names, which for UI template based docker images are still showing as 3.1.2-queen-rc7-4124c1f for example.

Part fix for ForgeCloud/ob-deploy#605