### PR TITLE
Restored account data migration (#296)

### DIFF
--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountBeneficiaryConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountBeneficiaryConverter.java
@@ -97,6 +97,16 @@ public class FRAccountBeneficiaryConverter {
     }
 
     // OB to FR
+    public static FRAccountBeneficiary toFRAccountBeneficiary(OBBeneficiary3 beneficiary) {
+        return beneficiary == null ? null : FRAccountBeneficiary.builder()
+                .accountId(beneficiary.getAccountId())
+                .beneficiaryId(beneficiary.getBeneficiaryId())
+                .reference(beneficiary.getReference())
+                .creditorAgent(toFRFinancialAgent(beneficiary.getCreditorAgent()))
+                .creditorAccount(toFRAccountIdentifier(beneficiary.getCreditorAccount()))
+                .build();
+    }
+
     public static FRAccountBeneficiary toFRAccountBeneficiary(OBBeneficiary5 beneficiary) {
         return beneficiary == null ? null : FRAccountBeneficiary.builder()
                 .accountId(beneficiary.getAccountId())

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountServicerConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRAccountServicerConverter.java
@@ -105,6 +105,13 @@ public class FRAccountServicerConverter {
     }
 
     // OB to FR
+    public static FRAccountServicer toFRAccountServicer(OBBranchAndFinancialInstitutionIdentification5 servicer) {
+        return servicer == null ? null : FRAccountServicer.builder()
+                .schemeName(servicer.getSchemeName())
+                .identification(servicer.getIdentification())
+                .build();
+    }
+
     public static FRAccountServicer toFRAccountServicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
         return servicer == null ? null : FRAccountServicer.builder()
                 .schemeName(servicer.getSchemeName())

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRCashBalanceConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRCashBalanceConverter.java
@@ -92,7 +92,7 @@ public class FRCashBalanceConverter {
                 .collect(toList());
     }
 
-    private static FRCreditLine toFRCreditLine(OBCreditLine1 creditLine) {
+    public static FRCreditLine toFRCreditLine(OBCreditLine1 creditLine) {
         return creditLine == null ? null : FRCreditLine.builder()
                 .included(creditLine.isIncluded())
                 .type(toFRLimitType(creditLine.getType()))
@@ -100,7 +100,7 @@ public class FRCashBalanceConverter {
                 .build();
     }
 
-    private static FRCreditLine.FRLimitType toFRLimitType(OBExternalLimitType1Code type) {
+    public static FRCreditLine.FRLimitType toFRLimitType(OBExternalLimitType1Code type) {
         return type == null ? null : FRCreditLine.FRLimitType.valueOf(type.name());
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRCreditDebitIndicatorConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRCreditDebitIndicatorConverter.java
@@ -66,4 +66,8 @@ public class FRCreditDebitIndicatorConverter {
     public static FRCreditDebitIndicator toFRCreditDebitIndicator(OBStatementInterest2.CreditDebitIndicatorEnum indicator) {
         return indicator == null ? null : FRCreditDebitIndicator.valueOf(indicator.name());
     }
+
+    public static FRCreditDebitIndicator toFRCreditDebitIndicator(OBTransaction5.CreditDebitIndicatorEnum indicator) {
+        return indicator == null ? null : FRCreditDebitIndicator.valueOf(indicator.name());
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRDirectDebitConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRDirectDebitConverter.java
@@ -65,6 +65,18 @@ public class FRDirectDebitConverter {
     }
 
     // OB to FR
+    public static FRDirectDebitData toFRDirectDebitData(OBDirectDebit1 obDirectDebit) {
+        return obDirectDebit == null ? null : FRDirectDebitData.builder()
+                .accountId(obDirectDebit.getAccountId())
+                .directDebitId(obDirectDebit.getDirectDebitId())
+                .mandateIdentification(obDirectDebit.getMandateIdentification())
+                .directDebitStatusCode(toFRDirectDebitStatus(obDirectDebit.getDirectDebitStatusCode()))
+                .name(obDirectDebit.getName())
+                .previousPaymentDateTime(obDirectDebit.getPreviousPaymentDateTime())
+                .previousPaymentAmount(toFRAmount(obDirectDebit.getPreviousPaymentAmount()))
+                .build();
+    }
+
     public static FRDirectDebitData toFRDirectDebitData(OBReadDirectDebit2DataDirectDebit obDirectDebit) {
         return obDirectDebit == null ? null : FRDirectDebitData.builder()
                 .accountId(obDirectDebit.getAccountId())

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRFinancialAccountConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRFinancialAccountConverter.java
@@ -26,6 +26,7 @@ import com.forgerock.openbanking.common.services.openbanking.converter.common.FR
 import uk.org.openbanking.datamodel.account.*;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRAccountServicerConverter.toFRAccountServicer;
@@ -119,6 +120,19 @@ public class FRFinancialAccountConverter {
     }
 
     // OB to FR
+    public static FRFinancialAccount toFRFinancialAccount(OBAccount3 account) {
+        return account == null ? null : FRFinancialAccount.builder()
+                .accountId(account.getAccountId())
+                .currency(account.getCurrency())
+                .accountType(toFRAccountTypeCode(account.getAccountType()))
+                .accountSubType(toFRAccountSubTypeCode(account.getAccountSubType()))
+                .description(account.getDescription())
+                .nickname(account.getNickname())
+                .accounts(toFRAccountIdentifierList(account.getAccount(), FRAccountIdentifierConverter::toFRAccountIdentifier))
+                .servicer(toFRAccountServicer(account.getServicer()))
+                .build();
+    }
+
     public static FRFinancialAccount toFRFinancialAccount(OBAccount6 account) {
         return account == null ? null : FRFinancialAccount.builder()
                 .accountId(account.getAccountId())
@@ -131,7 +145,7 @@ public class FRFinancialAccountConverter {
                 .nickname(account.getNickname())
                 .openingDate(account.getOpeningDate())
                 .maturityDate(account.getMaturityDate())
-                .accounts(toFRAccountIdentifierList(account.getAccount()))
+                .accounts(toFRAccountIdentifierList(account.getAccount(), FRAccountIdentifierConverter::toFRAccountIdentifier))
                 .servicer(toFRAccountServicer(account.getServicer()))
                 .build();
     }
@@ -148,11 +162,9 @@ public class FRFinancialAccountConverter {
         return accountSubType == null ? null : FRFinancialAccount.FRAccountSubTypeCode.valueOf(accountSubType.name());
     }
 
-    public static List<FRAccountIdentifier> toFRAccountIdentifierList(List<OBAccount3Account> accounts) {
+    public static <T> List<FRAccountIdentifier> toFRAccountIdentifierList(List<T> accounts, Function<T, FRAccountIdentifier> converter) {
         return accounts == null ? null : accounts.stream()
-                .map(FRAccountIdentifierConverter::toFRAccountIdentifier)
+                .map(converter)
                 .collect(Collectors.toList());
     }
-
-
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRScheduledPaymentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRScheduledPaymentConverter.java
@@ -43,6 +43,19 @@ import static com.forgerock.openbanking.common.services.openbanking.converter.co
 public class FRScheduledPaymentConverter {
 
     // OB to FR
+    public static FRScheduledPaymentData toFRScheduledPaymentData(OBScheduledPayment2 scheduledPayment) {
+        return scheduledPayment == null ? null : FRScheduledPaymentData.builder()
+                .accountId(scheduledPayment.getAccountId())
+                .scheduledPaymentId(scheduledPayment.getScheduledPaymentId())
+                .scheduledPaymentDateTime(scheduledPayment.getScheduledPaymentDateTime())
+                .scheduledType(toFRScheduleType(scheduledPayment.getScheduledType()))
+                .reference(scheduledPayment.getReference())
+                .instructedAmount(toFRAmount(scheduledPayment.getInstructedAmount()))
+                .creditorAgent(toFRFinancialAgent(scheduledPayment.getCreditorAgent()))
+                .creditorAccount(toFRAccountIdentifier(scheduledPayment.getCreditorAccount()))
+                .build();
+    }
+
     public static FRScheduledPaymentData toFRScheduledPaymentData(OBScheduledPayment3 scheduledPayment) {
         return scheduledPayment == null ? null : FRScheduledPaymentData.builder()
                 .accountId(scheduledPayment.getAccountId())

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStandingOrderConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStandingOrderConverter.java
@@ -158,6 +158,25 @@ public class FRStandingOrderConverter {
     }
 
     // OB to FR
+    public static FRStandingOrderData toFRStandingOrderData(OBStandingOrder5 obStandingOrder) {
+        return obStandingOrder == null ? null : FRStandingOrderData.builder()
+                .accountId(obStandingOrder.getAccountId())
+                .standingOrderId(obStandingOrder.getStandingOrderId())
+                .frequency(obStandingOrder.getFrequency())
+                .reference(obStandingOrder.getReference())
+                .firstPaymentDateTime(obStandingOrder.getFirstPaymentDateTime())
+                .nextPaymentDateTime(obStandingOrder.getNextPaymentDateTime())
+                .finalPaymentDateTime(obStandingOrder.getFinalPaymentDateTime())
+                .standingOrderStatusCode(toFRStandingOrderStatus(obStandingOrder.getStandingOrderStatusCode()))
+                .firstPaymentAmount(toFRAmount(obStandingOrder.getFirstPaymentAmount()))
+                .nextPaymentAmount(toFRAmount(obStandingOrder.getNextPaymentAmount()))
+                .finalPaymentAmount(toFRAmount(obStandingOrder.getFinalPaymentAmount()))
+                .creditorAgent(toFRFinancialAgent(obStandingOrder.getCreditorAgent()))
+                .creditorAccount(toFRAccountIdentifier(obStandingOrder.getCreditorAccount()))
+                .supplementaryData(toFRSupplementaryData(obStandingOrder.getSupplementaryData()))
+                .build();
+    }
+
     public static FRStandingOrderData toFRStandingOrderData(OBStandingOrder6 obStandingOrder) {
         return obStandingOrder == null ? null : FRStandingOrderData.builder()
                 .accountId(obStandingOrder.getAccountId())

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStatementConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRStatementConverter.java
@@ -21,9 +21,18 @@
 package com.forgerock.openbanking.common.services.openbanking.converter.account;
 
 import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementAmount;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementBenefit;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementDateTime;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementFee;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementInterest;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementRate;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementType;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData.FRStatementValue;
 import uk.org.openbanking.datamodel.account.*;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRCreditDebitIndicatorConverter.toFRCreditDebitIndicator;
@@ -78,78 +87,78 @@ public class FRStatementConverter {
                 .statementAmount(toOBStatementAmount1List(frStatementData.getStatementAmounts()));
     }
 
-    public static OBExternalStatementType1Code toOBExternalStatementType1Code(FRStatementData.FRStatementType type) {
+    public static OBExternalStatementType1Code toOBExternalStatementType1Code(FRStatementType type) {
         return type == null ? null : OBExternalStatementType1Code.valueOf(type.name());
     }
 
-    public static List<OBStatementBenefit1> toOBStatementBenefit1List(List<FRStatementData.FRStatementBenefit> statementBenefit) {
+    public static List<OBStatementBenefit1> toOBStatementBenefit1List(List<FRStatementBenefit> statementBenefit) {
         return statementBenefit == null ? null : statementBenefit.stream()
                 .map(FRStatementConverter::toOBStatementBenefit1)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementFee1> toOBStatementFee1List(List<FRStatementData.FRStatementFee> statementFee) {
+    public static List<OBStatementFee1> toOBStatementFee1List(List<FRStatementFee> statementFee) {
         return statementFee == null ? null : statementFee.stream()
                 .map(FRStatementConverter::toOBStatementFee1)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementFee2> toOBStatementFee2List(List<FRStatementData.FRStatementFee> statementFee) {
+    public static List<OBStatementFee2> toOBStatementFee2List(List<FRStatementFee> statementFee) {
         return statementFee == null ? null : statementFee.stream()
                 .map(FRStatementConverter::toOBStatementFee2)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementInterest1> toOBStatementInterest1List(List<FRStatementData.FRStatementInterest> statementInterest) {
+    public static List<OBStatementInterest1> toOBStatementInterest1List(List<FRStatementInterest> statementInterest) {
         return statementInterest == null ? null : statementInterest.stream()
                 .map(FRStatementConverter::toOBStatementInterest1)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementInterest2> toOBStatementInterest2List(List<FRStatementData.FRStatementInterest> statementInterest) {
+    public static List<OBStatementInterest2> toOBStatementInterest2List(List<FRStatementInterest> statementInterest) {
         return statementInterest == null ? null : statementInterest.stream()
                 .map(FRStatementConverter::toOBStatementInterest2)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementDateTime1> toOBStatementDateTime1List(List<FRStatementData.FRStatementDateTime> statementDateTime) {
+    public static List<OBStatementDateTime1> toOBStatementDateTime1List(List<FRStatementDateTime> statementDateTime) {
         return statementDateTime == null ? null : statementDateTime.stream()
                 .map(FRStatementConverter::toOBStatementDateTime1)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementRate1> toOBStatementRate1List(List<FRStatementData.FRStatementRate> statementRate) {
+    public static List<OBStatementRate1> toOBStatementRate1List(List<FRStatementRate> statementRate) {
         return statementRate == null ? null : statementRate.stream()
                 .map(FRStatementConverter::toOBStatementRate1)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementValue1> toOBStatementValue1List(List<FRStatementData.FRStatementValue> statementValue) {
+    public static List<OBStatementValue1> toOBStatementValue1List(List<FRStatementValue> statementValue) {
         return statementValue == null ? null : statementValue.stream()
                 .map(FRStatementConverter::toOBStatementValue1)
                 .collect(Collectors.toList());
     }
 
-    public static List<OBStatementAmount1> toOBStatementAmount1List(List<FRStatementData.FRStatementAmount> statementAmount) {
+    public static List<OBStatementAmount1> toOBStatementAmount1List(List<FRStatementAmount> statementAmount) {
         return statementAmount == null ? null : statementAmount.stream()
                 .map(FRStatementConverter::toOBStatementAmount1)
                 .collect(Collectors.toList());
     }
 
-    public static OBStatementBenefit1 toOBStatementBenefit1(FRStatementData.FRStatementBenefit statementBenefit) {
+    public static OBStatementBenefit1 toOBStatementBenefit1(FRStatementBenefit statementBenefit) {
         return statementBenefit == null ? null : new OBStatementBenefit1()
                 .type(statementBenefit.getType())
                 .amount(toOBActiveOrHistoricCurrencyAndAmount(statementBenefit.getAmount()));
     }
 
-    public static OBStatementFee1 toOBStatementFee1(FRStatementData.FRStatementFee statementFee) {
+    public static OBStatementFee1 toOBStatementFee1(FRStatementFee statementFee) {
         return statementFee == null ? null : new OBStatementFee1()
                 .creditDebitIndicator(toOBCreditDebitCode(statementFee.getCreditDebitIndicator()))
                 .type(statementFee.getType())
                 .amount(toOBActiveOrHistoricCurrencyAndAmount(statementFee.getAmount()));
     }
 
-    private static OBStatementFee2 toOBStatementFee2(FRStatementData.FRStatementFee statementFee) {
+    public static OBStatementFee2 toOBStatementFee2(FRStatementFee statementFee) {
         return statementFee == null ? null : new OBStatementFee2()
                 .description(statementFee.getDescription())
                 .creditDebitIndicator(toOBStatementFee2CreditDebitIndicatorEnum(statementFee.getCreditDebitIndicator()))
@@ -160,14 +169,14 @@ public class FRStatementConverter {
                 .amount(toAccountOBActiveOrHistoricCurrencyAndAmount(statementFee.getAmount()));
     }
 
-    public static OBStatementInterest1 toOBStatementInterest1(FRStatementData.FRStatementInterest statementInterest) {
+    public static OBStatementInterest1 toOBStatementInterest1(FRStatementInterest statementInterest) {
         return statementInterest == null ? null : new OBStatementInterest1()
                 .creditDebitIndicator(toOBCreditDebitCode(statementInterest.getCreditDebitIndicator()))
                 .type(statementInterest.getType())
                 .amount(toOBActiveOrHistoricCurrencyAndAmount(statementInterest.getAmount()));
     }
 
-    private static OBStatementInterest2 toOBStatementInterest2(FRStatementData.FRStatementInterest statementInterest) {
+    public static OBStatementInterest2 toOBStatementInterest2(FRStatementInterest statementInterest) {
         return statementInterest == null ? null : new OBStatementInterest2()
                 .description(statementInterest.getDescription())
                 .creditDebitIndicator(toOBStatementInterest2CreditDebitIndicatorEnum(statementInterest.getCreditDebitIndicator()))
@@ -178,25 +187,25 @@ public class FRStatementConverter {
                 .amount(toAccountOBActiveOrHistoricCurrencyAndAmount(statementInterest.getAmount()));
     }
 
-    public static OBStatementDateTime1 toOBStatementDateTime1(FRStatementData.FRStatementDateTime statementDateTime) {
+    public static OBStatementDateTime1 toOBStatementDateTime1(FRStatementDateTime statementDateTime) {
         return statementDateTime == null ? null : new OBStatementDateTime1()
                 .dateTime(statementDateTime.getDateTime())
                 .type(statementDateTime.getType());
     }
 
-    public static OBStatementRate1 toOBStatementRate1(FRStatementData.FRStatementRate statementRate) {
+    public static OBStatementRate1 toOBStatementRate1(FRStatementRate statementRate) {
         return statementRate == null ? null : new OBStatementRate1()
                 .rate(statementRate.getRate())
                 .type(statementRate.getType());
     }
 
-    public static OBStatementValue1 toOBStatementValue1(FRStatementData.FRStatementValue statementValue) {
+    public static OBStatementValue1 toOBStatementValue1(FRStatementValue statementValue) {
         return statementValue == null ? null : new OBStatementValue1()
                 .value(statementValue.getValue())
                 .type(statementValue.getType());
     }
 
-    public static OBStatementAmount1 toOBStatementAmount1(FRStatementData.FRStatementAmount statementAmount) {
+    public static OBStatementAmount1 toOBStatementAmount1(FRStatementAmount statementAmount) {
         return statementAmount == null ? null : new OBStatementAmount1()
                 .creditDebitIndicator(toOBCreditDebitCode(statementAmount.getCreditDebitIndicator()))
                 .type(statementAmount.getType())
@@ -204,6 +213,26 @@ public class FRStatementConverter {
     }
 
     // OB to FR
+    public static FRStatementData toFRStatementData(OBStatement1 obStatement) {
+        return obStatement == null ? null : FRStatementData.builder()
+                .accountId(obStatement.getAccountId())
+                .statementId(obStatement.getStatementId())
+                .statementReference(obStatement.getStatementReference())
+                .type(toFRStatementType(obStatement.getType()))
+                .startDateTime(obStatement.getStartDateTime())
+                .endDateTime(obStatement.getEndDateTime())
+                .creationDateTime(obStatement.getCreationDateTime())
+                .statementDescriptions(obStatement.getStatementDescription())
+                .statementBenefits(toStatementBenefitsList(obStatement.getStatementBenefit()))
+                .statementFees(toStatementFeesList(obStatement.getStatementFee(), FRStatementConverter::toFRStatementFee))
+                .statementInterests(toStatementInterestsList(obStatement.getStatementInterest(), FRStatementConverter::toFRStatementInterest))
+                .statementDateTimes(toStatementDateTimesList(obStatement.getStatementDateTime()))
+                .statementRates(toStatementRatesList(obStatement.getStatementRate()))
+                .statementValues(toStatementValuesList(obStatement.getStatementValue()))
+                .statementAmounts(toStatementAmountsList(obStatement.getStatementAmount()))
+                .build();
+    }
+
     public static FRStatementData toFRStatementData(OBStatement2 obStatement) {
         return obStatement == null ? null : FRStatementData.builder()
                 .accountId(obStatement.getAccountId())
@@ -215,8 +244,8 @@ public class FRStatementConverter {
                 .creationDateTime(obStatement.getCreationDateTime())
                 .statementDescriptions(obStatement.getStatementDescription())
                 .statementBenefits(toStatementBenefitsList(obStatement.getStatementBenefit()))
-                .statementFees(toStatementFeesList(obStatement.getStatementFee()))
-                .statementInterests(toStatementInterestsList(obStatement.getStatementInterest()))
+                .statementFees(toStatementFeesList(obStatement.getStatementFee(), FRStatementConverter::toFRStatementFee))
+                .statementInterests(toStatementInterestsList(obStatement.getStatementInterest(), FRStatementConverter::toFRStatementInterest))
                 .statementDateTimes(toStatementDateTimesList(obStatement.getStatementDateTime()))
                 .statementRates(toStatementRatesList(obStatement.getStatementRate()))
                 .statementValues(toStatementValuesList(obStatement.getStatementValue()))
@@ -224,61 +253,69 @@ public class FRStatementConverter {
                 .build();
     }
 
-    public static FRStatementData.FRStatementType toFRStatementType(OBExternalStatementType1Code type) {
-        return type == null ? null : FRStatementData.FRStatementType.valueOf(type.name());
+    public static FRStatementType toFRStatementType(OBExternalStatementType1Code type) {
+        return type == null ? null : FRStatementType.valueOf(type.name());
     }
 
-    public static List<FRStatementData.FRStatementBenefit> toStatementBenefitsList(List<OBStatementBenefit1> statementBenefit) {
+    public static List<FRStatementBenefit> toStatementBenefitsList(List<OBStatementBenefit1> statementBenefit) {
         return statementBenefit == null ? null : statementBenefit.stream()
                 .map(FRStatementConverter::toFRStatementBenefit)
                 .collect(Collectors.toList());
     }
 
-    private static List<FRStatementData.FRStatementFee> toStatementFeesList(List<OBStatementFee2> statementFee) {
+    public static <T> List<FRStatementFee> toStatementFeesList(List<T> statementFee, Function<T, FRStatementFee> converter) {
         return statementFee == null ? null : statementFee.stream()
-                .map(FRStatementConverter::toFRStatementFee)
+                .map(converter)
                 .collect(Collectors.toList());
     }
 
-    private static List<FRStatementData.FRStatementInterest> toStatementInterestsList(List<OBStatementInterest2> statementInterest) {
+    public static <T> List<FRStatementInterest> toStatementInterestsList(List<T> statementInterest, Function<T, FRStatementInterest> converter) {
         return statementInterest == null ? null : statementInterest.stream()
-                .map(FRStatementConverter::toFRStatementInterest)
+                .map(converter)
                 .collect(Collectors.toList());
     }
 
-    private static List<FRStatementData.FRStatementDateTime> toStatementDateTimesList(List<OBStatementDateTime1> statementDateTime) {
+    public static List<FRStatementDateTime> toStatementDateTimesList(List<OBStatementDateTime1> statementDateTime) {
         return statementDateTime == null ? null : statementDateTime.stream()
                 .map(FRStatementConverter::toFRStatementDateTime)
                 .collect(Collectors.toList());
     }
 
-    private static List<FRStatementData.FRStatementRate> toStatementRatesList(List<OBStatementRate1> statementRate) {
+    public static List<FRStatementRate> toStatementRatesList(List<OBStatementRate1> statementRate) {
         return statementRate == null ? null : statementRate.stream()
                 .map(FRStatementConverter::toFRStatementRate)
                 .collect(Collectors.toList());
     }
 
-    private static List<FRStatementData.FRStatementValue> toStatementValuesList(List<OBStatementValue1> statementValue) {
+    public static List<FRStatementValue> toStatementValuesList(List<OBStatementValue1> statementValue) {
         return statementValue == null ? null : statementValue.stream()
                 .map(FRStatementConverter::toFRStatementValue)
                 .collect(Collectors.toList());
     }
 
-    private static List<FRStatementData.FRStatementAmount> toStatementAmountsList(List<OBStatementAmount1> statementAmount) {
+    public static List<FRStatementAmount> toStatementAmountsList(List<OBStatementAmount1> statementAmount) {
         return statementAmount == null ? null : statementAmount.stream()
                 .map(FRStatementConverter::toFRStatementAmount)
                 .collect(Collectors.toList());
     }
 
-    public static FRStatementData.FRStatementBenefit toFRStatementBenefit(OBStatementBenefit1 statementBenefit) {
-        return statementBenefit == null ? null : FRStatementData.FRStatementBenefit.builder()
+    public static FRStatementBenefit toFRStatementBenefit(OBStatementBenefit1 statementBenefit) {
+        return statementBenefit == null ? null : FRStatementBenefit.builder()
                 .type(statementBenefit.getType())
                 .amount(toFRAmount(statementBenefit.getAmount()))
                 .build();
     }
 
-    public static FRStatementData.FRStatementFee toFRStatementFee(OBStatementFee2 statementFee) {
-        return statementFee == null ? null : FRStatementData.FRStatementFee.builder()
+    public static FRStatementFee toFRStatementFee(OBStatementFee1 statementFee) {
+        return statementFee == null ? null : FRStatementFee.builder()
+                .creditDebitIndicator(toFRCreditDebitIndicator(statementFee.getCreditDebitIndicator()))
+                .type(statementFee.getType())
+                .amount(toFRAmount(statementFee.getAmount()))
+                .build();
+    }
+
+    public static FRStatementFee toFRStatementFee(OBStatementFee2 statementFee) {
+        return statementFee == null ? null : FRStatementFee.builder()
                 .description(statementFee.getDescription())
                 .creditDebitIndicator(toFRCreditDebitIndicator(statementFee.getCreditDebitIndicator()))
                 .type(statementFee.getType())
@@ -289,8 +326,16 @@ public class FRStatementConverter {
                 .build();
     }
 
-    public static FRStatementData.FRStatementInterest toFRStatementInterest(OBStatementInterest2 statementInterest) {
-        return statementInterest == null ? null : FRStatementData.FRStatementInterest.builder()
+    public static FRStatementInterest toFRStatementInterest(OBStatementInterest1 statementInterest) {
+        return statementInterest == null ? null : FRStatementInterest.builder()
+                .creditDebitIndicator(toFRCreditDebitIndicator(statementInterest.getCreditDebitIndicator()))
+                .type(statementInterest.getType())
+                .amount(toFRAmount(statementInterest.getAmount()))
+                .build();
+    }
+
+    public static FRStatementInterest toFRStatementInterest(OBStatementInterest2 statementInterest) {
+        return statementInterest == null ? null : FRStatementInterest.builder()
                 .description(statementInterest.getDescription())
                 .creditDebitIndicator(toFRCreditDebitIndicator(statementInterest.getCreditDebitIndicator()))
                 .type(statementInterest.getType())
@@ -301,29 +346,29 @@ public class FRStatementConverter {
                 .build();
     }
 
-    public static FRStatementData.FRStatementDateTime toFRStatementDateTime(OBStatementDateTime1 statementDateTime) {
-        return statementDateTime == null ? null : FRStatementData.FRStatementDateTime.builder()
+    public static FRStatementDateTime toFRStatementDateTime(OBStatementDateTime1 statementDateTime) {
+        return statementDateTime == null ? null : FRStatementDateTime.builder()
                 .dateTime(statementDateTime.getDateTime())
                 .type(statementDateTime.getType())
                 .build();
     }
 
-    public static FRStatementData.FRStatementRate toFRStatementRate(OBStatementRate1 statementRate) {
-        return statementRate == null ? null : FRStatementData.FRStatementRate.builder()
+    public static FRStatementRate toFRStatementRate(OBStatementRate1 statementRate) {
+        return statementRate == null ? null : FRStatementRate.builder()
                 .rate(statementRate.getRate())
                 .type(statementRate.getType())
                 .build();
     }
 
-    public static FRStatementData.FRStatementValue toFRStatementValue(OBStatementValue1 statementValue) {
-        return statementValue == null ? null : FRStatementData.FRStatementValue.builder()
+    public static FRStatementValue toFRStatementValue(OBStatementValue1 statementValue) {
+        return statementValue == null ? null : FRStatementValue.builder()
                 .value(statementValue.getValue())
                 .type(statementValue.getType())
                 .build();
     }
 
-    public static FRStatementData.FRStatementAmount toFRStatementAmount(OBStatementAmount1 statementAmount) {
-        return statementAmount == null ? null : FRStatementData.FRStatementAmount.builder()
+    public static FRStatementAmount toFRStatementAmount(OBStatementAmount1 statementAmount) {
+        return statementAmount == null ? null : FRStatementAmount.builder()
                 .creditDebitIndicator(toFRCreditDebitIndicator(statementAmount.getCreditDebitIndicator()))
                 .type(statementAmount.getType())
                 .amount(toFRAmount(statementAmount.getAmount()))

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRTransactionConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/account/FRTransactionConverter.java
@@ -265,6 +265,34 @@ public class FRTransactionConverter {
     }
 
     // OB to FR
+    public static FRTransactionData toFRTransactionData(OBTransaction5 transaction) {
+        return transaction == null ? null : FRTransactionData.builder()
+                .accountId(transaction.getAccountId())
+                .transactionId(transaction.getTransactionId())
+                .transactionReference(transaction.getTransactionReference())
+                .statementReferences(transaction.getStatementReference())
+                .creditDebitIndicator(toFRCreditDebitIndicator(transaction.getCreditDebitIndicator()))
+                .status(toFREntryStatus(transaction.getStatus()))
+                .bookingDateTime(transaction.getBookingDateTime())
+                .valueDateTime(transaction.getValueDateTime())
+                .addressLine(transaction.getAddressLine())
+                .amount(toFRAmount(transaction.getAmount()))
+                .chargeAmount(toFRAmount(transaction.getChargeAmount()))
+                .currencyExchange(toFRCurrencyExchange(transaction.getCurrencyExchange()))
+                .bankTransactionCode(toFRBankTransactionCodeStructure(transaction.getBankTransactionCode()))
+                .proprietaryBankTransactionCode(toFRProprietaryBankTransactionCodeStructure(transaction.getProprietaryBankTransactionCode()))
+                .cardInstrument(toFRTransactionCardInstrument(transaction.getCardInstrument()))
+                .supplementaryData(toFRSupplementaryData(transaction.getSupplementaryData()))
+                .transactionInformation(transaction.getTransactionInformation())
+                .balance(toFRTransactionCashBalance(transaction.getBalance()))
+                .merchantDetails(toFRMerchantDetails(transaction.getMerchantDetails()))
+                .creditorAgent(toFRFinancialAgent(transaction.getCreditorAgent()))
+                .creditorAccount(toFRAccountIdentifier(transaction.getCreditorAccount()))
+                .debtorAgent(toFRFinancialAgent(transaction.getDebtorAgent()))
+                .debtorAccount(toFRAccountIdentifier(transaction.getDebtorAccount()))
+                .build();
+    }
+
     public static FRTransactionData toFRTransactionData(OBTransaction6 transaction) {
         return transaction == null ? null : FRTransactionData.builder()
                 .accountId(transaction.getAccountId())
@@ -295,17 +323,24 @@ public class FRTransactionConverter {
     }
 
     public static FRTransactionData.FREntryStatus toFREntryStatus(OBEntryStatus1Code status) {
-       return status == null ? null : FRTransactionData.FREntryStatus.valueOf(status.name());
+        return status == null ? null : FRTransactionData.FREntryStatus.valueOf(status.name());
     }
 
     public static FRTransactionData.FRTransactionMutability toFRTransactionMutability(OBTransactionMutability1Code transactionMutability) {
-       return transactionMutability == null ? null : FRTransactionData.FRTransactionMutability.valueOf(transactionMutability.name());
+        return transactionMutability == null ? null : FRTransactionData.FRTransactionMutability.valueOf(transactionMutability.name());
     }
 
     public static FRBankTransactionCodeStructure toFRBankTransactionCodeStructure(OBBankTransactionCodeStructure1 transactionCode) {
         return transactionCode == null ? null : FRBankTransactionCodeStructure.builder()
                 .code(transactionCode.getCode())
                 .subCode(transactionCode.getSubCode())
+                .build();
+    }
+
+    private static FRProprietaryBankTransactionCodeStructure toFRProprietaryBankTransactionCodeStructure(OBTransaction5ProprietaryBankTransactionCode proprietaryTransactionCode) {
+        return proprietaryTransactionCode == null ? null : FRProprietaryBankTransactionCodeStructure.builder()
+                .code(proprietaryTransactionCode.getCode())
+                .issuer(proprietaryTransactionCode.getIssuer())
                 .build();
     }
 
@@ -330,17 +365,6 @@ public class FRTransactionConverter {
                 .merchantCategoryCode(merchantDetails.getMerchantCategoryCode())
                 .build();
     }
-
-
-
-
-
-
-
-
-
-
-
 
 
     public static FRTransactionData.FRTransactionCardInstrument toFRTransactionCardInstrument(OBTransactionCardInstrument1 cardInstrument) {

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/common/FRAccountIdentifierConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/common/FRAccountIdentifierConverter.java
@@ -32,6 +32,10 @@ public class FRAccountIdentifierConverter {
         return FRModelMapper.map(account, FRAccountIdentifier.class);
     }
 
+    public static FRAccountIdentifier toFRAccountIdentifier(OBCashAccount6 account) {
+        return FRModelMapper.map(account, FRAccountIdentifier.class);
+    }
+
     public static FRAccountIdentifier toFRAccountIdentifier(OBCashAccount51 account) {
         return FRModelMapper.map(account, FRAccountIdentifier.class);
     }
@@ -186,6 +190,15 @@ public class FRAccountIdentifierConverter {
 
     // OB to FR
     public static FRAccountIdentifier toFRAccountIdentifier(OBAccount3Account account) {
+        return account == null ? null : FRAccountIdentifier.builder()
+                .schemeName(account.getSchemeName())
+                .identification(account.getIdentification())
+                .name(account.getName())
+                .secondaryIdentification(account.getSecondaryIdentification())
+                .build();
+    }
+
+    public static FRAccountIdentifier toFRAccountIdentifier(OBCashAccount5 account) {
         return account == null ? null : FRAccountIdentifier.builder()
                 .schemeName(account.getSchemeName())
                 .identification(account.getIdentification())

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/common/FRFinancialInstrumentConverter.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/converter/common/FRFinancialInstrumentConverter.java
@@ -66,7 +66,23 @@ public class FRFinancialInstrumentConverter {
                 .build();
     }
 
+    public static FRFinancialAgent toFRFinancialAgent(OBBranchAndFinancialInstitutionIdentification5 agent) {
+        return agent == null ? null : FRFinancialAgent.builder()
+                .schemeName(agent.getSchemeName())
+                .identification(agent.getIdentification())
+                .build();
+    }
+
     public static FRFinancialAgent toFRFinancialAgent(OBBranchAndFinancialInstitutionIdentification6 agent) {
+        return agent == null ? null : FRFinancialAgent.builder()
+                .schemeName(agent.getSchemeName())
+                .identification(agent.getIdentification())
+                .name(agent.getName())
+                .postalAddress(toFRPostalAddress(agent.getPostalAddress()))
+                .build();
+    }
+
+    public static FRFinancialAgent toFRFinancialAgent(uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification6 agent) {
         return agent == null ? null : FRFinancialAgent.builder()
                 .schemeName(agent.getSchemeName())
                 .identification(agent.getIdentification())

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRAccount3.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRAccount3.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts;
+
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.Account;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBAccount3;
+
+import java.util.Date;
+
+/**
+ * This class exists purely for migration purposes and should be removed once all clusters have been upgraded to a release of openbanking-reference-implementation
+ * containing v3.1.5 (currently REM).
+ *
+ * <p>
+ * Note that Prior to extensive refactoring, there were a series of these "FR" mongo document classes that were named in sequence (e.g. FRAccount2,
+ * FRAccount3 etc.). The sequence number was incremented each time there was a new version of the OB model objects they contained. Instead of this, there
+ * is now one FR document class (e.g. FRAccount) for each corresponding area of the payments API. Each one contains our own "domain" model object, rather
+ * than the OB model ones. This means that if a new OB release adds new fields to an OB object, the fields only need to be added to the our domain objects
+ * (and mapped accordingly). There should be no need to create a new version of the "FR" mongo documents and corresponding repositories.
+ * </p>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document
+@Deprecated
+public class FRAccount3 implements Account {
+
+    @Id
+    @Indexed
+    public String id;
+    @Indexed
+    public String userID;
+    public OBAccount3 account; // needs migrating to OBAccount6
+    @Indexed
+    public String latestStatementId;
+
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRBeneficiary3.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRBeneficiary3.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBBeneficiary3;
+
+import java.util.Date;
+
+/**
+ * This class exists purely for migration purposes and should be removed once all clusters have been upgraded to a release of openbanking-reference-implementation
+ * containing v3.1.5 (currently REM).
+ *
+ * <p>
+ * Note that Prior to extensive refactoring, there were a series of these "FR" mongo document classes that were named in sequence (e.g. FRAccount2,
+ * FRAccount3 etc.). The sequence number was incremented each time there was a new version of the OB model objects they contained. Instead of this, there
+ * is now one FR document class (e.g. FRAccount) for each corresponding area of the payments API. Each one contains our own "domain" model object, rather
+ * than the OB model ones. This means that if a new OB release adds new fields to an OB object, the fields only need to be added to the our domain objects
+ * (and mapped accordingly). There should be no need to create a new version of the "FR" mongo documents and corresponding repositories.
+ * </p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+@Deprecated
+public class FRBeneficiary3 {
+
+    @Id
+    @Indexed
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBBeneficiary3 beneficiary;
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRDirectDebit1.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRDirectDebit1.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBDirectDebit1;
+
+import java.util.Date;
+
+/**
+ * This class exists purely for migration purposes and should be removed once all clusters have been upgraded to a release of openbanking-reference-implementation
+ * containing v3.1.5 (currently REM).
+ *
+ * <p>
+ * Note that Prior to extensive refactoring, there were a series of these "FR" mongo document classes that were named in sequence (e.g. FRAccount2,
+ * FRAccount3 etc.). The sequence number was incremented each time there was a new version of the OB model objects they contained. Instead of this, there
+ * is now one FR document class (e.g. FRAccount) for each corresponding area of the payments API. Each one contains our own "domain" model object, rather
+ * than the OB model ones. This means that if a new OB release adds new fields to an OB object, the fields only need to be added to the our domain objects
+ * (and mapped accordingly). There should be no need to create a new version of the "FR" mongo documents and corresponding repositories.
+ * </p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+@Deprecated
+public class FRDirectDebit1 {
+
+    @Id
+    @Indexed
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBDirectDebit1 directDebit; // needs migrating to OBReadDirectDebit2DataDirectDebit
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+}
+

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRScheduledPayment2.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRScheduledPayment2.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts;
+
+import com.forgerock.openbanking.common.model.openbanking.status.ScheduledPaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBScheduledPayment2;
+
+import java.util.Date;
+
+/**
+ * This class exists purely for migration purposes and should be removed once all clusters have been upgraded to a release of openbanking-reference-implementation
+ * containing v3.1.5 (currently REM).
+ *
+ * <p>
+ * Note that Prior to extensive refactoring, there were a series of these "FR" mongo document classes that were named in sequence (e.g. FRAccount2,
+ * FRAccount3 etc.). The sequence number was incremented each time there was a new version of the OB model objects they contained. Instead of this, there
+ * is now one FR document class (e.g. FRAccount) for each corresponding area of the payments API. Each one contains our own "domain" model object, rather
+ * than the OB model ones. This means that if a new OB release adds new fields to an OB object, the fields only need to be added to the our domain objects
+ * (and mapped accordingly). There should be no need to create a new version of the "FR" mongo documents and corresponding repositories.
+ * </p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+@Deprecated
+public class FRScheduledPayment2 {
+
+    @Id
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBScheduledPayment2 scheduledPayment;
+
+    @Indexed
+    public String pispId;
+
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+    public String rejectionReason;
+
+    public ScheduledPaymentStatus status;
+}
+

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRStandingOrder5.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRStandingOrder5.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts;
+
+import com.forgerock.openbanking.common.model.openbanking.status.StandingOrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBStandingOrder5;
+
+import java.util.Date;
+
+/**
+ * This class exists purely for migration purposes and should be removed once all clusters have been upgraded to a release of openbanking-reference-implementation
+ * containing v3.1.5 (currently REM).
+ *
+ * <p>
+ * Note that Prior to extensive refactoring, there were a series of these "FR" mongo document classes that were named in sequence (e.g. FRAccount2,
+ * FRAccount3 etc.). The sequence number was incremented each time there was a new version of the OB model objects they contained. Instead of this, there
+ * is now one FR document class (e.g. FRAccount) for each corresponding area of the payments API. Each one contains our own "domain" model object, rather
+ * than the OB model ones. This means that if a new OB release adds new fields to an OB object, the fields only need to be added to the our domain objects
+ * (and mapped accordingly). There should be no need to create a new version of the "FR" mongo documents and corresponding repositories.
+ * </p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+@Deprecated
+public class FRStandingOrder5 {
+
+    @Id
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBStandingOrder5 standingOrder;
+
+    @Indexed
+    public String pispId;
+
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+    public String rejectionReason;
+
+    public StandingOrderStatus status;
+
+}
+

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRStatement1.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRStatement1.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBStatement1;
+import uk.org.openbanking.jackson.DateTimeDeserializer;
+import uk.org.openbanking.jackson.DateTimeSerializer;
+
+import java.util.Date;
+
+/**
+ * This class exists purely for migration purposes and should be removed once all clusters have been upgraded to a release of openbanking-reference-implementation
+ * containing v3.1.5 (currently REM).
+ *
+ * <p>
+ * Note that Prior to extensive refactoring, there were a series of these "FR" mongo document classes that were named in sequence (e.g. FRAccount2,
+ * FRAccount3 etc.). The sequence number was incremented each time there was a new version of the OB model objects they contained. Instead of this, there
+ * is now one FR document class (e.g. FRAccount) for each corresponding area of the payments API. Each one contains our own "domain" model object, rather
+ * than the OB model ones. This means that if a new OB release adds new fields to an OB object, the fields only need to be added to the our domain objects
+ * (and mapped accordingly). There should be no need to create a new version of the "FR" mongo documents and corresponding repositories.
+ * </p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+@Deprecated
+public class FRStatement1 {
+
+    @Id
+    public String id;
+    @Indexed
+    public String accountId;
+    public OBStatement1 statement;
+    @JsonDeserialize(using = DateTimeDeserializer.class)
+    @JsonSerialize(using = DateTimeSerializer.class)
+    private DateTime startDateTime = null;
+    private DateTime endDateTime = null;
+
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRTransaction5.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/legacy/accounts/FRTransaction5.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.org.openbanking.datamodel.account.OBTransaction5;
+import uk.org.openbanking.jackson.DateTimeDeserializer;
+import uk.org.openbanking.jackson.DateTimeSerializer;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This class exists purely for migration purposes and should be removed once all clusters have been upgraded to a release of openbanking-reference-implementation
+ * containing v3.1.5 (currently REM).
+ *
+ * <p>
+ * Note that Prior to extensive refactoring, there were a series of these "FR" mongo document classes that were named in sequence (e.g. FRAccount2,
+ * FRAccount3 etc.). The sequence number was incremented each time there was a new version of the OB model objects they contained. Instead of this, there
+ * is now one FR document class (e.g. FRAccount) for each corresponding area of the payments API. Each one contains our own "domain" model object, rather
+ * than the OB model ones. This means that if a new OB release adds new fields to an OB object, the fields only need to be added to the our domain objects
+ * (and mapped accordingly). There should be no need to create a new version of the "FR" mongo documents and corresponding repositories.
+ * </p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+@Deprecated
+public class FRTransaction5 {
+
+    @Id
+    public String id;
+    @Indexed
+    public String accountId;
+    public List<String> statementIds;
+    public OBTransaction5 transaction;
+    @CreatedDate
+    public Date created;
+    @LastModifiedDate
+    public Date updated;
+
+    @JsonDeserialize(using = DateTimeDeserializer.class)
+    @JsonSerialize(using = DateTimeSerializer.class)
+    private DateTime bookingDateTime = null;
+
+    public FRTransaction5 addStatementId(String statementId) {
+        if (statementIds==null) {
+            statementIds = new ArrayList<>();
+        }
+        this.statementIds.add(statementId);
+        return this;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbAccountsChangeLog.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbAccountsChangeLog.java
@@ -20,10 +20,28 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
 
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRAccount3;
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRBeneficiary3;
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRDirectDebit1;
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRScheduledPayment2;
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRStandingOrder5;
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRStatement1;
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRTransaction5;
 import com.github.mongobee.changeset.ChangeLog;
 import com.github.mongobee.changeset.ChangeSet;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.util.CloseableIterator;
+
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.getLegacyDocuments;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.migrate;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account.FRAccountMigrator.toFRAccount;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account.FRBeneficiaryMigrator.toFRBeneficiary;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account.FRDirectDebitMigrator.toFRDirectDebit;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account.FRScheduledPaymentMigrator.toFRScheduledPayment;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account.FRStandingOrderMigrator.toFRStandingOrder;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account.FRStatementMigrator.toFRStatement;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account.FRTransactionMigrator.toFRTransaction;
 
 @ChangeLog
 @Slf4j
@@ -33,27 +51,26 @@ public class MongoDbAccountsChangeLog {
     public void migrateAccountDocuments(MongoTemplate mongoTemplate) {
         log.info("Migrating accounts API data from v3.1.2 to v3.1.6...");
 
-        // TODO #296 - add legacy account objects to legacy.accounts package (and deprecate them)
-//        CloseableIterator<FRAccount3> frAccounts = getLegacyDocuments(mongoTemplate, FRAccount3.class);
-//        frAccounts.forEachRemaining(f -> migrate(mongoTemplate, f, toAccount4(f)));
-//
-//        CloseableIterator<FRBeneficiary3> frBeneficiaries = getLegacyDocuments(mongoTemplate, FRBeneficiary3.class);
-//        frBeneficiaries.forEachRemaining(f -> migrate(mongoTemplate, f, toFRBeneficiary5(f)));
-//
-//        CloseableIterator<FRStandingOrder5> frStandingOrders = getLegacyDocuments(mongoTemplate, FRStandingOrder5.class);
-//        frStandingOrders.forEachRemaining(f -> migrate(mongoTemplate, f, toFRStandingOrder6(f)));
-//
-//        CloseableIterator<FRTransaction5> frTransactionsIterator = getLegacyDocuments(mongoTemplate, FRTransaction5.class);
-//        frTransactionsIterator.forEachRemaining(f -> migrate(mongoTemplate, f, toFRTransaction6(f)));
-//
-//        CloseableIterator<FRStatement1> frStatements = getLegacyDocuments(mongoTemplate, FRStatement1.class);
-//        frStatements.forEachRemaining(f -> migrate(mongoTemplate, f, toFRStatement4(f)));
-//
-//        CloseableIterator<FRScheduledPayment2> frScheduledPayments = getLegacyDocuments(mongoTemplate, FRScheduledPayment2.class);
-//        frScheduledPayments.forEachRemaining(f -> migrate(mongoTemplate, f, toFRScheduledPayment4(f)));
-//
-//        CloseableIterator<FRDirectDebit1> frDirectDebits = getLegacyDocuments(mongoTemplate, FRDirectDebit1.class);
-//        frDirectDebits.forEachRemaining(f -> migrate(mongoTemplate, f, toFRDirectDebit4(f)));
+        CloseableIterator<FRAccount3> frAccounts = getLegacyDocuments(mongoTemplate, FRAccount3.class);
+        frAccounts.forEachRemaining(f -> migrate(mongoTemplate, f, toFRAccount(f)));
+
+        CloseableIterator<FRBeneficiary3> frBeneficiaries = getLegacyDocuments(mongoTemplate, FRBeneficiary3.class);
+        frBeneficiaries.forEachRemaining(f -> migrate(mongoTemplate, f, toFRBeneficiary(f)));
+
+        CloseableIterator<FRStandingOrder5> frStandingOrders = getLegacyDocuments(mongoTemplate, FRStandingOrder5.class);
+        frStandingOrders.forEachRemaining(f -> migrate(mongoTemplate, f, toFRStandingOrder(f)));
+
+        CloseableIterator<FRTransaction5> frTransactionsIterator = getLegacyDocuments(mongoTemplate, FRTransaction5.class);
+        frTransactionsIterator.forEachRemaining(f -> migrate(mongoTemplate, f, toFRTransaction(f)));
+
+        CloseableIterator<FRStatement1> frStatements = getLegacyDocuments(mongoTemplate, FRStatement1.class);
+        frStatements.forEachRemaining(f -> migrate(mongoTemplate, f, toFRStatement(f)));
+
+        CloseableIterator<FRScheduledPayment2> frScheduledPayments = getLegacyDocuments(mongoTemplate, FRScheduledPayment2.class);
+        frScheduledPayments.forEachRemaining(f -> migrate(mongoTemplate, f, toFRScheduledPayment(f)));
+
+        CloseableIterator<FRDirectDebit1> frDirectDebits = getLegacyDocuments(mongoTemplate, FRDirectDebit1.class);
+        frDirectDebits.forEachRemaining(f -> migrate(mongoTemplate, f, toFRDirectDebit(f)));
 
         log.info("Finished migrating accounts API data from v3.1.2 to v3.1.6");
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbPaymentsChangeLog.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/MongoDbPaymentsChangeLog.java
@@ -29,16 +29,16 @@ import org.springframework.data.util.CloseableIterator;
 
 import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.getLegacyDocuments;
 import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.MigrationHelper.migrate;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRDomesticConsentConverter.toFRDomesticConsent;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRDomesticScheduledConsentConverter.toFRDomesticScheduledConsent;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRDomesticStandingOrderConsentConverter.toFRDomesticStandingOrderConsent;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRFileConsentConverter.toFRFileConsent;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRInternationalConsentConverter.toFRInternationalConsent;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRInternationalScheduledConsentConverter.toFRInternationalScheduledConsent;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRInternationalStandingOrderConsentConverter.toFRInternationalStandingOrderConsent;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRInternationalPaymentSubmissionConverter.toFRInternationalPaymentSubmission;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRInternationalScheduledPaymentSubmissionConverter.toFRInternationalScheduledPaymentSubmission;
-import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.FRInternationalStandingOrderPaymentSubmissionConverter.toFRInternationalStandingOrderPaymentSubmission;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRDomesticConsentMigrator.toFRDomesticConsent;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRDomesticScheduledConsentMigrator.toFRDomesticScheduledConsent;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRDomesticStandingOrderConsentMigrator.toFRDomesticStandingOrderConsent;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRFileConsentMigrator.toFRFileConsent;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRInternationalConsentMigrator.toFRInternationalConsent;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRInternationalScheduledConsentMigrator.toFRInternationalScheduledConsent;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRInternationalStandingOrderConsentMigrator.toFRInternationalStandingOrderConsent;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRInternationalPaymentSubmissionMigrator.toFRInternationalPaymentSubmission;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRInternationalScheduledPaymentSubmissionMigrator.toFRInternationalScheduledPaymentSubmission;
+import static com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment.FRInternationalStandingOrderPaymentSubmissionMigrator.toFRInternationalStandingOrderPaymentSubmission;
 
 @ChangeLog
 @Slf4j

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRAccountMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRAccountMigrator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account;
+
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRAccount3;
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRAccount;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRFinancialAccountConverter.toFRFinancialAccount;
+
+public class FRAccountMigrator {
+
+    public static FRAccount toFRAccount(FRAccount3 frAccount3) {
+        return frAccount3 == null ? null : FRAccount.builder()
+                .id(frAccount3.getId())
+                .userID(frAccount3.getUserID())
+                .account(toFRFinancialAccount(frAccount3.getAccount()))
+                .latestStatementId(frAccount3.getLatestStatementId())
+                .created(frAccount3.getCreated())
+                .updated(frAccount3.getUpdated())
+                .build();
+    }
+
+
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRBeneficiaryMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRBeneficiaryMigrator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account;
+
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRBeneficiary3;
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRBeneficiary;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRAccountBeneficiaryConverter.toFRAccountBeneficiary;
+
+public class FRBeneficiaryMigrator {
+
+    public static FRBeneficiary toFRBeneficiary(FRBeneficiary3 frBeneficiary3) {
+        return frBeneficiary3 == null ? null : FRBeneficiary.builder()
+                .id(frBeneficiary3.getId())
+                .accountId(frBeneficiary3.getAccountId())
+                .beneficiary(toFRAccountBeneficiary(frBeneficiary3.getBeneficiary()))
+                .created(frBeneficiary3.getCreated())
+                .updated(frBeneficiary3.getUpdated())
+                .build();
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRDirectDebitMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRDirectDebitMigrator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account;
+
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRDirectDebit1;
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRDirectDebit;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRDirectDebitConverter.toFRDirectDebitData;
+
+public class FRDirectDebitMigrator {
+
+    public static FRDirectDebit toFRDirectDebit(FRDirectDebit1 frDirectDebit1) {
+        return frDirectDebit1 == null ? null : FRDirectDebit.builder()
+                .id(frDirectDebit1.getId())
+                .accountId(frDirectDebit1.getAccountId())
+                .directDebit(toFRDirectDebitData(frDirectDebit1.getDirectDebit()))
+                .created(frDirectDebit1.getCreated())
+                .updated(frDirectDebit1.getUpdated())
+                .build();
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRScheduledPaymentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRScheduledPaymentMigrator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account;
+
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRScheduledPayment2;
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRScheduledPayment;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRScheduledPaymentConverter.toFRScheduledPaymentData;
+
+public class FRScheduledPaymentMigrator {
+
+    public static FRScheduledPayment toFRScheduledPayment(FRScheduledPayment2 frScheduledPayment2) {
+        return frScheduledPayment2 == null ? null : FRScheduledPayment.builder()
+                .id(frScheduledPayment2.getId())
+                .accountId(frScheduledPayment2.getAccountId())
+                .scheduledPayment(toFRScheduledPaymentData(frScheduledPayment2.getScheduledPayment()))
+                .pispId(frScheduledPayment2.getPispId())
+                .created(frScheduledPayment2.getCreated())
+                .updated(frScheduledPayment2.getUpdated())
+                .rejectionReason(frScheduledPayment2.getRejectionReason())
+                .status(frScheduledPayment2.getStatus())
+                .build();
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRStandingOrderMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRStandingOrderMigrator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account;
+
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRStandingOrder5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRStandingOrder;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRStandingOrderConverter.toFRStandingOrderData;
+
+public class FRStandingOrderMigrator {
+
+    public static FRStandingOrder toFRStandingOrder(FRStandingOrder5 frStandingOrder5) {
+        return frStandingOrder5 == null ? null : FRStandingOrder.builder()
+                .id(frStandingOrder5.getId())
+                .accountId(frStandingOrder5.getAccountId())
+                .standingOrder(toFRStandingOrderData(frStandingOrder5.getStandingOrder()))
+                .pispId(frStandingOrder5.getPispId())
+                .created(frStandingOrder5.getCreated())
+                .updated(frStandingOrder5.getUpdated())
+                .rejectionReason(frStandingOrder5.getRejectionReason())
+                .status(frStandingOrder5.getStatus())
+                .build();
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRStatementMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRStatementMigrator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account;
+
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRStatement1;
+import com.forgerock.openbanking.common.model.openbanking.domain.account.FRStatementData;
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRStatement;
+import uk.org.openbanking.datamodel.account.OBStatement1;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRStatementConverter.toFRStatementData;
+
+public class FRStatementMigrator {
+
+    public static FRStatement toFRStatement(FRStatement1 frStatement1) {
+        return frStatement1 == null ? null : FRStatement.builder()
+                .id(frStatement1.getId())
+                .accountId(frStatement1.getAccountId())
+                .statement(toFRStatementData(frStatement1.getStatement()))
+                .created(frStatement1.getCreated())
+                .updated(frStatement1.getUpdated())
+                .build();
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRTransactionMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/account/FRTransactionMigrator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.account;
+
+import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.accounts.FRTransaction5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRTransaction;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRTransactionConverter.toFRTransactionData;
+
+public class FRTransactionMigrator {
+
+    public static FRTransaction toFRTransaction(FRTransaction5 frTransaction5) {
+        return frTransaction5 == null ? null : FRTransaction.builder()
+                .id(frTransaction5.getId())
+                .accountId(frTransaction5.getAccountId())
+                .statementIds(frTransaction5.getStatementIds())
+                .transaction(toFRTransactionData(frTransaction5.getTransaction()))
+                .created(frTransaction5.getCreated())
+                .updated(frTransaction5.getUpdated())
+                .bookingDateTime(frTransaction5.getBookingDateTime())
+                .build();
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRDomesticConsentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRDomesticConsentMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.FRDomesticConsent2;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRDomesticConsent;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteDomesticConsentConverter.toFRWriteDomesticConsent;
 
-public class FRDomesticConsentConverter {
+public class FRDomesticConsentMigrator {
 
     public static FRDomesticConsent toFRDomesticConsent(FRDomesticConsent2 frDomesticConsent2) {
         FRDomesticConsent frDomesticConsent = new FRDomesticConsent();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRDomesticScheduledConsentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRDomesticScheduledConsentMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.FRDomesticScheduledConsent2;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRDomesticScheduledConsent;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteDomesticScheduledConsentConverter.toFRWriteDomesticScheduledConsent;
 
-public class FRDomesticScheduledConsentConverter {
+public class FRDomesticScheduledConsentMigrator {
 
     public static FRDomesticScheduledConsent toFRDomesticScheduledConsent(FRDomesticScheduledConsent2 frDomesticScheduledConsent2) {
         FRDomesticScheduledConsent frDomesticScheduledConsent = new FRDomesticScheduledConsent();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRDomesticStandingOrderConsentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRDomesticStandingOrderConsentMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.FRDomesticStandingOrderConsent3;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRDomesticStandingOrderConsent;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteDomesticStandingOrderConsentConverter.toFRWriteDomesticStandingOrderConsent;
 
-public class FRDomesticStandingOrderConsentConverter {
+public class FRDomesticStandingOrderConsentMigrator {
 
     public static FRDomesticStandingOrderConsent toFRDomesticStandingOrderConsent(FRDomesticStandingOrderConsent3 frDomesticStandingOrderConsent3) {
         FRDomesticStandingOrderConsent frDomesticScheduledConsent5 = new FRDomesticStandingOrderConsent();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRFileConsentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRFileConsentMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.FRFileConsent2;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileConsent;
 
-public class FRFileConsentConverter {
+public class FRFileConsentMigrator {
 
     public static FRFileConsent toFRFileConsent(FRFileConsent2 frFileConsent2) {
         return FRFileConsent.builder()

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalConsentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalConsentMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.FRInternationalConsent2;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRInternationalConsent;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteInternationalConsentConverter.toFRWriteInternationalConsent;
 
-public class FRInternationalConsentConverter {
+public class FRInternationalConsentMigrator {
 
     public static FRInternationalConsent toFRInternationalConsent(FRInternationalConsent2 frInternationalConsent2) {
         FRInternationalConsent frInternationalConsent = new FRInternationalConsent();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalPaymentSubmissionMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalPaymentSubmissionMigrator.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.InternationalPaymentSubmission2;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRInternationalPaymentSubmission;
@@ -26,7 +26,7 @@ import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FR
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteInternationalConverter.toFRWriteInternational;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBWriteInternational3DataInitiation;
 
-public class FRInternationalPaymentSubmissionConverter {
+public class FRInternationalPaymentSubmissionMigrator {
 
     public static FRInternationalPaymentSubmission toFRInternationalPaymentSubmission(InternationalPaymentSubmission2 frInternationalPaymentSubmission2) {
         return frInternationalPaymentSubmission2 == null ? null : FRInternationalPaymentSubmission.builder()

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalScheduledConsentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalScheduledConsentMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.FRInternationalScheduledConsent2;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRInternationalScheduledConsent;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteInternationalScheduledConsentConverter.toFRWriteInternationalScheduledConsent;
 
-public class FRInternationalScheduledConsentConverter {
+public class FRInternationalScheduledConsentMigrator {
 
     public static FRInternationalScheduledConsent toFRInternationalScheduledConsent(FRInternationalScheduledConsent2 frInternationalScheduledConsent2) {
         FRInternationalScheduledConsent frInternationalScheduledConsent = new FRInternationalScheduledConsent();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalScheduledPaymentSubmissionMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalScheduledPaymentSubmissionMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.InternationalScheduledPaymentSubmission2;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRInternationalScheduledPaymentSubmission;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteInternationalScheduledConverter.toFRWriteInternationalScheduled;
 
-public class FRInternationalScheduledPaymentSubmissionConverter {
+public class FRInternationalScheduledPaymentSubmissionMigrator {
 
     public static FRInternationalScheduledPaymentSubmission toFRInternationalScheduledPaymentSubmission(InternationalScheduledPaymentSubmission2 frInternationalScheduledPaymentSubmission2) {
         return frInternationalScheduledPaymentSubmission2 == null ? null : FRInternationalScheduledPaymentSubmission.builder()

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalStandingOrderConsentMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalStandingOrderConsentMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.FRInternationalStandingOrderConsent3;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRInternationalStandingOrderConsent;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteInternationalStandingOrderConsentConverter.toFRWriteInternationalStandingOrderConsent;
 
-public class FRInternationalStandingOrderConsentConverter {
+public class FRInternationalStandingOrderConsentMigrator {
 
     public static FRInternationalStandingOrderConsent toFRInternationalStandingOrderConsent(FRInternationalStandingOrderConsent3 frInternationalStandingOrderConsent3) {
         FRInternationalStandingOrderConsent frInternationalScheduledConsent5 = new FRInternationalStandingOrderConsent();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalStandingOrderPaymentSubmissionMigrator.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/migration/v3_1_6/payment/FRInternationalStandingOrderPaymentSubmissionMigrator.java
@@ -18,14 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6;
+package com.forgerock.openbanking.aspsp.rs.store.repository.migration.v3_1_6.payment;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.migration.legacy.payments.InternationalStandingOrderPaymentSubmission3;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRInternationalStandingOrderPaymentSubmission;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteInternationalStandingOrderConverter.toFRWriteInternationalStandingOrder;
 
-public class FRInternationalStandingOrderPaymentSubmissionConverter {
+public class FRInternationalStandingOrderPaymentSubmissionMigrator {
 
     public static FRInternationalStandingOrderPaymentSubmission toFRInternationalStandingOrderPaymentSubmission(InternationalStandingOrderPaymentSubmission3 frInternationalStandingOrderPaymentSubmission3) {
         return frInternationalStandingOrderPaymentSubmission3 == null ? null : FRInternationalStandingOrderPaymentSubmission.builder()


### PR DESCRIPTION
### Restored account data migration (#296)

- Added legacy account mongo documents (determined from looking at LBG's production instance).
- Renamed migration specific converters to xMigrator in order to avoid name conflicts and to make it clear they're only intended for migration.

Note that all of the classes under `repository.migration.v3_1_6` can be removed in a future release, once all the relevant data has been migrated.