### PR TITLE
741: Report file payment, csv file type not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/28
 
 * 28: fetch statement pdf resource from gcp
 Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/28
+### GitHub [#374](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/374) Release/1.3.0
+[3814a23a87850d9](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/3814a23a87850d9) Jorge Sanchez Perez *2021-04-20 14:55:39*
+Release/1.3.0 (#374)
+
+* upgrade the version
+
+* Release candidate: prepare release 1.3.0
+
+* Release candidate: prepare for next development iteration
+
+* added changelog
 [2c8e8e022f91825](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/2c8e8e022f91825) Matt Wills *2021-03-25 09:55:27*
 16: Switch to GenericOBDiscoveryAPILinks in uk-datamodel
 

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/forgerock/filepayment/v3_0/UnsupportedFileTypeException.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/forgerock/filepayment/v3_0/UnsupportedFileTypeException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0;
+
+public class UnsupportedFileTypeException extends RuntimeException {
+    public UnsupportedFileTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnsupportedFileTypeException(String message) {
+        super(message);
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/forgerock/filepayment/v3_0/report/PaymentReportFile1Service.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/forgerock/filepayment/v3_0/report/PaymentReportFile1Service.java
@@ -69,13 +69,13 @@ public class PaymentReportFile1Service {
         }
 
         switch (consent.getFileType()) {
-                case UK_OBIE_PAYMENT_INITIATION_V3_0:
-                    return obiePaymentInitiationReportBuilder.toPaymentReport(consent);
-                case UK_OBIE_PAIN_001:
-                    return obiePainXmlReportBuilder.toPaymentReport(consent);
-                default:
-                    log.error("Consent submitted with file type {} should not have passed validation. No report file is supported for this type.", consent.getFileType());
-                    throw new IllegalArgumentException("Unknown payment file type: "+consent.getFileType());
+            case UK_OBIE_PAYMENT_INITIATION_V3_0:
+                return obiePaymentInitiationReportBuilder.toPaymentReport(consent);
+            case UK_OBIE_PAIN_001:
+                return obiePainXmlReportBuilder.toPaymentReport(consent);
+            default:
+                log.error("Consent submitted with file type {} should not have passed validation. No report file is supported for this type.", consent.getFileType());
+                throw new IllegalArgumentException("No report file is supported for this type: " + consent.getFileType());
         }
     }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/forgerock/filepayment/v3_0/report/PaymentReportFile1Service.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/forgerock/filepayment/v3_0/report/PaymentReportFile1Service.java
@@ -21,6 +21,7 @@
 package com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.report;
 
 
+import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.UnsupportedFileTypeException;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
@@ -75,7 +76,7 @@ public class PaymentReportFile1Service {
                 return obiePainXmlReportBuilder.toPaymentReport(consent);
             default:
                 log.error("Consent submitted with file type {} should not have passed validation. No report file is supported for this type.", consent.getFileType());
-                throw new IllegalArgumentException("No report file is supported for this type: " + consent.getFileType());
+                throw new UnsupportedFileTypeException("No report file is supported for this type: " + consent.getFileType());
         }
     }
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/file/FilePaymentsApiController.java
@@ -225,9 +225,13 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                                         .toOBError1(filePaymentId))
                 );
         log.debug("Consent '{}' exists with status: {} so generating a report file for type: '{}'", consent.getId(), consent.getStatus(), consent.getFileType());
-        final String reportFile = paymentReportFileService.createPaymentReport(consent);
-        log.debug("Generated report file for consent: '{}'", consent.getId());
-        return ResponseEntity.ok(reportFile);
+        try {
+            final String reportFile = paymentReportFileService.createPaymentReport(consent);
+            log.debug("Generated report file for consent: '{}'", consent.getId());
+            return ResponseEntity.ok(reportFile);
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type " + consent.getFileType().getFileType() + " not supported\" }");
+        }
     }
 
     private OBWriteFileResponse1 responseEntity(FRFilePaymentSubmission frPaymentSubmission, FRFileConsent frFileConsent) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_0/file/FilePaymentsApiController.java
@@ -26,6 +26,7 @@ import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FilePaymentS
 import com.forgerock.openbanking.aspsp.rs.store.utils.VersionPathExtractor;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.domain.payment.FRWriteFile;
+import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.UnsupportedFileTypeException;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.report.PaymentReportFile1Service;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
@@ -229,7 +230,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             final String reportFile = paymentReportFileService.createPaymentReport(consent);
             log.debug("Generated report file for consent: '{}'", consent.getId());
             return ResponseEntity.ok(reportFile);
-        } catch (IllegalArgumentException exception) {
+        } catch (UnsupportedFileTypeException exception) {
             return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type " + consent.getFileType().getFileType() + " not supported\" }");
         }
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/file/FilePaymentsApiController.java
@@ -21,15 +21,15 @@
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.file;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.IdempotentRepositoryAdapter;
-import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FilePaymentSubmissionRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FileConsentRepository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FilePaymentSubmissionRepository;
 import com.forgerock.openbanking.aspsp.rs.store.utils.VersionPathExtractor;
 import com.forgerock.openbanking.common.conf.discovery.DiscoveryConfigurationProperties;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.domain.payment.FRWriteFile;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.report.PaymentReportFile1Service;
-import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
 import com.forgerock.openbanking.model.error.OBRIErrorType;
@@ -96,7 +96,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
+            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
             @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
@@ -149,7 +149,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
+            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
             @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
@@ -200,7 +200,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
+            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
             @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
@@ -225,9 +225,13 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                                         .toOBError1(filePaymentId))
                 );
         log.debug("Consent '{}' exists so generating a report file for type: '{}'", consent.getId(), consent.getStatus(), consent.getFileType());
-        final String reportFile = paymentReportFileService.createPaymentReport(consent);
-        log.debug("Generated report file for consent: '{}'", consent.getId());
-        return ResponseEntity.ok(reportFile);
+        try {
+            final String reportFile = paymentReportFileService.createPaymentReport(consent);
+            log.debug("Generated report file for consent: '{}'", consent.getId());
+            return ResponseEntity.ok(reportFile);
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type " + consent.getFileType().getFileType() + " not supported\" }");
+        }
     }
 
     private OBWriteFileResponse2 responseEntity(FRFilePaymentSubmission frPaymentSubmission, FRFileConsent frFileConsent) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1/file/FilePaymentsApiController.java
@@ -27,6 +27,7 @@ import com.forgerock.openbanking.aspsp.rs.store.utils.VersionPathExtractor;
 import com.forgerock.openbanking.common.conf.discovery.DiscoveryConfigurationProperties;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.domain.payment.FRWriteFile;
+import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.UnsupportedFileTypeException;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.report.PaymentReportFile1Service;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
@@ -229,7 +230,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             final String reportFile = paymentReportFileService.createPaymentReport(consent);
             log.debug("Generated report file for consent: '{}'", consent.getId());
             return ResponseEntity.ok(reportFile);
-        } catch (IllegalArgumentException exception) {
+        } catch (UnsupportedFileTypeException exception) {
             return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type " + consent.getFileType().getFileType() + " not supported\" }");
         }
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentsApiController.java
@@ -26,15 +26,15 @@
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_3.file;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.IdempotentRepositoryAdapter;
-import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FilePaymentSubmissionRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FileConsentRepository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FilePaymentSubmissionRepository;
 import com.forgerock.openbanking.aspsp.rs.store.utils.VersionPathExtractor;
 import com.forgerock.openbanking.common.conf.discovery.DiscoveryConfigurationProperties;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.domain.payment.FRWriteFile;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.report.PaymentReportFile1Service;
-import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
 import com.forgerock.openbanking.model.error.OBRIErrorType;
@@ -181,9 +181,13 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                                         .toOBError1(filePaymentId))
                 );
         log.debug("Consent '{}' exists so generating a report file for type: '{}'", consent.getId(), consent.getStatus(), consent.getFileType());
-        final String reportFile = paymentReportFileService.createPaymentReport(consent);
-        log.debug("Generated report file for consent: '{}'", consent.getId());
-        return ResponseEntity.ok(reportFile);
+        try {
+            final String reportFile = paymentReportFileService.createPaymentReport(consent);
+            log.debug("Generated report file for consent: '{}'", consent.getId());
+            return ResponseEntity.ok(reportFile);
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type \"" + consent.getFileType().getFileType() + " not supported\" }");
+        }
     }
 
     private OBWriteFileResponse2 responseEntity(FRFilePaymentSubmission frPaymentSubmission, FRFileConsent frFileConsent) {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentsApiController.java
@@ -32,6 +32,7 @@ import com.forgerock.openbanking.aspsp.rs.store.utils.VersionPathExtractor;
 import com.forgerock.openbanking.common.conf.discovery.DiscoveryConfigurationProperties;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.domain.payment.FRWriteFile;
+import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.UnsupportedFileTypeException;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.report.PaymentReportFile1Service;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
@@ -185,7 +186,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             final String reportFile = paymentReportFileService.createPaymentReport(consent);
             log.debug("Generated report file for consent: '{}'", consent.getId());
             return ResponseEntity.ok(reportFile);
-        } catch (IllegalArgumentException exception) {
+        } catch (UnsupportedFileTypeException exception) {
             return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type \"" + consent.getFileType().getFileType() + " not supported\" }");
         }
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_3/file/FilePaymentsApiController.java
@@ -187,7 +187,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             log.debug("Generated report file for consent: '{}'", consent.getId());
             return ResponseEntity.ok(reportFile);
         } catch (UnsupportedFileTypeException exception) {
-            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type \"" + consent.getFileType().getFileType() + " not supported\" }");
+            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type " + consent.getFileType().getFileType() + " not supported\" }");
         }
     }
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentsApiController.java
@@ -32,6 +32,7 @@ import com.forgerock.openbanking.aspsp.rs.store.utils.VersionPathExtractor;
 import com.forgerock.openbanking.common.conf.discovery.DiscoveryConfigurationProperties;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.domain.payment.FRWriteFile;
+import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.UnsupportedFileTypeException;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.filepayment.v3_0.report.PaymentReportFile1Service;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFilePaymentSubmission;
@@ -185,7 +186,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             final String reportFile = paymentReportFileService.createPaymentReport(consent);
             log.debug("Generated report file for consent: '{}'", consent.getId());
             return ResponseEntity.ok(reportFile);
-        } catch (IllegalArgumentException exception) {
+        } catch (UnsupportedFileTypeException exception) {
             return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type \"" + consent.getFileType().getFileType() + " not supported\" }");
         }
     }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentsApiController.java
@@ -187,7 +187,7 @@ public class FilePaymentsApiController implements FilePaymentsApi {
             log.debug("Generated report file for consent: '{}'", consent.getId());
             return ResponseEntity.ok(reportFile);
         } catch (UnsupportedFileTypeException exception) {
-            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type \"" + consent.getFileType().getFileType() + " not supported\" }");
+            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type " + consent.getFileType().getFileType() + " not supported\" }");
         }
     }
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_5/file/FilePaymentsApiController.java
@@ -181,9 +181,13 @@ public class FilePaymentsApiController implements FilePaymentsApi {
                                         .toOBError1(filePaymentId))
                 );
         log.debug("Consent '{}' exists so generating a report file for type: '{}'", consent.getId(), consent.getStatus(), consent.getFileType());
-        final String reportFile = paymentReportFileService.createPaymentReport(consent);
-        log.debug("Generated report file for consent: '{}'", consent.getId());
-        return ResponseEntity.ok(reportFile);
+        try {
+            final String reportFile = paymentReportFileService.createPaymentReport(consent);
+            log.debug("Generated report file for consent: '{}'", consent.getId());
+            return ResponseEntity.ok(reportFile);
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("{ \"Description\" : \"Report for file type \"" + consent.getFileType().getFileType() + " not supported\" }");
+        }
     }
 
     private OBWriteFileResponse3 responseEntity(FRFilePaymentSubmission frPaymentSubmission, FRFileConsent frFileConsent) {


### PR DESCRIPTION
- Report file not supported for CSV file types, response improved

Issue: https://github.com/ForgeCloud/ob-deploy/issues/741