### PR TITLE
674: response_types FAPI compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,30 @@ Release/1.0.112 (#322)
 
 * Release candidate: prepare release 1.0.112
 * Release candidate: prepare for next development iteration
+### GitHub [#323](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/323) 18: Discover RS aspsp payments 3.1.4 links
+[4726880f61e5c4d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/4726880f61e5c4d) Jorge Sanchez Perez *2021-01-14 09:24:20*
+18: Discover RS aspsp payments 3.1.4 links (#323)
+
+- Updated the value obReference on @OpenBankingAPI annotation to fix the links published by discovery service
+  - URL: rs.aspsp.${DOMAIN}/open-banking/discovery
+### GitHub [#324](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/324) Release/1.0.113
+[58e7ca0d31e3bee](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/58e7ca0d31e3bee) Jorge Sanchez Perez *2021-01-14 10:27:25*
+Release/1.0.113 (#324)
+
+* Release candidate: prepare release 1.0.113
+
+* Release candidate: prepare for next development iteration
+### GitHub [#328](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/328) 672: payment frequency pattern validation
+[5a90bea1d1cd3b4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/5a90bea1d1cd3b4) Jorge Sanchez Perez *2021-02-04 10:47:30*
+672: payment frequency pattern validation (#328)
+
+* 672: Payment Frequency pattern validation error
+- update the regular expression for frequency type 'IntrvlMnthDay'
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/672
+
+* - JUnit tests added to validate the payment frequency interval
+
+Co-authored-by: Matt Wills <matt.wills@forgerock.com>
 [c1ddc763b46e6c9](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c1ddc763b46e6c9) JamieB *2021-01-11 15:46:34*
 635: Support OBWac and OBSeal Open Banking certs
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/oauth2/discovery/DiscoveryConfig.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/oauth2/discovery/DiscoveryConfig.java
@@ -36,6 +36,8 @@ public class DiscoveryConfig {
     private List<String> supportedAuthMethod;
     @Value("${grant-types.supported}")
     private List<String> supportedGrantTypes;
+    @Value("${response-types.supported}")
+    private List<String> supportedResponseTypes;
     @Value("${user-info.enable}")
     private boolean isUserInfoEnable;
     @Value("${introspection.enable}")

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/api/authorisation/AuthorisationApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/api/authorisation/AuthorisationApiControllerTest.java
@@ -22,6 +22,7 @@ package com.forgerock.openbanking.aspsp.as.api.authorisation;
 
 import com.forgerock.openbanking.am.services.AMGatewayService;
 import com.forgerock.openbanking.aspsp.as.api.authorisation.redirect.AuthorisationApiController;
+import com.forgerock.openbanking.aspsp.as.api.oauth2.discovery.DiscoveryConfig;
 import com.forgerock.openbanking.aspsp.as.service.headless.authorisation.HeadLessAuthorisationService;
 import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
 import com.forgerock.openbanking.exceptions.OBErrorException;
@@ -35,14 +36,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 import static com.forgerock.openbanking.aspsp.as.api.authorisation.JwtTestHelper.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.BDDMockito.given;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -56,12 +60,16 @@ public class AuthorisationApiControllerTest {
     private CryptoApiClient cryptoApiClient;
     @Mock
     private AMGatewayService amGatewayService;
+    @Mock
+    private DiscoveryConfig discoveryConfig;
     @InjectMocks
     private AuthorisationApiController authorisationApiController;
 
     @Test
     public void shouldNotThrowExceptionWhenContainAllScopes() throws OBErrorException, OBErrorResponseException {
         // Given
+        List<String> responseTypes = List.of("code id_token");
+        given(discoveryConfig.getSupportedResponseTypes()).willReturn(responseTypes);
         String jwt = toEncodedSignedTestJwt("jwt/authorisation.jwt");
         Tpp tpp = new Tpp();
         OIDCRegistrationResponse registrationResponse = new OIDCRegistrationResponse();
@@ -70,7 +78,7 @@ public class AuthorisationApiControllerTest {
         given(tppStoreService.findByClientId(null)).willReturn(Optional.of(tpp));
 
         // When
-        authorisationApiController.getAuthorisation(null, null, null, null, "openid accounts payments", null, jwt, true, null, null, null, null, null);
+        authorisationApiController.getAuthorisation(responseTypes.get(0), null, null, null, "openid accounts payments", null, jwt, true, null, null, null, null, null);
 
         // Then no exception
     }
@@ -78,6 +86,8 @@ public class AuthorisationApiControllerTest {
     @Test
     public void shouldNotThrowExceptionContainAllScopesAnyOrder() throws OBErrorException, OBErrorResponseException {
         // Given
+        List<String> responseTypes = List.of("code id_token");
+        given(discoveryConfig.getSupportedResponseTypes()).willReturn(responseTypes);
         String jwt = toEncodedSignedTestJwt("jwt/authorisation.jwt");
         Tpp tpp = new Tpp();
         OIDCRegistrationResponse registrationResponse = new OIDCRegistrationResponse();
@@ -86,7 +96,7 @@ public class AuthorisationApiControllerTest {
         given(tppStoreService.findByClientId(null)).willReturn(Optional.of(tpp));
 
         // When
-        authorisationApiController.getAuthorisation(null, null, null, null, "payments openid accounts", null, jwt, true, null, null, null, null, null);
+        authorisationApiController.getAuthorisation(responseTypes.get(0), null, null, null, "payments openid accounts", null, jwt, true, null, null, null, null, null);
 
         // Then no exception
     }
@@ -94,6 +104,8 @@ public class AuthorisationApiControllerTest {
     @Test
     public void shouldNotThrowExceptionWhenNoUserInfo() throws OBErrorException, OBErrorResponseException {
         // Given
+        List<String> responseTypes = List.of("code id_token");
+        given(discoveryConfig.getSupportedResponseTypes()).willReturn(responseTypes);
         String jwt = toEncodedSignedTestJwt("jwt/authorisation-no-user-info.jwt");
         Tpp tpp = new Tpp();
         OIDCRegistrationResponse registrationResponse = new OIDCRegistrationResponse();
@@ -102,7 +114,7 @@ public class AuthorisationApiControllerTest {
         given(tppStoreService.findByClientId(null)).willReturn(Optional.of(tpp));
 
         // When
-        authorisationApiController.getAuthorisation(null, null, null, null, "payments openid accounts", null, jwt, true, null, null, null, null, null);
+        authorisationApiController.getAuthorisation(responseTypes.get(0), null, null, null, "payments openid accounts", null, jwt, true, null, null, null, null, null);
 
         // Then no exception
     }
@@ -110,6 +122,8 @@ public class AuthorisationApiControllerTest {
     @Test(expected = OBErrorException.class)
     public void shouldThrowExceptionWhenJwtScopesDoNotMatchQueryParamScope() throws OBErrorException, OBErrorResponseException {
         // Given
+        List<String> responseTypes = List.of("code id_token");
+        given(discoveryConfig.getSupportedResponseTypes()).willReturn(responseTypes);
         String jwt = toEncodedSignedTestJwt("jwt/authorisation.jwt");
         Tpp tpp = new Tpp();
         OIDCRegistrationResponse registrationResponse = new OIDCRegistrationResponse();
@@ -118,9 +132,48 @@ public class AuthorisationApiControllerTest {
         given(tppStoreService.findByClientId(null)).willReturn(Optional.of(tpp));
 
         // When
-        authorisationApiController.getAuthorisation(null, null, null, null, "openid accounts", null, jwt, true, null, null, null, null, null);
+        authorisationApiController.getAuthorisation(responseTypes.get(0), null, null, null, "openid accounts", null, jwt, true, null, null, null, null, null);
 
         // Then exception
+    }
+
+    @Test
+    public void shouldNotThrowExceptionWhen_responseTypesMatch() throws OBErrorException, OBErrorResponseException {
+        // Given
+        List<String> responseTypes = List.of("code id_token");
+        given(discoveryConfig.getSupportedResponseTypes()).willReturn(responseTypes);
+        String jwt = toEncodedSignedTestJwt("jwt/authorisation.jwt");
+        Tpp tpp = new Tpp();
+        OIDCRegistrationResponse registrationResponse = new OIDCRegistrationResponse();
+        registrationResponse.setJwks_uri("");
+        tpp.setRegistrationResponse(registrationResponse);
+        given(tppStoreService.findByClientId(null)).willReturn(Optional.of(tpp));
+        String responseType = responseTypes.get(0);
+
+        // When
+        authorisationApiController.getAuthorisation(responseType, null, null, null, "openid accounts payments", null, jwt, true, null, null, null, null, null);
+
+        // Then no exception
+    }
+
+    @Test
+    public void shouldBeBadRequestWhen_responseTypesNotMatch() {
+        // Given
+        List<String> responseTypes = List.of("code id_token");
+        given(discoveryConfig.getSupportedResponseTypes()).willReturn(responseTypes);
+        String jwt = toEncodedSignedTestJwt("jwt/authorisation.jwt");
+        Tpp tpp = new Tpp();
+        OIDCRegistrationResponse registrationResponse = new OIDCRegistrationResponse();
+        registrationResponse.setJwks_uri("");
+        tpp.setRegistrationResponse(registrationResponse);
+        String responseType = "device_code";
+
+        // When
+        OBErrorResponseException e = catchThrowableOfType(() -> authorisationApiController.getAuthorisation(responseType, null, null, null, "openid accounts payments", null, jwt, true, null, null, null, null, null), OBErrorResponseException.class);
+
+        // Then
+        assertThat(e.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(e.getErrors().get(0).getMessage()).isEqualTo("The response type '" + responseType + "' is not supported. Supported response types are '"+discoveryConfig.getSupportedResponseTypes()+"'");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.0.86</ob-common.version>
+        <ob-common.version>1.0.87</ob-common.version>
         <ob-clients.version>1.0.44</ob-clients.version>
         <ob-auth.version>1.0.65</ob-auth.version>
         <ob-jwkms.version>1.1.76</ob-jwkms.version>


### PR DESCRIPTION
### Description
- Added supported for new spring configuration property `response-types.supported` that contains the values of responses types supported by as-api ([see config app](https://github.com/OpenBankingToolkit/openbanking-reference-implementation/blob/master/forgerock-openbanking-config/forgerock-openbanking-git-config/aspsp/as/as-api))
   - Added the response-types property holder in `DiscoveryConfig`
- Support for new Error types [Common](https://github.com/OpenBankingToolkit/openbanking-common)
- Added a condition in `DiscoveryApiController#getDiscovery` to check if the configured responses types in as-api match with the configured response types in AM.
 - Added new unit tests in `DiscoveryApiControllerTest` and `AuthorisationApiControllerTest`
### Issues related
- [Issue 674](https://github.com/ForgeCloud/ob-deploy/issues/674)