### PR TITLE
16: Revert change to Discovery Serlialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
-[8fed42b0aaa563e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/8fed42b0aaa563e) JamieB *2021-03-18 17:34:43*
-Release candidate: prepare for next development iteration
-## 1.2.2
 ### GitHub [#342](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/342) Release/1.1.118
 [141816573d0231d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/141816573d0231d) Jorge Sanchez Perez *2021-02-22 15:07:48*
 Release/1.1.118 (#342)
@@ -40,37 +37,6 @@ Release/1.2.0 (#350)
 * Release candidate: prepare release 1.2.0
 
 * Release candidate: prepare for next development iteration
-### GitHub [#354](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/354) Release/1.2.1
-[8e85606d358c96d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/8e85606d358c96d) Jorge Sanchez Perez *2021-03-18 09:49:29*
-Release/1.2.1 (#354)
-
-* Release candidate: prepare release 1.2.1
-
-* Release candidate: prepare for next development iteration
-[d24b7341d82295e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d24b7341d82295e) JamieB *2021-03-18 17:34:37*
-Release candidate: prepare release 1.2.2
-[49c8d51b3ae697f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/49c8d51b3ae697f) JamieB *2021-03-18 17:12:30*
-721: Need a default spring value for all spring config
-
-So that this can run even if no spring config server is available the
-rs.data.upload.limit.documents spring config value. This was causing
-failure of integration tests in the obri project when no spring config
-was available.
-
-Issue: https://github.com/ForgeCloud/ob-deploy/issues/721
-[b78ec6751ee3bc4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/b78ec6751ee3bc4) jorgesanchezperez *2021-03-17 17:31:18*
-Deleted application.yml file from rs-mock-store-server library
-[0049d9050fa579c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0049d9050fa579c) jorgesanchezperez *2021-03-17 17:29:06*
-increase default values for limits defined on DataCreator
-[9af9357b7254cd4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/9af9357b7254cd4) jorgesanchezperez *2021-03-17 17:25:24*
-Fix license
-[5c211b60d24784f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/5c211b60d24784f) jorgesanchezperez *2021-03-17 17:24:08*
-Added default values for data creator documents and accounts limits
-[20e8a19e9790614](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/20e8a19e9790614) jorgesanchezperez *2021-03-17 17:11:17*
-351-352: self link by version and funds confirmations
-Issues:
-https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/351
-https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/352
 [0bd6069b9ede3cf](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0bd6069b9ede3cf) Matt Wills *2021-03-10 11:29:45*
 20 - Fix expected JSON format
 

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/conf/discovery/GenericOBDiscoveryAPILinks.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/conf/discovery/GenericOBDiscoveryAPILinks.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.conf.discovery;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinks;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenericOBDiscoveryAPILinks implements OBDiscoveryAPILinks  {
+    private Map<String, String> links = new HashMap<>();
+
+    public GenericOBDiscoveryAPILinks addLink(String reference, String endpoint) {
+        links.put(reference, endpoint);
+        return this;
+    }
+
+    public Collection<String> getLinkValues() {
+        return new ArrayList<>(links.values());
+    };
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/conf/discovery/RSAPIsConfigurationProperties.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/conf/discovery/RSAPIsConfigurationProperties.java
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.ClassPathScanningCandidateComponen
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestMapping;
-import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
 
 import java.lang.reflect.Method;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/configuration/SwaggerDocumentationConfig.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/configuration/SwaggerDocumentationConfig.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.aspsp.rs.configuration;
 
+import com.forgerock.openbanking.common.conf.discovery.GenericOBDiscoveryAPILinks;
 import com.forgerock.openbanking.common.conf.discovery.RSAPIsConfigurationProperties;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -34,7 +35,6 @@ import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.ApiSelectorBuilder;
 import springfox.documentation.spring.web.plugins.Docket;
-import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
 
 import java.security.Principal;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/discovery/DiscoveryResponse.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/discovery/DiscoveryResponse.java
@@ -21,11 +21,11 @@
 package com.forgerock.openbanking.aspsp.rs.api.discovery;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.forgerock.openbanking.common.conf.discovery.GenericOBDiscoveryAPILinks;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
 
 import java.util.List;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/discovery/DiscoveryTestIT.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/discovery/DiscoveryTestIT.java
@@ -21,6 +21,7 @@
 package com.forgerock.openbanking.aspsp.rs.api.discovery;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.openbanking.common.conf.discovery.GenericOBDiscoveryAPILinks;
 import kong.unirest.HttpResponse;
 import kong.unirest.JacksonObjectMapper;
 import kong.unirest.Unirest;
@@ -33,7 +34,6 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.util.UriComponentsBuilder;
-import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
 import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
 
 import java.net.URI;

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.1.87</version>
+        <version>1.1.86</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
### Revert switch to GenericOBDiscoveryAPILinks within uk-datamodel

Unfortunately this change unexpectedly broke several other services, as it seems they are dependent on `uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks`! It resulted in a `ClassNotFoundException` within these services:

- jwkms
- as-api
- rs-ui
- monitoring
- rs-rcs
- metrics-services
- rs-store

I'm reverting this change as it's not worth the benefit.

**Issue**: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/16