### PR TITLE
18: Discover RS aspsp payments 3.1.4 links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ Release/1.0.111 (#319)
 - Refund fixes
 - starter parent updated to the lastest version
 - prepare for next development iteration
+### GitHub [#322](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/322) Release/1.0.112
+[c60c3c987af6225](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c60c3c987af6225) Jorge Sanchez Perez *2021-01-12 11:17:40*
+Release/1.0.112 (#322)
+
+* Release candidate: prepare release 1.0.112
+* Release candidate: prepare for next development iteration
+[c1ddc763b46e6c9](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c1ddc763b46e6c9) JamieB *2021-01-11 15:46:34*
+635: Support OBWac and OBSeal Open Banking certs
+
+This code allows registration with Open Banking Test Directory issued
+OBWac and OBSeal certificates.
+
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/635
 [92f3cb2843318b8](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/92f3cb2843318b8) Matt Wills *2020-12-21 11:34:30*
 Release candidate: prepare for next development iteration
 ## 1.0.110

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentConsentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentConsentsApi.java
@@ -127,7 +127,7 @@ public interface DomesticScheduledPaymentConsentsApi {
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
     @PreAuthorize("hasAuthority('ROLE_PISP')")
     @OpenBankingAPI(
-            obReference = OBReference.CREATE_DOMESTIC_SCHEDULED_PAYMENT_CONSENT
+            obReference = OBReference.GET_DOMESTIC_SCHEDULED_PAYMENT_CONSENT
     )
     @RequestMapping(value = "/domestic-scheduled-payment-consents/{ConsentId}",
             produces = {"application/json; charset=utf-8", "application/jose+jwe"},

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -122,7 +122,7 @@ public interface DomesticScheduledPaymentsApi {
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
     @PreAuthorize("hasAuthority('ROLE_PISP')")
     @OpenBankingAPI(
-            obReference = OBReference.CREATE_DOMESTIC_SCHEDULED_PAYMENT
+            obReference = OBReference.GET_DOMESTIC_SCHEDULED_PAYMENT
     )
     @RequestMapping(value = "/domestic-scheduled-payments/{DomesticScheduledPaymentId}",
             produces = {"application/json; charset=utf-8", "application/jose+jwe"},
@@ -168,7 +168,7 @@ public interface DomesticScheduledPaymentsApi {
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
     @PreAuthorize("hasAuthority('ROLE_PISP')")
     @OpenBankingAPI(
-            obReference = OBReference.CREATE_DOMESTIC_SCHEDULED_PAYMENT
+            obReference = OBReference.GET_DOMESTIC_SCHEDULED_PAYMENTS_DOMESTIC_SCHEDULED_PAYMENT_ID_PAYMENT_DETAILS
     )
     @RequestMapping(value = "/domestic-scheduled-payments/{DomesticScheduledPaymentId}/payment-details",
             produces = {"application/json; charset=utf-8", "application/jose+jwe"},

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticstandingorders/DomesticStandingOrderConsentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticstandingorders/DomesticStandingOrderConsentsApi.java
@@ -129,7 +129,7 @@ public interface DomesticStandingOrderConsentsApi {
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
     @PreAuthorize("hasAuthority('ROLE_PISP')")
     @OpenBankingAPI(
-            obReference = OBReference.CREATE_DOMESTIC_STANDING_ORDER_CONSENT
+            obReference = OBReference.GET_DOMESTIC_STANDING_ORDER_CONSENT
     )
     @RequestMapping(value = "/domestic-standing-order-consents/{ConsentId}",
             produces = {"application/json; charset=utf-8", "application/jose+jwe"},

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/internationalstandingorders/InternationalStandingOrderConsentsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/internationalstandingorders/InternationalStandingOrderConsentsApi.java
@@ -129,7 +129,7 @@ public interface InternationalStandingOrderConsentsApi {
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
     @PreAuthorize("hasAuthority('ROLE_PISP')")
     @OpenBankingAPI(
-            obReference = OBReference.CREATE_INTERNATIONAL_STANDING_ORDER_CONSENT
+            obReference = OBReference.GET_INTERNATIONAL_STANDING_ORDER_CONSENT
     )
     @RequestMapping(value = "/international-standing-order-consents/{ConsentId}",
             produces = {"application/json; charset=utf-8", "application/jose+jwe"},


### PR DESCRIPTION
## Features and fixes
- Updated the value `obReference` on `@OpenBankingAPI` annotation to fix the links published by discovery service for payments version 3.1.4
  - URL: `rs.aspsp.${DOMAIN}/open-banking/discovery`
 
## Issues
- [Issue 18](https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/18)