### PR TITLE
"CreateFundsConfirmationConsent" now in Discovery endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+### GitHub [#310](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/310) 13: International Payments flow error
+[73af6a81dce87c1](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/73af6a81dce87c1) Jorge Sanchez Perez *2020-12-09 09:52:37*
+13: International Payments flow error (#310)
+
+* 13: International Payments flow error
+- ZD: 55780
+- Add conditional control to manage null calculating exchange rates
+- Added tests for optional fields
+* Fix license
 [671c9af01b1a3d2](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/671c9af01b1a3d2) Matt Wills *2020-11-06 14:24:30*
 Release candidate: prepare for next development iteration
 ## 1.0.109

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/funds/v3_0/FundsConfirmationConsentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/funds/v3_0/FundsConfirmationConsentsApi.java
@@ -68,7 +68,7 @@ public interface FundsConfirmationConsentsApi {
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
     @PreAuthorize("hasAuthority('ROLE_CBPII')")
     @OpenBankingAPI(
-            obReference = OBReference.GET_FUNDS_CONFIRMATION_CONSENT
+            obReference = OBReference.CREATE_FUNDS_CONFIRMATION_CONSENT
     )
     @RequestMapping(value = FUNDS_CONFIRMATION_CONSENTS_PATH,
             produces = {"application/json; charset=utf-8"},

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/funds/v3_1_3/FundsConfirmationConsentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/funds/v3_1_3/FundsConfirmationConsentsApi.java
@@ -79,7 +79,7 @@ public interface FundsConfirmationConsentsApi {
 
     @PreAuthorize("hasAuthority('ROLE_CBPII')")
     @OpenBankingAPI(
-            obReference = OBReference.GET_FUNDS_CONFIRMATION_CONSENT
+            obReference = OBReference.CREATE_FUNDS_CONFIRMATION_CONSENT
     )
     @RequestMapping(value = FUNDS_CONFIRMATION_CONSENTS_PATH,
             produces = {"application/json; charset=utf-8"},


### PR DESCRIPTION
### Fix to enable "CreateFundsConfirmationConsent" to appear in Discovery endpoint

Tested against dev-ob running locally:

![image](https://user-images.githubusercontent.com/63234126/102107755-f9c5c080-3e29-11eb-9659-a8e233214314.png)

**Issue:** https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/15