### PR TITLE
344: Internal ID filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Changelog of Git Changelog Maven plugin.
 - Add conditional control to manage null calculating exchange rates
 - Added tests for optional fields
 * Fix license
+[713410ab33f16e4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/713410ab33f16e4) Matt Wills *2020-12-14 15:54:35*
+Fix to enable "CreateFundsConfirmationConsent" to appear in Discovery endpoint
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/15
 [671c9af01b1a3d2](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/671c9af01b1a3d2) Matt Wills *2020-11-06 14:24:30*
 Release candidate: prepare for next development iteration
 ## 1.0.109

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v1_1/standingorders/StandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v1_1/standingorders/StandingOrdersApiController.java
@@ -21,7 +21,6 @@
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v1_1.standingorders;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.accounts.standingorders.FRStandingOrderRepository;
-import com.forgerock.openbanking.aspsp.rs.store.utils.AccountDataInternalIdFilter;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
 import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRStandingOrder;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
@@ -59,8 +58,6 @@ public class StandingOrdersApiController implements StandingOrdersApi {
     private int PAGE_LIMIT_STANDING_ORDERS;
     @Autowired
     private FRStandingOrderRepository frStandingOrderRepository;
-    @Autowired
-    private AccountDataInternalIdFilter accountDataInternalIdFilter;
 
     @Override
     public ResponseEntity<OBReadStandingOrder1> getAccountStandingOrders(
@@ -91,7 +88,6 @@ public class StandingOrdersApiController implements StandingOrdersApi {
                 PageRequest.of(page, PAGE_LIMIT_STANDING_ORDERS));
         List<OBStandingOrder1> standingOrders = standingOrdersResponse.stream()
                 .map(so -> toOBStandingOrder1(so.getStandingOrder()))
-                .map(so -> accountDataInternalIdFilter.apply(so))
                 .collect(Collectors.toList());
 
         int totalPages = standingOrdersResponse.getTotalPages();
@@ -139,7 +135,6 @@ public class StandingOrdersApiController implements StandingOrdersApi {
                 PageRequest.of(page, PAGE_LIMIT_STANDING_ORDERS));
         List<OBStandingOrder1> standingOrders = standingOrdersResponse.stream()
                 .map(so -> toOBStandingOrder1(so.getStandingOrder()))
-                .map(so -> accountDataInternalIdFilter.apply(so))
                 .collect(Collectors.toList());
         int totalPages = standingOrdersResponse.getTotalPages();
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v1_1/transactions/TransactionsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v1_1/transactions/TransactionsApiController.java
@@ -21,7 +21,6 @@
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v1_1.transactions;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.accounts.transactions.FRTransactionRepository;
-import com.forgerock.openbanking.aspsp.rs.store.utils.AccountDataInternalIdFilter;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
 import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRTransaction;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
@@ -50,9 +49,7 @@ import java.util.stream.Collectors;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRExternalPermissionsCodeConverter.toFRExternalPermissionsCodeList;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRTransactionConverter.toOBTransaction1;
-import static com.forgerock.openbanking.constants.OpenBankingConstants.AVAILABLE_DATE_FORMAT;
-import static com.forgerock.openbanking.constants.OpenBankingConstants.BOOKED_TIME_DATE_FORMAT;
-import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static com.forgerock.openbanking.constants.OpenBankingConstants.*;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.ParametersFieldName.FROM_BOOKING_DATE_TIME;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.ParametersFieldName.TO_BOOKING_DATE_TIME;
 
@@ -64,8 +61,6 @@ public class TransactionsApiController implements TransactionsApi {
     private int PAGE_LIMIT_TRANSACTIONS;
     @Autowired
     private FRTransactionRepository frTransactionRepository;
-    @Autowired
-    private AccountDataInternalIdFilter accountDataInternalIdFilter;
 
     @Override
     public ResponseEntity getAccountTransactions(
@@ -124,7 +119,6 @@ public class TransactionsApiController implements TransactionsApi {
         List<OBTransaction1> transactions = transactionsResponse.getContent()
                 .stream()
                 .map(t -> toOBTransaction1(t.getTransaction()))
-                .map(t -> accountDataInternalIdFilter.apply(t))
                 .collect(Collectors.toList());
 
         int totalPages = transactionsResponse.getTotalPages();
@@ -204,7 +198,6 @@ public class TransactionsApiController implements TransactionsApi {
         List<OBTransaction1> transactions = transactionsResponse.getContent()
                 .stream()
                 .map(t -> toOBTransaction1(t.getTransaction()))
-                .map(t -> accountDataInternalIdFilter.apply(t))
                 .collect(Collectors.toList());
         int totalPages = transactionsResponse.getTotalPages();
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v2_0/products/ProductsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v2_0/products/ProductsApiController.java
@@ -21,6 +21,7 @@
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v2_0.products;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.accounts.products.FRProductRepository;
+import com.forgerock.openbanking.aspsp.rs.store.utils.AccountDataInternalIdFilter;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
 import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRProduct;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
@@ -56,6 +57,8 @@ public class ProductsApiController implements ProductsApi {
     private int PAGE_LIMIT_PRODUCTS;
     @Autowired
     private FRProductRepository frProductRepository;
+    @Autowired
+    private AccountDataInternalIdFilter accountDataInternalIdFilter;
 
     @Override
     public ResponseEntity<OBReadProduct2> getAccountProduct(
@@ -95,7 +98,8 @@ public class ProductsApiController implements ProductsApi {
 
         return ResponseEntity.ok(new OBReadProduct2()
                 .data(new OBReadProduct2Data().product(products.getContent().stream()
-                        .map(p -> p.getProduct()).collect(Collectors.toList())))
+                        .map(p -> accountDataInternalIdFilter.apply(p.getProduct()))
+                        .collect(Collectors.toList())))
                 .links(PaginationUtil.generateLinks(httpUrl, page, totalPage))
                 .meta(PaginationUtil.generateMetaData(totalPage)));
     }
@@ -143,7 +147,8 @@ public class ProductsApiController implements ProductsApi {
 
         return ResponseEntity.ok(new OBReadProduct2()
                 .data(new OBReadProduct2Data().product(products.getContent().stream()
-                        .map(p -> p.getProduct()).collect(Collectors.toList())))
+                        .map(p -> accountDataInternalIdFilter.apply(p.getProduct()))
+                        .collect(Collectors.toList())))
                 .links(PaginationUtil.generateLinks(httpUrl, page, totalPage))
                 .meta(PaginationUtil.generateMetaData(totalPage)));
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v2_0/standingorders/StandingOrdersApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v2_0/standingorders/StandingOrdersApiController.java
@@ -21,7 +21,6 @@
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v2_0.standingorders;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.accounts.standingorders.FRStandingOrderRepository;
-import com.forgerock.openbanking.aspsp.rs.store.utils.AccountDataInternalIdFilter;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
 import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRStandingOrder;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
@@ -59,8 +58,6 @@ public class StandingOrdersApiController implements StandingOrdersApi {
     private int PAGE_LIMIT_STANDING_ORDERS;
     @Autowired
     private FRStandingOrderRepository frStandingOrderRepository;
-    @Autowired
-    private AccountDataInternalIdFilter accountDataInternalIdFilter;
 
     @Override
     public ResponseEntity<OBReadStandingOrder2> getAccountStandingOrders(
@@ -99,7 +96,6 @@ public class StandingOrdersApiController implements StandingOrdersApi {
                 frStandingOrderRepository.byAccountIdWithPermissions(accountId, toFRExternalPermissionsCodeList(permissions), PageRequest.of(page, PAGE_LIMIT_STANDING_ORDERS));
         List<OBStandingOrder2> standingOrders = standingOrdersResponse.stream()
                 .map(so -> toOBStandingOrder2(so.getStandingOrder()))
-                .map(so -> accountDataInternalIdFilter.apply(so))
                 .collect(Collectors.toList());
         int totalPages = standingOrdersResponse.getTotalPages();
 
@@ -146,7 +142,6 @@ public class StandingOrdersApiController implements StandingOrdersApi {
                 PageRequest.of(page, PAGE_LIMIT_STANDING_ORDERS));
         List<OBStandingOrder2> standingOrders = standingOrdersResponse.stream()
                 .map(so -> toOBStandingOrder2(so.getStandingOrder()))
-                .map(so -> accountDataInternalIdFilter.apply(so))
                 .collect(Collectors.toList());
         int totalPages = standingOrdersResponse.getTotalPages();
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v2_0/transactions/TransactionsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/account/v2_0/transactions/TransactionsApiController.java
@@ -21,7 +21,6 @@
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v2_0.transactions;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.accounts.transactions.FRTransactionRepository;
-import com.forgerock.openbanking.aspsp.rs.store.utils.AccountDataInternalIdFilter;
 import com.forgerock.openbanking.aspsp.rs.store.utils.PaginationUtil;
 import com.forgerock.openbanking.common.model.openbanking.persistence.account.FRTransaction;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
@@ -50,9 +49,7 @@ import java.util.stream.Collectors;
 
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRExternalPermissionsCodeConverter.toFRExternalPermissionsCodeList;
 import static com.forgerock.openbanking.common.services.openbanking.converter.account.FRTransactionConverter.toOBTransaction2;
-import static com.forgerock.openbanking.constants.OpenBankingConstants.AVAILABLE_DATE_FORMAT;
-import static com.forgerock.openbanking.constants.OpenBankingConstants.BOOKED_TIME_DATE_FORMAT;
-import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
+import static com.forgerock.openbanking.constants.OpenBankingConstants.*;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.ParametersFieldName.FROM_BOOKING_DATE_TIME;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.ParametersFieldName.TO_BOOKING_DATE_TIME;
 
@@ -65,8 +62,6 @@ public class TransactionsApiController implements TransactionsApi {
 
     @Autowired
     private FRTransactionRepository frTransactionRepository;
-    @Autowired
-    private AccountDataInternalIdFilter accountDataInternalIdFilter;
 
     @Override
     public ResponseEntity<OBReadTransaction2> getAccountTransactions(
@@ -135,7 +130,6 @@ public class TransactionsApiController implements TransactionsApi {
         List<OBTransaction2> transactions = response.getContent()
                 .stream()
                 .map(t -> toOBTransaction2(t.getTransaction()))
-                .map(t -> accountDataInternalIdFilter.apply(t))
                 .collect(Collectors.toList());
 
         //Package the answer
@@ -216,7 +210,6 @@ public class TransactionsApiController implements TransactionsApi {
         List<OBTransaction2> transactions = response.getContent()
                 .stream()
                 .map(t -> toOBTransaction2(t.getTransaction()))
-                .map(t -> accountDataInternalIdFilter.apply(t))
                 .collect(Collectors.toList());
 
         //Package the answer
@@ -301,7 +294,6 @@ public class TransactionsApiController implements TransactionsApi {
         List<OBTransaction2> transactions = response.getContent()
                 .stream()
                 .map(t -> toOBTransaction2(t.getTransaction()))
-                .map(t -> accountDataInternalIdFilter.apply(t))
                 .collect(Collectors.toList());
 
         //Package the answer

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/utils/AccountDataInternalIdFilter.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/utils/AccountDataInternalIdFilter.java
@@ -25,124 +25,278 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.org.openbanking.datamodel.account.*;
 
-import java.util.Objects;
 import java.util.function.Consumer;
 
+/**
+ * Responsible for determining if an object's internal ID (e.g. a Direct Debit's internal ID) should be displayed.
+ * Depending on the application's Spring configuration, this class either sets the ID of each object to null (so it is
+ * not displayed), or leaves it populated.
+ *
+ * <p>
+ * By default, the config property <code>rs.data.internal_ids.show</code> is set to <code>true</code>, meaning all IDs
+ * remain populated. If some of the internal IDs should be hidden, then <code>rs.data.internal_ids.show</code> should
+ * be set to <code>false</code> and the preference for each relevant object should be specified (e.g.
+ * <code>rs.data.internal_ids.direct_debit.show</code> for a Direct Debit).
+ */
 @Service
 @Slf4j
 public class AccountDataInternalIdFilter {
-    private final boolean showAccountDataInternalIds;
 
-    public AccountDataInternalIdFilter(@Value("${rs.data.internal_ids.show:true}") boolean showAccountDataInternalIds) {
-        this.showAccountDataInternalIds = showAccountDataInternalIds;
-    }
+    private final boolean showAllAccountDataInternalIds;
+    private final boolean showDirectDebitIds;
+    private final boolean showOfferIds;
+    private final boolean showProductIds;
+    private final boolean showStatementIds;
+    private final boolean showDomesticTransactionIds;
+    private final boolean showInternationalTransactionIds;
+    private final boolean showDomesticBeneficiaryIds;
+    private final boolean showInternationalBeneficiaryIds;
+    private final boolean showDomesticScheduledPaymentIds;
+    private final boolean showInternationalScheduledPaymentIds;
+    private final boolean showDomesticStandingOrderIds;
+    private final boolean showInternationalStandingOrderIds;
 
-    public OBTransaction1 apply(final OBTransaction1 data) {
-        return apply(data, data::setTransactionId);
-    }
-
-    public OBTransaction2 apply(final OBTransaction2 data) {
-        return apply(data, data::setTransactionId);
-    }
-
-    public OBTransaction3 apply(final OBTransaction3 data) {
-        return apply(data, data::setTransactionId);
-    }
-
-    public OBTransaction4 apply(final OBTransaction4 data) {
-        return apply(data, data::setTransactionId);
-    }
-
-    public OBTransaction5 apply(final OBTransaction5 data) {
-        return apply(data, data::setTransactionId);
-    }
-
-    public OBTransaction6 apply(final OBTransaction6 data) {
-        return apply(data, data::setTransactionId);
-    }
-
-    public OBBeneficiary2 apply(final OBBeneficiary2 data) {
-        return apply(data, data::setBeneficiaryId);
-    }
-
-    public OBBeneficiary3 apply(final OBBeneficiary3 data) {
-        return apply(data, data::setBeneficiaryId);
-    }
-
-    public OBBeneficiary4 apply(final OBBeneficiary4 data) {
-        return apply(data, data::setBeneficiaryId);
-    }
-
-    public OBBeneficiary5 apply(final OBBeneficiary5 data) {
-        return apply(data, data::setBeneficiaryId);
+    public AccountDataInternalIdFilter(
+            @Value("${rs.data.internal_ids.show:true}") boolean showAllAccountDataInternalIds,
+            @Value("${rs.data.internal_ids.direct_debit.show:false}") boolean showDirectDebitIds,
+            @Value("${rs.data.internal_ids.offer.show:false}") boolean showOfferIds,
+            @Value("${rs.data.internal_ids.product.show:false}") boolean showProductIds,
+            @Value("${rs.data.internal_ids.statement.show:false}") boolean showStatementIds,
+            @Value("${rs.data.internal_ids.domestic.transaction.show:false}") boolean showDomesticTransactionIds,
+            @Value("${rs.data.internal_ids.international.transaction.show:false}") boolean showInternationalTransactionIds,
+            @Value("${rs.data.internal_ids.domestic.beneficiary.show:false}") boolean showDomesticBeneficiaryIds,
+            @Value("${rs.data.internal_ids.international.beneficiary.show:false}") boolean showInternationalBeneficiaryIds,
+            @Value("${rs.data.internal_ids.domestic.scheduled_payment.show:false}") boolean showDomesticScheduledPaymentIds,
+            @Value("${rs.data.internal_ids.international.scheduled_payment.show:false}") boolean showInternationalScheduledPaymentIds,
+            @Value("${rs.data.internal_ids.domestic.standing_order.show:false}") boolean showDomesticStandingOrderIds,
+            @Value("${rs.data.internal_ids.international.standing_order.show:false}") boolean showInternationalStandingOrderIds) {
+        this.showAllAccountDataInternalIds = showAllAccountDataInternalIds;
+        this.showDirectDebitIds = showDirectDebitIds;
+        this.showOfferIds = showOfferIds;
+        this.showProductIds = showProductIds;
+        this.showStatementIds = showStatementIds;
+        this.showDomesticTransactionIds = showDomesticTransactionIds;
+        this.showInternationalTransactionIds = showInternationalTransactionIds;
+        this.showDomesticBeneficiaryIds = showDomesticBeneficiaryIds;
+        this.showInternationalBeneficiaryIds = showInternationalBeneficiaryIds;
+        this.showDomesticScheduledPaymentIds = showDomesticScheduledPaymentIds;
+        this.showInternationalScheduledPaymentIds = showInternationalScheduledPaymentIds;
+        this.showDomesticStandingOrderIds = showDomesticStandingOrderIds;
+        this.showInternationalStandingOrderIds = showInternationalStandingOrderIds;
     }
 
     public OBDirectDebit1 apply(OBDirectDebit1 data) {
-        return apply(data, data::setDirectDebitId);
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+        return apply(data, showDirectDebitIds, data::setDirectDebitId);
     }
 
     public OBReadDirectDebit2DataDirectDebit apply(OBReadDirectDebit2DataDirectDebit data) {
-        return apply(data, data::setDirectDebitId);
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+        return apply(data, showDirectDebitIds, data::setDirectDebitId);
     }
 
     public OBOffer1 apply(OBOffer1 data) {
-        return apply(data, data::setOfferId);
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+        return apply(data, showOfferIds, data::setOfferId);
     }
 
-    public OBScheduledPayment1 apply(OBScheduledPayment1 data) {
-        return apply(data, data::setScheduledPaymentId);
-    }
-
-    public OBScheduledPayment2 apply(OBScheduledPayment2 data) {
-        return apply(data, data::setScheduledPaymentId);
-    }
-
-    public OBScheduledPayment3 apply(OBScheduledPayment3 data) {
-        return apply(data, data::setScheduledPaymentId);
-    }
-
-    public OBStandingOrder1 apply(OBStandingOrder1 data) {
-        return apply(data, data::setStandingOrderId);
-    }
-
-    public OBStandingOrder2 apply(OBStandingOrder2 data) {
-        return apply(data, data::setStandingOrderId);
-    }
-
-    public OBStandingOrder3 apply(OBStandingOrder3 data) {
-        return apply(data, data::setStandingOrderId);
-    }
-
-    public OBStandingOrder4 apply(OBStandingOrder4 data) {
-        return apply(data, data::setStandingOrderId);
-    }
-
-    public OBStandingOrder5 apply(OBStandingOrder5 data) {
-        return apply(data, data::setStandingOrderId);
-    }
-
-    public OBStandingOrder6 apply(OBStandingOrder6 data) {
-        return apply(data, data::setStandingOrderId);
+    public OBReadProduct2DataProduct apply(OBReadProduct2DataProduct data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+        return apply(data, showProductIds, data::setProductId);
     }
 
     public OBStatement1 apply(OBStatement1 data) {
-        return apply(data, data::setStatementId);
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+        return apply(data, showStatementIds, data::setStatementId);
     }
 
     public OBStatement2 apply(OBStatement2 data) {
-        return apply(data, data::setStatementId);
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+        return apply(data, showStatementIds, data::setStatementId);
     }
 
-    private <T> T apply(final T data, Consumer<String> setIdFunction) {
-        if (showAccountDataInternalIds) {
-            log.debug("Show Account Data Internal Ids is 'ON'. Data response will contain internal ids");
+    public OBTransaction3 apply(final OBTransaction3 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticTransactionIds : showInternationalTransactionIds;
+        return apply(data, showId, data::setTransactionId);
+    }
+
+    public OBTransaction4 apply(final OBTransaction4 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticTransactionIds : showInternationalTransactionIds;
+        return apply(data, showId, data::setTransactionId);
+    }
+
+    public OBTransaction5 apply(final OBTransaction5 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticTransactionIds : showInternationalTransactionIds;
+        return apply(data, showId, data::setTransactionId);
+    }
+
+    public OBTransaction6 apply(final OBTransaction6 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticTransactionIds : showInternationalTransactionIds;
+        return apply(data, showId, data::setTransactionId);
+    }
+
+    public OBBeneficiary2 apply(final OBBeneficiary2 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticBeneficiaryIds : showInternationalBeneficiaryIds;
+        return apply(data, showId, data::setBeneficiaryId);
+    }
+
+    public OBBeneficiary3 apply(final OBBeneficiary3 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticBeneficiaryIds : showInternationalBeneficiaryIds;
+        return apply(data, showId, data::setBeneficiaryId);
+    }
+
+    public OBBeneficiary4 apply(final OBBeneficiary4 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticBeneficiaryIds : showInternationalBeneficiaryIds;
+        return apply(data, showId, data::setBeneficiaryId);
+    }
+
+    public OBBeneficiary5 apply(final OBBeneficiary5 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticBeneficiaryIds : showInternationalBeneficiaryIds;
+        return apply(data, showId, data::setBeneficiaryId);
+    }
+
+    public OBScheduledPayment1 apply(OBScheduledPayment1 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticScheduledPaymentIds : showInternationalScheduledPaymentIds;
+        return apply(data, showId, data::setScheduledPaymentId);
+    }
+
+    public OBScheduledPayment2 apply(OBScheduledPayment2 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticScheduledPaymentIds : showInternationalScheduledPaymentIds;
+        return apply(data, showId, data::setScheduledPaymentId);
+    }
+
+    public OBScheduledPayment3 apply(OBScheduledPayment3 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticScheduledPaymentIds : showInternationalScheduledPaymentIds;
+        return apply(data, showId, data::setScheduledPaymentId);
+    }
+
+    public OBStandingOrder3 apply(OBStandingOrder3 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticStandingOrderIds : showInternationalStandingOrderIds;
+        return apply(data, showId, data::setStandingOrderId);
+    }
+
+    public OBStandingOrder4 apply(OBStandingOrder4 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticStandingOrderIds : showInternationalStandingOrderIds;
+        return apply(data, showId, data::setStandingOrderId);
+    }
+
+    public OBStandingOrder5 apply(OBStandingOrder5 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticStandingOrderIds : showInternationalStandingOrderIds;
+        return apply(data, showId, data::setStandingOrderId);
+    }
+
+    public OBStandingOrder6 apply(OBStandingOrder6 data) {
+        if (showAllAccountDataInternalIds) {
+            return displayAllInternalIds(data);
+        }
+
+        String schemeName = data.getCreditorAccount() != null ? data.getCreditorAccount().getSchemeName() : "";
+        boolean showId = isDomestic(schemeName) ? showDomesticStandingOrderIds : showInternationalStandingOrderIds;
+        return apply(data, showId, data::setStandingOrderId);
+    }
+
+    private <T> T displayAllInternalIds(final T data) {
+        log.debug("Show All Account Data Internal Ids is 'ON'. Data response will contain internal ids");
+        return data;
+    }
+
+    private <T> T apply(final T data, boolean showIds, Consumer<String> setIdFunction) {
+        String objectName = data.getClass().getSimpleName();
+        if (showIds) {
+            log.debug("Show Internal Ids is 'ON' for {}. Data response will contain internal ids", objectName);
             return data;
         }
-        log.debug("Show Data API Internal Ids is 'OFF'. Data response will NOT contain internal ids. Data: {}", data);
-        if (Objects.nonNull(data)) {
-            setIdFunction.accept(null);
-            log.debug("Removed id");
-        }
+
+        log.debug("Show Internal Ids is 'OFF' for {}. Data response will NOT contain internal ids.", objectName);
+        setIdFunction.accept(null);
+        log.debug("Removed id");
         return data;
+    }
+
+    private boolean isDomestic(String schemeName) {
+        return !(OBExternalAccountIdentification3Code.IBAN.toString().equals(schemeName) ||
+                OBExternalAccountIdentification4Code.IBAN.toString().equals(schemeName) ||
+                OBExternalAccountIdentification4Code.BBAN.toString().equals(schemeName));
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/utils/AccountDataInternalIdFilterTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/utils/AccountDataInternalIdFilterTest.java
@@ -25,137 +25,333 @@ import uk.org.openbanking.datamodel.account.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Unit test for {@link AccountDataInternalIdFilter}.
+ */
 public class AccountDataInternalIdFilterTest {
-    private AccountDataInternalIdFilter accountDataInternalIdFilter_showId = new AccountDataInternalIdFilter(true);
-    private AccountDataInternalIdFilter accountDataInternalIdFilter_hideId = new AccountDataInternalIdFilter(false);
+
+    private static final String INTERNAL_ID = "12345";
+    private static final String DOMESTIC_SCHEME = OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER.toString();
+    private static final String INTERNATIONAL_SCHEME = OBExternalAccountIdentification4Code.IBAN.toString();
+    private static final OBCashAccount3 DOMESTIC_ACCOUNT = new OBCashAccount3().schemeName(DOMESTIC_SCHEME);
+    private static final OBCashAccount3 INTERNATIONAL_ACCOUNT = new OBCashAccount3().schemeName(INTERNATIONAL_SCHEME);
+
+    private final OBDirectDebit1 directDebit = new OBDirectDebit1().directDebitId(INTERNAL_ID);
+    private final OBOffer1 offer = new OBOffer1().offerId(INTERNAL_ID);
+    private final OBReadProduct2DataProduct product = new OBReadProduct2DataProduct().productId(INTERNAL_ID);
+    private final OBStatement1 statement = new OBStatement1().statementId(INTERNAL_ID);
+    private final OBTransaction4 domesticTransaction = new OBTransaction4().transactionId(INTERNAL_ID).creditorAccount(DOMESTIC_ACCOUNT);
+    private final OBTransaction4 internationalTransaction = new OBTransaction4().transactionId(INTERNAL_ID).creditorAccount(INTERNATIONAL_ACCOUNT);
+    private final OBBeneficiary2 domesticBeneficiary = new OBBeneficiary2().beneficiaryId(INTERNAL_ID).creditorAccount(DOMESTIC_ACCOUNT);
+    private final OBBeneficiary2 internationalBeneficiary = new OBBeneficiary2().beneficiaryId(INTERNAL_ID).creditorAccount(INTERNATIONAL_ACCOUNT);
+    private final OBScheduledPayment1 domesticScheduledPayment = new OBScheduledPayment1().scheduledPaymentId(INTERNAL_ID).creditorAccount(DOMESTIC_ACCOUNT);
+    private final OBScheduledPayment1 internationalScheduledPayment = new OBScheduledPayment1().scheduledPaymentId(INTERNAL_ID).creditorAccount(INTERNATIONAL_ACCOUNT);
+    private final OBStandingOrder4 domesticStandingOrder = new OBStandingOrder4().standingOrderId(INTERNAL_ID).creditorAccount(DOMESTIC_ACCOUNT);
+    private final OBStandingOrder4 internationalStandingOrder = new OBStandingOrder4().standingOrderId(INTERNAL_ID).creditorAccount(INTERNATIONAL_ACCOUNT);
 
     @Test
-    public void applyTransaction1() {
-        OBTransaction1 data = new OBTransaction1().transactionId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getTransactionId()).isNotNull();
+    public void shouldIncludeAllIdsGivenShowAllAccountDataInternalIdsIsTrue() {
+        // Given
+        AccountDataInternalIdFilter filter = filterWithAllIdsDisplayed();
 
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getTransactionId()).isNull();
+        // When
+        filter.apply(directDebit);
+        filter.apply(offer);
+        filter.apply(product);
+        filter.apply(statement);
+        filter.apply(domesticTransaction);
+        filter.apply(internationalTransaction);
+        filter.apply(domesticBeneficiary);
+        filter.apply(internationalBeneficiary);
+        filter.apply(domesticScheduledPayment);
+        filter.apply(internationalScheduledPayment);
+        filter.apply(domesticStandingOrder);
+        filter.apply(internationalStandingOrder);
+
+        // Then
+        assertThat(directDebit.getDirectDebitId()).isNotNull();
+        assertThat(offer.getOfferId()).isNotNull();
+        assertThat(product.getProductId()).isNotNull();
+        assertThat(statement.getStatementId()).isNotNull();
+        assertThat(domesticTransaction.getTransactionId()).isNotNull();
+        assertThat(internationalTransaction.getTransactionId()).isNotNull();
+        assertThat(domesticBeneficiary.getBeneficiaryId()).isNotNull();
+        assertThat(internationalBeneficiary.getBeneficiaryId()).isNotNull();
+        assertThat(domesticScheduledPayment.getScheduledPaymentId()).isNotNull();
+        assertThat(internationalScheduledPayment.getScheduledPaymentId()).isNotNull();
+        assertThat(domesticStandingOrder.getStandingOrderId()).isNotNull();
+        assertThat(internationalStandingOrder.getStandingOrderId()).isNotNull();
     }
 
     @Test
-    public void applyTransaction2() {
-        OBTransaction2 data = new OBTransaction2().transactionId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getTransactionId()).isNotNull();
+    public void shouldNotIncludeIdsGivenShowAllAccountDataInternalIdsIsFalse() {
+        // Given
+        AccountDataInternalIdFilter filter = filterWithAllIdsHidden();
 
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getTransactionId()).isNull();
+        // When
+        filter.apply(directDebit);
+        filter.apply(offer);
+        filter.apply(product);
+        filter.apply(statement);
+        filter.apply(domesticTransaction);
+        filter.apply(internationalTransaction);
+        filter.apply(domesticBeneficiary);
+        filter.apply(internationalBeneficiary);
+        filter.apply(domesticScheduledPayment);
+        filter.apply(internationalScheduledPayment);
+        filter.apply(domesticStandingOrder);
+        filter.apply(internationalStandingOrder);
+
+        // Then
+        assertThat(directDebit.getDirectDebitId()).isNull();
+        assertThat(offer.getOfferId()).isNull();
+        assertThat(product.getProductId()).isNull();
+        assertThat(statement.getStatementId()).isNull();
+        assertThat(domesticTransaction.getTransactionId()).isNull();
+        assertThat(internationalTransaction.getTransactionId()).isNull();
+        assertThat(domesticBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(internationalBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(domesticScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(internationalScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(domesticStandingOrder.getStandingOrderId()).isNull();
+        assertThat(internationalStandingOrder.getStandingOrderId()).isNull();
     }
 
     @Test
-    public void applyTransaction3() {
-        OBTransaction3 data = new OBTransaction3().transactionId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getTransactionId()).isNotNull();
+    public void shouldOnlyIncludeDirectDebitId() {
+        // Given
+        AccountDataInternalIdFilter filter = filterWithOnlyDirectDebitIdsDisplayed();
 
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getTransactionId()).isNull();
+        // When
+        filter.apply(directDebit);
+        filter.apply(offer);
+        filter.apply(product);
+        filter.apply(statement);
+        filter.apply(domesticTransaction);
+        filter.apply(internationalTransaction);
+        filter.apply(domesticBeneficiary);
+        filter.apply(internationalBeneficiary);
+        filter.apply(domesticScheduledPayment);
+        filter.apply(internationalScheduledPayment);
+        filter.apply(domesticStandingOrder);
+        filter.apply(internationalStandingOrder);
+
+        // Then
+        assertThat(directDebit.getDirectDebitId()).isNotNull();
+        assertThat(offer.getOfferId()).isNull();
+        assertThat(product.getProductId()).isNull();
+        assertThat(statement.getStatementId()).isNull();
+        assertThat(domesticTransaction.getTransactionId()).isNull();
+        assertThat(internationalTransaction.getTransactionId()).isNull();
+        assertThat(domesticBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(internationalBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(domesticScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(internationalScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(domesticStandingOrder.getStandingOrderId()).isNull();
+        assertThat(internationalStandingOrder.getStandingOrderId()).isNull();
     }
 
     @Test
-    public void applyTransaction4() {
-        OBTransaction4 data = new OBTransaction4().transactionId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getTransactionId()).isNotNull();
+    public void shouldIncludeAllExceptDirectDebitId() {
+        // Given
+        AccountDataInternalIdFilter filter = filterWithOnlyDirectDebitIdsHidden();
 
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getTransactionId()).isNull();
+        // When
+        filter.apply(directDebit);
+        filter.apply(offer);
+        filter.apply(product);
+        filter.apply(statement);
+        filter.apply(domesticTransaction);
+        filter.apply(internationalTransaction);
+        filter.apply(domesticBeneficiary);
+        filter.apply(internationalBeneficiary);
+        filter.apply(domesticScheduledPayment);
+        filter.apply(internationalScheduledPayment);
+        filter.apply(domesticStandingOrder);
+        filter.apply(internationalStandingOrder);
+
+        // Then
+        assertThat(directDebit.getDirectDebitId()).isNull();
+        assertThat(offer.getOfferId()).isNotNull();
+        assertThat(product.getProductId()).isNotNull();
+        assertThat(statement.getStatementId()).isNotNull();
+        assertThat(domesticTransaction.getTransactionId()).isNotNull();
+        assertThat(internationalTransaction.getTransactionId()).isNotNull();
+        assertThat(domesticBeneficiary.getBeneficiaryId()).isNotNull();
+        assertThat(internationalBeneficiary.getBeneficiaryId()).isNotNull();
+        assertThat(domesticScheduledPayment.getScheduledPaymentId()).isNotNull();
+        assertThat(internationalScheduledPayment.getScheduledPaymentId()).isNotNull();
+        assertThat(domesticStandingOrder.getStandingOrderId()).isNotNull();
+        assertThat(internationalStandingOrder.getStandingOrderId()).isNotNull();
     }
 
     @Test
-    public void applyBeneficiary2() {
-        OBBeneficiary2 data = new OBBeneficiary2().beneficiaryId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getBeneficiaryId()).isNotNull();
+    public void shouldOnlyIncludeDomesticTransactionId() {
+        // Given
+        AccountDataInternalIdFilter filter = filterWithOnlyDomesticTransactionIdsDisplayed();
 
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getBeneficiaryId()).isNull();
+        // When
+        filter.apply(directDebit);
+        filter.apply(offer);
+        filter.apply(product);
+        filter.apply(statement);
+        filter.apply(domesticTransaction);
+        filter.apply(internationalTransaction);
+        filter.apply(domesticBeneficiary);
+        filter.apply(internationalBeneficiary);
+        filter.apply(domesticScheduledPayment);
+        filter.apply(internationalScheduledPayment);
+        filter.apply(domesticStandingOrder);
+        filter.apply(internationalStandingOrder);
+
+        // Then
+        assertThat(directDebit.getDirectDebitId()).isNull();
+        assertThat(offer.getOfferId()).isNull();
+        assertThat(product.getProductId()).isNull();
+        assertThat(statement.getStatementId()).isNull();
+        assertThat(domesticTransaction.getTransactionId()).isNotNull();
+        assertThat(internationalTransaction.getTransactionId()).isNull();
+        assertThat(domesticBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(internationalBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(domesticScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(internationalScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(domesticStandingOrder.getStandingOrderId()).isNull();
+        assertThat(internationalStandingOrder.getStandingOrderId()).isNull();
     }
 
     @Test
-    public void applyDirectDebit1() {
-        OBDirectDebit1 data = new OBDirectDebit1().directDebitId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getDirectDebitId()).isNotNull();
+    public void shouldOnlyIncludeInternationalTransactionId() {
+        // Given
+        AccountDataInternalIdFilter filter = filterWithOnlyInternationalTransactionIdsDisplayed();
 
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getDirectDebitId()).isNull();
+        // When
+        filter.apply(directDebit);
+        filter.apply(offer);
+        filter.apply(product);
+        filter.apply(statement);
+        filter.apply(domesticTransaction);
+        filter.apply(internationalTransaction);
+        filter.apply(domesticBeneficiary);
+        filter.apply(internationalBeneficiary);
+        filter.apply(domesticScheduledPayment);
+        filter.apply(internationalScheduledPayment);
+        filter.apply(domesticStandingOrder);
+        filter.apply(internationalStandingOrder);
+
+        // Then
+        assertThat(directDebit.getDirectDebitId()).isNull();
+        assertThat(offer.getOfferId()).isNull();
+        assertThat(product.getProductId()).isNull();
+        assertThat(statement.getStatementId()).isNull();
+        assertThat(domesticTransaction.getTransactionId()).isNull();
+        assertThat(internationalTransaction.getTransactionId()).isNotNull();
+        assertThat(domesticBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(internationalBeneficiary.getBeneficiaryId()).isNull();
+        assertThat(domesticScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(internationalScheduledPayment.getScheduledPaymentId()).isNull();
+        assertThat(domesticStandingOrder.getStandingOrderId()).isNull();
+        assertThat(internationalStandingOrder.getStandingOrderId()).isNull();
     }
 
-    @Test
-    public void applyOffer1() {
-        OBOffer1 data = new OBOffer1().offerId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getOfferId()).isNotNull();
-
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getOfferId()).isNull();
+    private AccountDataInternalIdFilter filterWithAllIdsDisplayed() {
+        return new AccountDataInternalIdFilter(
+                true, //showAllAccountDataInternalIds - overrides others below
+                false, //showDirectDebitIds
+                false, //showOfferIds
+                false, //showProductIds
+                false, //showStatementIds
+                false, //showDomesticTransactionIds
+                false, //showInternationalTransactionIds
+                false, //showDomesticBeneficiaryIds
+                false, //showInternationalBeneficiaryIds
+                false, //showDomesticScheduledPaymentIds
+                false, //showInternationalScheduledPaymentIds
+                false, //showDomesticStandingOrderIds
+                false); //showInternationalStandingOrderIds
     }
 
-    @Test
-    public void applyScheduledPayment1() {
-        OBScheduledPayment1 data = new OBScheduledPayment1().scheduledPaymentId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getScheduledPaymentId()).isNotNull();
-
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getScheduledPaymentId()).isNull();
+    private AccountDataInternalIdFilter filterWithAllIdsHidden() {
+        return new AccountDataInternalIdFilter(
+                false, //showAllAccountDataInternalIds
+                false, //showDirectDebitIds
+                false, //showOfferIds
+                false, //showProductIds
+                false, //showStatementIds
+                false, //showDomesticTransactionIds
+                false, //showInternationalTransactionIds
+                false, //showDomesticBeneficiaryIds
+                false, //showInternationalBeneficiaryIds
+                false, //showDomesticScheduledPaymentIds
+                false, //showInternationalScheduledPaymentIds
+                false, //showDomesticStandingOrderIds
+                false); //showInternationalStandingOrderIds
     }
 
-    @Test
-    public void applyStandingOrder1() {
-        OBStandingOrder1 data = new OBStandingOrder1().standingOrderId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getStandingOrderId()).isNotNull();
-
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getStandingOrderId()).isNull();
+    private AccountDataInternalIdFilter filterWithOnlyDirectDebitIdsDisplayed() {
+        return new AccountDataInternalIdFilter(
+                false, //showAllAccountDataInternalIds
+                true, //showDirectDebitIds
+                false, //showOfferIds
+                false, //showProductIds
+                false, //showStatementIds
+                false, //showDomesticTransactionIds
+                false, //showInternationalTransactionIds
+                false, //showDomesticBeneficiaryIds
+                false, //showInternationalBeneficiaryIds
+                false, //showDomesticScheduledPaymentIds
+                false, //showInternationalScheduledPaymentIds
+                false, //showDomesticStandingOrderIds
+                false); //showInternationalStandingOrderIds
     }
 
-    @Test
-    public void applyStandingOrder2() {
-        OBStandingOrder2 data = new OBStandingOrder2().standingOrderId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getStandingOrderId()).isNotNull();
-
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getStandingOrderId()).isNull();
+    private AccountDataInternalIdFilter filterWithOnlyDirectDebitIdsHidden() {
+        return new AccountDataInternalIdFilter(
+                false, //showAllAccountDataInternalIds
+                false, //showDirectDebitIds
+                true, //showOfferIds
+                true, //showProductIds
+                true, //showStatementIds
+                true, //showDomesticTransactionIds
+                true, //showInternationalTransactionIds
+                true, //showDomesticBeneficiaryIds
+                true, //showInternationalBeneficiaryIds
+                true, //showDomesticScheduledPaymentIds
+                true, //showInternationalScheduledPaymentIds
+                true, //showDomesticStandingOrderIds
+                true); //showInternationalStandingOrderIds
     }
 
-    @Test
-    public void applyStandingOrder3() {
-        OBStandingOrder3 data = new OBStandingOrder3().standingOrderId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getStandingOrderId()).isNotNull();
-
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getStandingOrderId()).isNull();
+    private AccountDataInternalIdFilter filterWithOnlyDomesticTransactionIdsDisplayed() {
+        return new AccountDataInternalIdFilter(
+                false, //showAllAccountDataInternalIds
+                false, //showDirectDebitIds
+                false, //showOfferIds
+                false, //showProductIds
+                false, //showStatementIds
+                true, //showDomesticTransactionIds
+                false, //showInternationalTransactionIds
+                false, //showDomesticBeneficiaryIds
+                false, //showInternationalBeneficiaryIds
+                false, //showDomesticScheduledPaymentIds
+                false, //showInternationalScheduledPaymentIds
+                false, //showDomesticStandingOrderIds
+                false); //showInternationalStandingOrderIds
     }
 
-    @Test
-    public void applyStandingOrder4() {
-        OBStandingOrder4 data = new OBStandingOrder4().standingOrderId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getStandingOrderId()).isNotNull();
-
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getStandingOrderId()).isNull();
-    }
-
-    @Test
-    public void applyStatement1() {
-        OBStatement1 data = new OBStatement1().statementId("12345");
-        accountDataInternalIdFilter_showId.apply(data);
-        assertThat(data.getStatementId()).isNotNull();
-
-        accountDataInternalIdFilter_hideId.apply(data);
-        assertThat(data.getStatementId()).isNull();
+    private AccountDataInternalIdFilter filterWithOnlyInternationalTransactionIdsDisplayed() {
+        return new AccountDataInternalIdFilter(
+                false, //showAllAccountDataInternalIds
+                false, //showDirectDebitIds
+                false, //showOfferIds
+                false, //showProductIds
+                false, //showStatementIds
+                false, //showDomesticTransactionIds
+                true, //showInternationalTransactionIds
+                false, //showDomesticBeneficiaryIds
+                false, //showInternationalBeneficiaryIds
+                false, //showDomesticScheduledPaymentIds
+                false, //showInternationalScheduledPaymentIds
+                false, //showDomesticStandingOrderIds
+                false); //showInternationalStandingOrderIds
     }
 }


### PR DESCRIPTION
This PR allows us to easily control which "internal" object IDs are returned (and thereby displayed), via the application's configuration.

For example, it is possible to set `rs.data.internal_ids.direct_debit.show` to false to prevent direct debit IDs being returned. Or where relevant, it is possible to split this further into domestic/international criteria. For example, `rs.data.internal_ids.domestic.beneficiary.show` can be set to false and `rs.data.internal_ids.international.beneficiary.show` set to true, in order to filter domestic beneficiary IDs.

Additionally, this PR introduces the filtering of product IDs.

Issue: https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/344