### PR TITLE
Feature 238 - Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,77 +1,12 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
-### GitHub [#283](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/283) Feature/lbg/issue obdeploy 606
-[81188506085341e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/81188506085341e) Jorge Sanchez Perez *2020-09-30 11:32:23*
-Feature/lbg/issue obdeploy 606 (#283)
-
-* Payment File Type - MediaType changed (Batch and Bulk)
-- changed the mediaType to `text/plain` instead of `text/csv`
-
-* badge release changed to github release
-[43bb526864e027b](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/43bb526864e027b) JamieB *2020-09-29 09:37:28*
+[01e143ac8a5097f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/01e143ac8a5097f) JamieB *2020-10-07 09:43:22*
 Release candidate: prepare for next development iteration
-## 1.0.101
-[aea2d305be072d7](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/aea2d305be072d7) Matt Wills *2020-09-17 08:10:15*
-New Payment consent FR model objects (#296)
-[2fa17af225eb155](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/2fa17af225eb155) JamieB *2020-09-23 14:11:38*
-Updated ui project version to updating-ui-version-to-3.1.6-rem-rc1
-[00bf3b045b6951c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/00bf3b045b6951c) JamieB *2020-09-29 09:37:20*
-Release candidate: prepare release 1.0.101
-[d2a5578aae14713](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d2a5578aae14713) JamieB *2020-09-29 09:28:26*
-Use latest openbanking-starter-parent 1.0.83
-[b43e7382a8f9c7d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/b43e7382a8f9c7d) JamieB *2020-09-29 08:56:28*
-Improved error when incorrect type is used in b64 jws header
-[f2aec21fa339ddd](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/f2aec21fa339ddd) JamieB *2020-09-29 08:39:03*
-Remove duplicate test
-[e99722e3becea3d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e99722e3becea3d) JamieB *2020-09-29 08:27:14*
-Remove unused import
-[01e82666a58b8af](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/01e82666a58b8af) JamieB *2020-09-29 08:10:06*
-More refactoring and addressing of PR comments
-[92126b6c2976f10](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/92126b6c2976f10) JamieB *2020-09-28 15:54:13*
-Refactor and Optimise DetachedJwsVerifier
 
-Fix bad format in debug string
-Refactoring of DetachedJwsVerifier
-Optimisation of DetachedJwsVerifier
-Removed needless reconstruction of full jws in methods just
-manipulating/using the header
-Made newly added test work like other tests
-Add missing javadoc
-Makes ClaimsUtils naming more explicit - Now called JwsClaimsUtils
-[2dac7dd056b5484](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/2dac7dd056b5484) JamieB *2020-09-28 14:00:01*
-Address PR comments
-
-https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/281/
-[97e8718e4238aaf](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/97e8718e4238aaf) JamieB *2020-09-28 13:07:10*
-Use nimbusds shaded minidev library
-
-Latest nimbusds is packaged with a shaded version of minidev. aspsp used
-to have minidev as a package, the version of which was controlled in the
-openbanking-parent pom. We now need to remove that dependency and
-changes our code to use classes directly from the shaded nimbusds
-libary.
-[68fd47483d0596b](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/68fd47483d0596b) dependabot-preview[bot] *2020-09-28 08:45:21*
-Bump ob-clients.version from 1.0.36 to 1.0.40
-
-Bumps `ob-clients.version` from 1.0.36 to 1.0.40.
-
-Updates `forgerock-openbanking-jwkms-client` from 1.0.36 to 1.0.40
-- [Release notes](https://github.com/OpenBankingToolkit/openbanking-clients/releases)
-- [Commits](https://github.com/OpenBankingToolkit/openbanking-clients/compare/1.0.36...1.0.40)
-
-Updates `forgerock-openbanking-analytics-client` from 1.0.36 to 1.0.40
-- [Release notes](https://github.com/OpenBankingToolkit/openbanking-clients/releases)
-- [Commits](https://github.com/OpenBankingToolkit/openbanking-clients/compare/1.0.36...1.0.40)
-
-Updates `forgerock-openbanking-analytics-webclient` from 1.0.36 to 1.0.40
-- [Release notes](https://github.com/OpenBankingToolkit/openbanking-clients/releases)
-- [Commits](https://github.com/OpenBankingToolkit/openbanking-clients/compare/1.0.36...1.0.40)
-
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
-[86ee5a444b8ba34](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/86ee5a444b8ba34) Matt Wills *2020-09-10 10:50:20*
-Release candidate: prepare for next development iteration
-## 1.0.100
+This reverts commit b198ec1ab8b95a1c75ebef72bfdf52c7c43b1ffe, reversing
+changes made to 006af5906e56448d8e15b7c3f6043d35bf5ddf1e.
+## 1.0.103
 ### GitHub [#170](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/170) Bump forgerock-openbanking-starter-parent from 1.0.66 to 1.0.67
 [7cf1703eed6fe35](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/7cf1703eed6fe35) Matt Wills *2020-07-22 13:52:02*
 Separated the reporting of the API versions, so that the read/write API and client registration API can be specified separately (#170)
@@ -347,6 +282,25 @@ Ensured detached JWS headers containing a b64 claim are rejected from 3.1.4 onwa
 ### GitHub [#282](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/282) Make release 1.0.101
 [0893846c278ec7b](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0893846c278ec7b) Matt Wills *2020-09-10 09:50:16*
 Fix for idempotency verification. Removed redundant repositories (#282)
+### GitHub [#283](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/283) Feature/lbg/issue obdeploy 606
+[81188506085341e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/81188506085341e) Jorge Sanchez Perez *2020-09-30 11:32:23*
+Feature/lbg/issue obdeploy 606 (#283)
+
+* Payment File Type - MediaType changed (Batch and Bulk)
+- changed the mediaType to `text/plain` instead of `text/csv`
+
+* badge release changed to github release
+### GitHub [#284](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/284) Release/1.0.102
+[d2c38ec9e36f729](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d2c38ec9e36f729) Jorge Sanchez Perez *2020-09-30 12:09:46*
+Release/1.0.102 (#284)
+
+* Release candidate: prepare release 1.0.102
+
+* Release candidate: prepare for next development iteration
+
+* changelog updated
+[aea2d305be072d7](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/aea2d305be072d7) Matt Wills *2020-09-17 08:10:15*
+New Payment consent FR model objects (#296)
 [9f6afb8063341ee](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/9f6afb8063341ee) Jorge Sanchez Perez *2020-04-24 17:06:53*
 Release 1.0.79 (#181)
 
@@ -477,10 +431,80 @@ Bumps [forgerock-openbanking-jwkms-embedded](https://github.com/OpenBankingToolk
 - [Commits](https://github.com/OpenBankingToolkit/openbanking-jwkms/compare/forgerock-openbanking-reference-implementation-jwkms-1.1.67...1.1.70)
 
 Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
+[2fa17af225eb155](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/2fa17af225eb155) JamieB *2020-09-23 14:11:38*
+Updated ui project version to updating-ui-version-to-3.1.6-rem-rc1
 [f3b878ca0944044](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/f3b878ca0944044) JamieB *2020-05-15 09:52:09*
 Updated ui project version to updating-ui-version-to-3.1.2-queen-rc7
-[58d5f5075306aaa](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/58d5f5075306aaa) Matt Wills *2020-09-10 10:43:41*
-Release candidate: prepare release 1.0.100
+[3430f68c3636578](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/3430f68c3636578) JamieB *2020-10-06 09:34:36*
+Release candidate: prepare release 1.0.103
+[1a001bf7f085d96](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/1a001bf7f085d96) JamieB *2020-10-06 09:24:52*
+Fix missing analytics entries use 1.0.41 of ob clients
+
+Use latests versions of ob libs that use version 1.0.41 of openbanking
+clients which contains a fix
+
+Part fix for https://github.com/OpenBankingToolkit/openbanking-analytics/issues/163
+[62ebb09658028a3](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/62ebb09658028a3) dependabot-preview[bot] *2020-10-05 08:59:14*
+Bump forgerock-openbanking-jwkms-embedded from 1.1.73 to 1.1.74
+
+Bumps [forgerock-openbanking-jwkms-embedded](https://github.com/OpenBankingToolkit/openbanking-jwkms) from 1.1.73 to 1.1.74.
+- [Release notes](https://github.com/OpenBankingToolkit/openbanking-jwkms/releases)
+- [Commits](https://github.com/OpenBankingToolkit/openbanking-jwkms/compare/1.1.73...1.1.74)
+
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
+[43bb526864e027b](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/43bb526864e027b) JamieB *2020-09-29 09:37:28*
+Release candidate: prepare for next development iteration
+[b43e7382a8f9c7d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/b43e7382a8f9c7d) JamieB *2020-09-29 08:56:28*
+Improved error when incorrect type is used in b64 jws header
+[f2aec21fa339ddd](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/f2aec21fa339ddd) JamieB *2020-09-29 08:39:03*
+Remove duplicate test
+[e99722e3becea3d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e99722e3becea3d) JamieB *2020-09-29 08:27:14*
+Remove unused import
+[01e82666a58b8af](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/01e82666a58b8af) JamieB *2020-09-29 08:10:06*
+More refactoring and addressing of PR comments
+[92126b6c2976f10](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/92126b6c2976f10) JamieB *2020-09-28 15:54:13*
+Refactor and Optimise DetachedJwsVerifier
+
+Fix bad format in debug string
+Refactoring of DetachedJwsVerifier
+Optimisation of DetachedJwsVerifier
+Removed needless reconstruction of full jws in methods just
+manipulating/using the header
+Made newly added test work like other tests
+Add missing javadoc
+Makes ClaimsUtils naming more explicit - Now called JwsClaimsUtils
+[2dac7dd056b5484](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/2dac7dd056b5484) JamieB *2020-09-28 14:00:01*
+Address PR comments
+
+https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/281/
+[97e8718e4238aaf](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/97e8718e4238aaf) JamieB *2020-09-28 13:07:10*
+Use nimbusds shaded minidev library
+
+Latest nimbusds is packaged with a shaded version of minidev. aspsp used
+to have minidev as a package, the version of which was controlled in the
+openbanking-parent pom. We now need to remove that dependency and
+changes our code to use classes directly from the shaded nimbusds
+libary.
+[68fd47483d0596b](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/68fd47483d0596b) dependabot-preview[bot] *2020-09-28 08:45:21*
+Bump ob-clients.version from 1.0.36 to 1.0.40
+
+Bumps `ob-clients.version` from 1.0.36 to 1.0.40.
+
+Updates `forgerock-openbanking-jwkms-client` from 1.0.36 to 1.0.40
+- [Release notes](https://github.com/OpenBankingToolkit/openbanking-clients/releases)
+- [Commits](https://github.com/OpenBankingToolkit/openbanking-clients/compare/1.0.36...1.0.40)
+
+Updates `forgerock-openbanking-analytics-client` from 1.0.36 to 1.0.40
+- [Release notes](https://github.com/OpenBankingToolkit/openbanking-clients/releases)
+- [Commits](https://github.com/OpenBankingToolkit/openbanking-clients/compare/1.0.36...1.0.40)
+
+Updates `forgerock-openbanking-analytics-webclient` from 1.0.36 to 1.0.40
+- [Release notes](https://github.com/OpenBankingToolkit/openbanking-clients/releases)
+- [Commits](https://github.com/OpenBankingToolkit/openbanking-clients/compare/1.0.36...1.0.40)
+
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
+[86ee5a444b8ba34](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/86ee5a444b8ba34) Matt Wills *2020-09-10 10:50:20*
+Release candidate: prepare for next development iteration
 [450d679943400e6](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/450d679943400e6) Matt Wills *2020-09-09 10:04:02*
 Release candidate: prepare for next development iteration
 [4ebbaeac1b213f0](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/4ebbaeac1b213f0) Matt Wills *2020-09-08 11:01:17*
@@ -529,6 +553,16 @@ Release candidate: prepare for next development iteration
 Release candidate: prepare for next development iteration
 [861981393939c0a](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/861981393939c0a) JamieB *2020-06-15 11:27:45*
 Release candidate: prepare for next development iteration
+[91f910625f5fcb1](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/91f910625f5fcb1) JamieB *2020-06-15 10:23:12*
+Make OBRisk1.PaymentCodeContext field configurably a required field
+
+Part fix for https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/196
+
+Some implementors have expressed a need to be able to enfore that a
+PaymentCodeContext is provided in the Risk object when requesting a
+consent. This PR enables this feature to be turned on by setting the
+following spring config setting to true;
+`rs.api.payment.validate.risk.require-payment-context-code`
 [50f645798ab6ff6](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/50f645798ab6ff6) Matt Wills *2020-06-15 09:11:57*
 Release candidate: prepare for next development iteration
 [475850b80e3e28f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/475850b80e3e28f) jorgesanchezperez *2020-05-13 10:53:11*
@@ -543,6 +577,14 @@ remove unused file
 upgrade common ui. https://github.com/OpenBankingToolkit/openbanking-common/issues/59
 [e567d3cd251e50f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e567d3cd251e50f) JamieB *2020-04-22 15:53:06*
 Updated ui project version to updating-ui-version-to-
+## 1.0.101
+[00bf3b045b6951c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/00bf3b045b6951c) JamieB *2020-09-29 09:37:20*
+Release candidate: prepare release 1.0.101
+[d2a5578aae14713](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d2a5578aae14713) JamieB *2020-09-29 09:28:26*
+Use latest openbanking-starter-parent 1.0.83
+## 1.0.100
+[58d5f5075306aaa](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/58d5f5075306aaa) Matt Wills *2020-09-10 10:43:41*
+Release candidate: prepare release 1.0.100
 ## 1.0.99
 [40c050ffb3d641f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/40c050ffb3d641f) Matt Wills *2020-09-09 10:03:52*
 Release candidate: prepare release 1.0.99
@@ -582,16 +624,6 @@ Release candidate: prepare release 1.0.85
 ## 1.0.83
 [553440e6b90bbf9](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/553440e6b90bbf9) JamieB *2020-06-15 11:27:36*
 Release candidate: prepare release 1.0.83
-[91f910625f5fcb1](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/91f910625f5fcb1) JamieB *2020-06-15 10:23:12*
-Make OBRisk1.PaymentCodeContext field configurably a required field
-
-Part fix for https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/196
-
-Some implementors have expressed a need to be able to enfore that a
-PaymentCodeContext is provided in the Risk object when requesting a
-consent. This PR enables this feature to be turned on by setting the
-following spring config setting to true;
-`rs.api.payment.validate.risk.require-payment-context-code`
 ## 1.0.82
 [162d7fe6da5c45e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/162d7fe6da5c45e) Matt Wills *2020-06-15 09:11:46*
 Release candidate: prepare release 1.0.82

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/version/OBVersion.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/version/OBVersion.java
@@ -60,4 +60,12 @@ public enum OBVersion {
     public boolean isAfterVersion(OBVersion version) {
         return this.ordinal() > version.ordinal();
     }
+
+    /**
+     * Canonical value of version replacing '_' for '.'
+     * @return canonical string version
+     */
+    public String getCanonicalVersion(){
+        return this.name().replace("_",".");
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/event/v3_1_2/callbackurl/CallbackUrlApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/event/v3_1_2/callbackurl/CallbackUrlApiController.java
@@ -41,6 +41,8 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Collections;
 
+import static com.forgerock.openbanking.aspsp.rs.api.payment.ApiVersionMatcher.getOBVersion;
+
 @Controller("CallbackUrlApiV3.1.2")
 @Slf4j
 public class CallbackUrlApiController implements CallbackUrlApi {
@@ -76,6 +78,7 @@ public class CallbackUrlApiController implements CallbackUrlApi {
         return rsEndpointWrapperService.eventNotificationEndpoint()
                 .authorization(authorization)
                 .principal(principal)
+                .obVersion(getOBVersion(request.getRequestURI()))
                 .filters(f ->
                         {
                             f.verifyJwsDetachedSignature(xJwsSignature, request);
@@ -139,6 +142,7 @@ public class CallbackUrlApiController implements CallbackUrlApi {
         return rsEndpointWrapperService.eventNotificationEndpoint()
                 .authorization(authorization)
                 .principal(principal)
+                .obVersion(getOBVersion(request.getRequestURI()))
                 .filters(f ->
                         {
                             f.verifyJwsDetachedSignature(xJwsSignature, request);
@@ -170,6 +174,7 @@ public class CallbackUrlApiController implements CallbackUrlApi {
         return rsEndpointWrapperService.eventNotificationEndpoint()
                 .authorization(authorization)
                 .principal(principal)
+                .obVersion(getOBVersion(request.getRequestURI()))
                 .execute(
                         (String tppId) -> {
                             HttpHeaders additionalHttpHeaders = new HttpHeaders();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/helper/EventsHelper.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/helper/EventsHelper.java
@@ -9,7 +9,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,7 +18,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package com.forgerock.openbanking.aspsp.rs.store.api.helper;
 
 import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/helper/EventsHelper.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/helper/EventsHelper.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.forgerock.openbanking.aspsp.rs.store.api.helper;
+
+import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
+
+import java.util.function.Predicate;
+
+public class EventsHelper {
+
+    public static Predicate<FRCallbackUrl1> matchingVersion(OBVersion version){
+        return frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(version.getCanonicalVersion());
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
@@ -9,7 +9,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
@@ -23,6 +23,7 @@ package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_0;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.Tpp;
 import io.swagger.annotations.ApiParam;
@@ -68,8 +69,8 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
-            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload." ,required=true)
-            @RequestHeader(value="x-jws-signature", required=false) String xJwsSignature,
+            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = false) String xJwsSignature,
 
             @ApiParam(value = "An RFC4122 UID used as a correlation id.")
             @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
@@ -130,7 +131,7 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
             HttpServletRequest request,
 
             Principal principal
-    )  {
+    ) {
         return Optional.ofNullable(tppRepository.findByClientId(clientId))
                 .map(Tpp::getId)
                 .map(id -> callbackUrlsRepository.findByTppId(id))
@@ -218,9 +219,12 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
         }
     }
 
-    private OBCallbackUrlsResponse1 packageResponse(final Collection<FRCallbackUrl1> frCallbackUrls) {
+    protected OBCallbackUrlsResponse1 packageResponse(final Collection<FRCallbackUrl1> frCallbackUrls) {
         final List<OBCallbackUrlResponseData1> callbackUrls =
                 frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_0.getCanonicalVersion())
+                        )
                         .map(this::toOBCallbackUrlResponseData1)
                         .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
@@ -229,7 +233,7 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
                 );
     }
 
-    private OBCallbackUrlResponse1 packageResponse(FRCallbackUrl1 frCallbackUrl) {
+    protected OBCallbackUrlResponse1 packageResponse(FRCallbackUrl1 frCallbackUrl) {
         return new OBCallbackUrlResponse1()
                 .data(
                         toOBCallbackUrlResponseData1(frCallbackUrl)
@@ -237,7 +241,7 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
     }
 
 
-    private OBCallbackUrlResponseData1 toOBCallbackUrlResponseData1(FRCallbackUrl1 frCallbackUrl) {
+    protected OBCallbackUrlResponseData1 toOBCallbackUrlResponseData1(FRCallbackUrl1 frCallbackUrl) {
         final OBCallbackUrlData1 data = frCallbackUrl.getObCallbackUrl().getData();
         return new OBCallbackUrlResponseData1()
                 .callbackUrlId(frCallbackUrl.getId())

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
@@ -224,9 +224,8 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_0)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_0))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_0/CallbackUrlsApiController.java
@@ -9,7 +9,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_0;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
@@ -40,7 +41,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -220,18 +220,18 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
     }
 
     protected OBCallbackUrlsResponse1 packageResponse(final Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_0.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_0)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
     }
+
 
     protected OBCallbackUrlResponse1 packageResponse(FRCallbackUrl1 frCallbackUrl) {
         return new OBCallbackUrlResponse1()
@@ -239,7 +239,6 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
                         toOBCallbackUrlResponseData1(frCallbackUrl)
                 );
     }
-
 
     protected OBCallbackUrlResponseData1 toOBCallbackUrlResponseData1(FRCallbackUrl1 frCallbackUrl) {
         final OBCallbackUrlData1 data = frCallbackUrl.getObCallbackUrl().getData();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1/CallbackUrlsApiController.java
@@ -22,8 +22,17 @@ package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
+import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponseData1;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller("CallbackUrlsApiV3.1")
 @Slf4j
@@ -31,5 +40,20 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository, TppRepository tppRepository) {
         super(callbackUrlsRepository, tppRepository);
+    }
+
+    @Override
+    protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
+        final List<OBCallbackUrlResponseData1> callbackUrls =
+                frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1.getCanonicalVersion())
+                        )
+                        .map(this::toOBCallbackUrlResponseData1)
+                        .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1()
+                        .callbackUrl(callbackUrls)
+                );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1/CallbackUrlsApiController.java
@@ -49,9 +49,8 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_1)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_1))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1/CallbackUrlsApiController.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
@@ -44,16 +45,15 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     @Override
     protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_1)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_1/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_1/CallbackUrlsApiController.java
@@ -49,9 +49,8 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_1_1)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_1_1))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_1/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_1/CallbackUrlsApiController.java
@@ -22,8 +22,17 @@ package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_1;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
+import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponseData1;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller("CallbackUrlsApiV3.1.1")
 @Slf4j
@@ -31,5 +40,20 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository, TppRepository tppRepository) {
         super(callbackUrlsRepository, tppRepository);
+    }
+
+    @Override
+    protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
+        final List<OBCallbackUrlResponseData1> callbackUrls =
+                frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_1.getCanonicalVersion())
+                        )
+                        .map(this::toOBCallbackUrlResponseData1)
+                        .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1()
+                        .callbackUrl(callbackUrls)
+                );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_1/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_1/CallbackUrlsApiController.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_1;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
@@ -44,16 +45,15 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     @Override
     protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_1.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_1_1)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_2.callbackurl;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
@@ -229,17 +230,25 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
 
 
     protected OBCallbackUrlsResponse1 packageResponse(final Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_2.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_1_2)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
+    }
+
+    protected List<OBCallbackUrlResponseData1> callbackUrlFilteredByVersion(final Collection<FRCallbackUrl1> frCallbackUrls, final String version){
+        return frCallbackUrls.stream()
+                .filter(
+                        frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(version)
+                )
+                .map(this::toOBCallbackUrlResponseData1)
+                .collect(Collectors.toList());
     }
 
     protected OBCallbackUrlResponse1 packageResponse(FRCallbackUrl1 frCallbackUrl) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
@@ -24,6 +24,7 @@ import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.Tpp;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
@@ -36,7 +37,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import uk.org.openbanking.datamodel.account.Links;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.event.*;
 
@@ -44,9 +44,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Controller("CallbackUrlsApiV3.1.2")
 @Slf4j
@@ -71,8 +72,8 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
-            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload." ,required=true)
-            @RequestHeader(value="x-jws-signature", required=false) String xJwsSignature,
+            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = false) String xJwsSignature,
 
             @ApiParam(value = "An RFC4122 UID used as a correlation id.")
             @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
@@ -136,16 +137,16 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
             HttpServletRequest request,
 
             Principal principal
-    )  throws OBErrorResponseException {
+    ) throws OBErrorResponseException {
         return Optional.ofNullable(tppRepository.findByClientId(clientId))
                 .map(Tpp::getId)
                 .map(id -> callbackUrlsRepository.findByTppId(id))
-                .map(url -> ResponseEntity.ok(packageResponse(url)))
+                .map(urls -> ResponseEntity.ok(packageResponse(urls)))
                 .orElseThrow(() -> new OBErrorResponseException(
-                                    HttpStatus.NOT_FOUND,
-                                    OBRIErrorResponseCategory.REQUEST_INVALID,
-                                    OBRIErrorType.TPP_NOT_FOUND.toOBError1(clientId)
-                            )
+                                HttpStatus.NOT_FOUND,
+                                OBRIErrorResponseCategory.REQUEST_INVALID,
+                                OBRIErrorType.TPP_NOT_FOUND.toOBError1(clientId)
+                        )
                 );
     }
 
@@ -227,40 +228,28 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
     }
 
 
-    private OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> url) {
-        final Optional<FRCallbackUrl1> hasUrl = url.stream().findFirst();
-        if (hasUrl.isPresent()) {
-            return new OBCallbackUrlsResponse1()
-                    .data(toOBCallbackUrlsResponseData1(hasUrl.get()))
-                    .meta(new Meta())
-                    .links(resourceLinkService.toSelfLink(hasUrl.get(), discovery -> discovery.getV_3_1_2().getGetCallbackUrls()));
-        } else {
-            return new OBCallbackUrlsResponse1()
-                    .data(new OBCallbackUrlsResponseData1().callbackUrl(Collections.emptyList()))
-                    .meta(new Meta())
-                    .links(new Links());
-        }
+    protected OBCallbackUrlsResponse1 packageResponse(final Collection<FRCallbackUrl1> frCallbackUrls) {
+        final List<OBCallbackUrlResponseData1> callbackUrls =
+                frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_2.getCanonicalVersion())
+                        )
+                        .map(this::toOBCallbackUrlResponseData1)
+                        .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1()
+                        .callbackUrl(callbackUrls)
+                );
     }
 
-    private OBCallbackUrlResponse1 packageResponse(FRCallbackUrl1 frCallbackUrl) {
+    protected OBCallbackUrlResponse1 packageResponse(FRCallbackUrl1 frCallbackUrl) {
         return new OBCallbackUrlResponse1()
                 .data(toOBCallbackUrlResponseData1(frCallbackUrl))
                 .meta(new Meta())
                 .links(resourceLinkService.toSelfLink(frCallbackUrl, discovery -> discovery.getV_3_1_2().getGetCallbackUrls()));
     }
 
-    private OBCallbackUrlsResponseData1 toOBCallbackUrlsResponseData1(FRCallbackUrl1 frCallbackUrl) {
-        final OBCallbackUrlData1 data = frCallbackUrl.getObCallbackUrl().getData();
-        return new OBCallbackUrlsResponseData1()
-                .callbackUrl(Collections.singletonList(
-                        new OBCallbackUrlResponseData1()
-                                .url(data.getUrl())
-                                .callbackUrlId(frCallbackUrl.getId())
-                                .version(data.getVersion())
-                ));
-    }
-
-    private OBCallbackUrlResponseData1 toOBCallbackUrlResponseData1(FRCallbackUrl1 frCallbackUrl) {
+    protected OBCallbackUrlResponseData1 toOBCallbackUrlResponseData1(FRCallbackUrl1 frCallbackUrl) {
         final OBCallbackUrlData1 data = frCallbackUrl.getObCallbackUrl().getData();
         return new OBCallbackUrlResponseData1()
                 .url(data.getUrl())

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
@@ -234,9 +234,8 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_1_2)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_1_2))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
@@ -48,9 +48,8 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_1_3)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_1_3))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
@@ -23,12 +23,36 @@ package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_3.ca
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
+import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponseData1;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller("CallbackUrlsApiV3.1.3")
 public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_2.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
 
     public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository, TppRepository tppRepository, ResourceLinkService resourceLinkService) {
         super(callbackUrlsRepository, tppRepository, resourceLinkService);
+    }
+
+    @Override
+    protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
+        final List<OBCallbackUrlResponseData1> callbackUrls =
+                frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_3.getCanonicalVersion())
+                        )
+                        .map(this::toOBCallbackUrlResponseData1)
+                        .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1()
+                        .callbackUrl(callbackUrls)
+                );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_3.callbackurl;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
@@ -43,16 +44,15 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     @Override
     protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_3.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_1_3)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_4.callbackurl;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
@@ -43,16 +44,15 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     @Override
     protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_4.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_1_4)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
@@ -23,12 +23,36 @@ package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_4.ca
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
+import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponseData1;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller("CallbackUrlsApiV3.1.4")
 public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_3.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
 
     public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository, TppRepository tppRepository, ResourceLinkService resourceLinkService) {
         super(callbackUrlsRepository, tppRepository, resourceLinkService);
+    }
+
+    @Override
+    protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
+        final List<OBCallbackUrlResponseData1> callbackUrls =
+                frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_4.getCanonicalVersion())
+                        )
+                        .map(this::toOBCallbackUrlResponseData1)
+                        .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1()
+                        .callbackUrl(callbackUrls)
+                );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
@@ -48,9 +48,8 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_1_4)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_1_4))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_5.callbackurl;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
@@ -43,16 +44,15 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     @Override
     protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_5.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_1_5)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
@@ -23,12 +23,36 @@ package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_5.ca
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
+import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponseData1;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller("CallbackUrlsApiV3.1.5")
 public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_4.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
 
     public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository, TppRepository tppRepository, ResourceLinkService resourceLinkService) {
         super(callbackUrlsRepository, tppRepository, resourceLinkService);
+    }
+
+    @Override
+    protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
+        final List<OBCallbackUrlResponseData1> callbackUrls =
+                frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_5.getCanonicalVersion())
+                        )
+                        .map(this::toOBCallbackUrlResponseData1)
+                        .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1()
+                        .callbackUrl(callbackUrls)
+                );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
@@ -48,9 +48,8 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_1_5)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_1_5))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
@@ -48,9 +48,8 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
                 .data(new OBCallbackUrlsResponseData1()
                         .callbackUrl(
                                 frCallbackUrls.stream()
-                                        .filter(
-                                                EventsHelper.matchingVersion(OBVersion.v3_1_6)
-                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .filter(EventsHelper.matchingVersion(OBVersion.v3_1_6))
+                                        .map(this::toOBCallbackUrlResponseData1)
                                         .collect(Collectors.toList())
                         )
                 );

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
@@ -23,12 +23,36 @@ package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_6.ca
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
+import com.forgerock.openbanking.common.model.openbanking.v3_0.event.FRCallbackUrl1;
+import com.forgerock.openbanking.common.model.version.OBVersion;
 import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponseData1;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller("CallbackUrlsApiV3.1.6")
 public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_5.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
 
     public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository, TppRepository tppRepository, ResourceLinkService resourceLinkService) {
         super(callbackUrlsRepository, tppRepository, resourceLinkService);
+    }
+
+    @Override
+    protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
+        final List<OBCallbackUrlResponseData1> callbackUrls =
+                frCallbackUrls.stream()
+                        .filter(
+                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_6.getCanonicalVersion())
+                        )
+                        .map(this::toOBCallbackUrlResponseData1)
+                        .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1()
+                        .callbackUrl(callbackUrls)
+                );
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.event.v3_1_6.callbackurl;
 
+import com.forgerock.openbanking.aspsp.rs.store.api.helper.EventsHelper;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_0.events.CallbackUrlsRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
@@ -43,16 +44,15 @@ public class CallbackUrlsApiController extends com.forgerock.openbanking.aspsp.r
 
     @Override
     protected OBCallbackUrlsResponse1 packageResponse(Collection<FRCallbackUrl1> frCallbackUrls) {
-        final List<OBCallbackUrlResponseData1> callbackUrls =
-                frCallbackUrls.stream()
-                        .filter(
-                                frCallbackUrl1 -> frCallbackUrl1.obCallbackUrl.getData().getVersion().equals(OBVersion.v3_1_6.getCanonicalVersion())
-                        )
-                        .map(this::toOBCallbackUrlResponseData1)
-                        .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1()
-                        .callbackUrl(callbackUrls)
+                        .callbackUrl(
+                                frCallbackUrls.stream()
+                                        .filter(
+                                                EventsHelper.matchingVersion(OBVersion.v3_1_6)
+                                        ).map(this::toOBCallbackUrlResponseData1)
+                                        .collect(Collectors.toList())
+                        )
                 );
     }
 }


### PR DESCRIPTION
- Fix Versioning of callbackURLs APIs
- versions: 3.0, 3.1, 3.1.1, 3.1.2, 3.1.3, 3.1.4, 3.1.5, 3.1.6
Part of [issue 238](https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/238)