### PR TITLE
742: token endpoint 500 error improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+### GitHub [#391](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/391) 32: Bumped version of parent pom to pull in minor fix to datamodel
+[0e5b86be2bf47ae](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0e5b86be2bf47ae) Matt Wills *2021-05-13 10:34:21*
+32: Bumped version of parent pom to pull in minor fix to datamodel (#391)
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
 [6891d6ec4fbeb64](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/6891d6ec4fbeb64) Matt Wills *2021-05-12 11:54:03*
 32: Bumped parent pom to release version
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
@@ -31,8 +31,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
@@ -31,8 +31,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
@@ -35,11 +35,12 @@
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
 		<version>1.3.4-SNAPSHOT</version>
-		<relativePath>../../../</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 
 	<properties>
 		<snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
+		<main.basedir.license>${project.parent.basedir}</main.basedir.license>
 	</properties>
 
 	<dependencies>

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
@@ -35,11 +35,12 @@
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
 		<version>1.3.4-SNAPSHOT</version>
-		<relativePath>../../../</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 
 	<properties>
 		<snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
+		<main.basedir.license>${project.parent.basedir}</main.basedir.license>
 	</properties>
 
 	<dependencies>

--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -33,6 +33,10 @@
         <version>1.3.4-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.forgerock.openbanking</groupId>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
@@ -31,8 +31,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
@@ -31,8 +31,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
@@ -35,8 +35,12 @@
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
 		<version>1.3.4-SNAPSHOT</version>
-		<relativePath>../../../</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
+
+	<properties>
+		<main.basedir.license>${project.parent.basedir}</main.basedir.license>
+	</properties>
 
 	<dependencies>
 		<dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
@@ -35,8 +35,12 @@
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
 		<version>1.3.4-SNAPSHOT</version>
-		<relativePath>../../../</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
+
+	<properties>
+		<main.basedir.license>${project.parent.basedir}</main.basedir.license>
+	</properties>
 
 	<dependencies>
 		<dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
@@ -35,8 +35,12 @@
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
 		<version>1.3.4-SNAPSHOT</version>
-		<relativePath>../../../</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
+
+	<properties>
+		<main.basedir.license>${project.parent.basedir}</main.basedir.license>
+	</properties>
 
 	<dependencies>
 		<dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
@@ -35,8 +35,12 @@
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
 		<version>1.3.4-SNAPSHOT</version>
-		<relativePath>../../../</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
+
+	<properties>
+		<main.basedir.license>${project.parent.basedir}</main.basedir.license>
+	</properties>
 
 	<dependencies>
 		<dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
@@ -35,8 +35,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
@@ -38,6 +38,10 @@
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.forgerock.openbanking.uk</groupId>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
@@ -35,8 +35,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
@@ -35,8 +35,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/integration-test-support/pom.xml
+++ b/integration-test-support/pom.xml
@@ -30,7 +30,12 @@
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
         <version>1.3.4-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <main.basedir.license>${project.parent.basedir}</main.basedir.license>
+    </properties>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,12 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.1.3</ob-common.version>
-        <ob-clients.version>1.1.3</ob-clients.version>
-        <ob-jwkms.version>1.1.82</ob-jwkms.version>
-        <ob-auth.version>1.0.70</ob-auth.version>
+        <ob-common.version>1.1.4</ob-common.version>
+        <ob-clients.version>1.1.4</ob-clients.version>
+        <ob-jwkms.version>1.1.83</ob-jwkms.version>
+        <ob-auth.version>1.0.71</ob-auth.version>
         <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
+        <main.basedir.license>${project.basedir}</main.basedir.license>
     </properties>
 
     <modules>
@@ -200,6 +201,13 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${main.basedir.license}/legal/LICENSE.txt</header>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
- Bumped starter parent version 1.1.97
- Bumped common version 1.1.4
- Bumped clients version 1.1.4
- Bumped jwkms version 1.1.83
- Bumped auth version 1.0.71
- Added support to build module independently avoiding license error.
- Added UnsupportedOIDCAuthMethodsException and UnsupportedOIDCGrantTypeException in custom handler

Issue: https://github.com/ForgeCloud/ob-deploy/issues/742