### PR TITLE
745: Make hybrid flow redirect uri's id_token verifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+
+e9a36d40... 745: Make hybrid flow redirect uri's id_token verifiable
+
 ### GitHub [#391](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/391) 32: Bumped version of parent pom to pull in minor fix to datamodel
 [0e5b86be2bf47ae](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0e5b86be2bf47ae) Matt Wills *2021-05-13 10:34:21*
 32: Bumped version of parent pom to pull in minor fix to datamodel (#391)
@@ -52,6 +55,7 @@ Release/1.4.1 (#406)
 * Release candidate: prepare release 1.4.1
 
 * Release candidate: prepare for next development iteration
+
 [75f094eb79dcb7c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/75f094eb79dcb7c) Matt Wills *2021-05-24 13:36:57*
 33: v3.1.8 of Events and Funds Confirmation APIs
 
@@ -71,6 +75,7 @@ Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33
 - Fixes prior to new v3.1.8 controller classes and interfaces
 
 Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/76
+
 [9f3308ce4919304](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/9f3308ce4919304) Matt Wills *2021-05-18 10:12:41*
 32: Removed accidental import of org.bouncycastle.asn1.x500.style.RFC4519Style.postalAddress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,112 +1,52 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
-
-e9a36d40... 745: Make hybrid flow redirect uri's id_token verifiable
-
-### GitHub [#391](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/391) 32: Bumped version of parent pom to pull in minor fix to datamodel
-[0e5b86be2bf47ae](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0e5b86be2bf47ae) Matt Wills *2021-05-13 10:34:21*
-32: Bumped version of parent pom to pull in minor fix to datamodel (#391)
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
-### GitHub [#392](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/392) 742: token endpoint 500 error improvements
-[d1c2a4ea43d7d45](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d1c2a4ea43d7d45) Jorge Sanchez Perez *2021-05-14 07:38:05*
-742: token endpoint 500 error improvements (#392)
-
-- Bumped starter parent version 1.1.97
-- Bumped common version 1.1.4
-- Bumped clients version 1.1.4
-- Bumped jwkms version 1.1.83
-- Bumped auth version 1.0.71
-- Added support to build module independently avoiding license error.
-- Added UnsupportedOIDCAuthMethodsException and UnsupportedOIDCGrantTypeException in custom handler
-Issue: https://github.com/ForgeCloud/ob-deploy/issues/742
-### GitHub [#397](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/397) Release/1.3.4
-[92492510eba8e77](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/92492510eba8e77) Jorge Sanchez Perez *2021-05-14 08:05:45*
-Release/1.3.4 (#397)
-
-* changelog
-
-* Release candidate: prepare release 1.3.4
-
-* Release candidate: prepare for next development iteration
-### GitHub [#404](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/404) Release/1.4.0
-[e56fad339682b16](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e56fad339682b16) Jorge Sanchez Perez *2021-05-17 10:31:59*
-Release/1.4.0 (#404)
-
-* Release 1.4.0
-- Bumped common version 1.2.0
-- Bumped clients version 1.2.0
-- Bumped jwkms version 1.2.0
-- Bumped auth version 1.1.0
-- Upgrade aspsp version to 1.4.0
-
-* Release candidate: prepare release 1.4.0
-
-* Release candidate: prepare for next development iteration
-
-* changelog
-### GitHub [#406](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/406) Release/1.4.1
-[c20afa490c34de8](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c20afa490c34de8) Jorge Sanchez Perez *2021-05-18 14:33:09*
-Release/1.4.1 (#406)
-
-* changelog
-
-* Release candidate: prepare release 1.4.1
-
-* Release candidate: prepare for next development iteration
-
-[75f094eb79dcb7c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/75f094eb79dcb7c) Matt Wills *2021-05-24 13:36:57*
-33: v3.1.8 of Events and Funds Confirmation APIs
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33
-[ff6bd0672f383d6](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/ff6bd0672f383d6) Matt Wills *2021-05-24 13:25:28*
-33: v3.1.8 of Accounts API gateway controllers and interfaces
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33
-[0a1b7f53da3cc34](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0a1b7f53da3cc34) Matt Wills *2021-05-24 12:54:37*
-33: v3.1.8 of Payment API controllers and interfaces
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33
-[492016f2f9a6054](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/492016f2f9a6054) Matt Wills *2021-05-21 14:27:18*
-76: Migrated to v3.1.8 of uk-datamodel
-
-- Fixed compilation errors after moving to consolidated enums
-- Fixes prior to new v3.1.8 controller classes and interfaces
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/76
-
-[9f3308ce4919304](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/9f3308ce4919304) Matt Wills *2021-05-18 10:12:41*
-32: Removed accidental import of org.bouncycastle.asn1.x500.style.RFC4519Style.postalAddress
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
-[764b09728e0b43b](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/764b09728e0b43b) Matt Wills *2021-05-17 09:59:54*
-32: v3.1.7 Discovery config
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
-[708ca312a764b16](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/708ca312a764b16) Matt Wills *2021-05-14 10:31:10*
-32: Bumped version of parent pom to include v3.1.7 of Events/Funds datamodel
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
-[7e7eac2b578b928](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/7e7eac2b578b928) Matt Wills *2021-05-14 09:14:32*
-32: v3.1.7 of Events and Funds API
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
-[6891d6ec4fbeb64](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/6891d6ec4fbeb64) Matt Wills *2021-05-12 11:54:03*
-32: Bumped parent pom to release version
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/32
-[9daa4c020e616a9](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/9daa4c020e616a9) Matt Wills *2021-05-12 11:53:24*
-32: Additional changes after regeneration of v3.1.7 datamodel (using Open API spec)
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/32
-[0336d2691fa87ce](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0336d2691fa87ce) Matt Wills *2021-05-12 11:53:24*
-32: v3.1.7 of Payments API controllers
-
-Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/32
-[79073ae9e7c4814](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/79073ae9e7c4814) JamieB *2021-05-11 08:02:35*
+[82f8ccbff075bf2](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/82f8ccbff075bf2) Matt Wills *2021-05-24 14:43:50*
 Release candidate: prepare for next development iteration
-## 1.3.3
+## 1.4.2
+### GitHub [#342](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/342) Release/1.1.118
+[141816573d0231d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/141816573d0231d) Jorge Sanchez Perez *2021-02-22 15:07:48*
+Release/1.1.118 (#342)
+
+* Bumped versions
+- Bumped starter parent version 1.1.86
+- Bumped clients version 1.0.45
+- Bumped common version 1.0.90
+- Bumped auth version 1.0.66
+- Bumped jwkms version 1.1.77
+
+* Release candidate: prepare release 1.1.118
+
+* Release candidate: prepare for next development iteration
+### GitHub [#346](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/346) 201: Analytics empty data
+[c0e3227e4ed0b8c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c0e3227e4ed0b8c) Jorge Sanchez Perez *2021-03-11 08:46:35*
+201: Analytics empty data (#346)
+
+* 201: Analytics empty data
+- Bumped `ob-common` version 1.1.0
+- Added new dependency `ob-common-annotations`
+- Refactorisation of classes to use the new origin of annotation `OpenBankingAPI`
+- Bumped `ob-clients` version 1.1.0
+- Bumped `ob-auth` version 1.0.67
+- Bumped `ob-jwkms` version 1.1.78
+- Upgrade minor version to 1.2.0-SNAPSHOT
+- Prepare for the next release
+
+* Changelog updated
+### GitHub [#350](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/350) Release/1.2.0
+[32efab6fcf30f25](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/32efab6fcf30f25) Jorge Sanchez Perez *2021-03-11 09:18:43*
+Release/1.2.0 (#350)
+
+* Release candidate: prepare release 1.2.0
+
+* Release candidate: prepare for next development iteration
+### GitHub [#354](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/354) Release/1.2.1
+[8e85606d358c96d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/8e85606d358c96d) Jorge Sanchez Perez *2021-03-18 09:49:29*
+Release/1.2.1 (#354)
+
+* Release candidate: prepare release 1.2.1
+
+* Release candidate: prepare for next development iteration
 ### GitHub [#356](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/356) 16: Switched to GenericOBDiscoveryAPILinks in uk-datamodel
 [47a5dac51797c70](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/47a5dac51797c70) Matt Wills *2021-03-25 11:09:09*
 Revert "Merge pull request #356 from OpenBankingToolkit/issue/16-discovery-serialization"
@@ -256,10 +196,108 @@ Release/1.3.2 (#380)
 * Release candidate: prepare release 1.3.2
 
 * Release candidate: prepare for next development iteration
-[fd3ba6bccc88d73](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/fd3ba6bccc88d73) JamieB *2021-05-11 08:02:28*
-Release candidate: prepare release 1.3.3
-[c4f059c5d87c7c3](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c4f059c5d87c7c3) JamieB *2021-05-11 07:39:18*
-34: Empty commit to force codefresh build
+### GitHub [#391](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/391) 32: Bumped version of parent pom to pull in minor fix to datamodel
+[0e5b86be2bf47ae](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0e5b86be2bf47ae) Matt Wills *2021-05-13 10:34:21*
+32: Bumped version of parent pom to pull in minor fix to datamodel (#391)
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
+### GitHub [#392](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/392) 742: token endpoint 500 error improvements
+[d1c2a4ea43d7d45](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d1c2a4ea43d7d45) Jorge Sanchez Perez *2021-05-14 07:38:05*
+742: token endpoint 500 error improvements (#392)
+
+- Bumped starter parent version 1.1.97
+- Bumped common version 1.1.4
+- Bumped clients version 1.1.4
+- Bumped jwkms version 1.1.83
+- Bumped auth version 1.0.71
+- Added support to build module independently avoiding license error.
+- Added UnsupportedOIDCAuthMethodsException and UnsupportedOIDCGrantTypeException in custom handler
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/742
+### GitHub [#397](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/397) Release/1.3.4
+[92492510eba8e77](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/92492510eba8e77) Jorge Sanchez Perez *2021-05-14 08:05:45*
+Release/1.3.4 (#397)
+
+* changelog
+
+* Release candidate: prepare release 1.3.4
+
+* Release candidate: prepare for next development iteration
+### GitHub [#404](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/404) Release/1.4.0
+[e56fad339682b16](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/e56fad339682b16) Jorge Sanchez Perez *2021-05-17 10:31:59*
+Release/1.4.0 (#404)
+
+* Release 1.4.0
+- Bumped common version 1.2.0
+- Bumped clients version 1.2.0
+- Bumped jwkms version 1.2.0
+- Bumped auth version 1.1.0
+- Upgrade aspsp version to 1.4.0
+
+* Release candidate: prepare release 1.4.0
+
+* Release candidate: prepare for next development iteration
+
+* changelog
+### GitHub [#406](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/406) Release/1.4.1
+[c20afa490c34de8](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c20afa490c34de8) Jorge Sanchez Perez *2021-05-18 14:33:09*
+Release/1.4.1 (#406)
+
+* changelog
+
+* Release candidate: prepare release 1.4.1
+
+* Release candidate: prepare for next development iteration
+[8fc3878e3b83fa2](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/8fc3878e3b83fa2) Matt Wills *2021-05-24 14:42:15*
+Release candidate: prepare release 1.4.2
+[75f094eb79dcb7c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/75f094eb79dcb7c) Matt Wills *2021-05-24 13:36:57*
+33: v3.1.8 of Events and Funds Confirmation APIs
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33
+[ff6bd0672f383d6](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/ff6bd0672f383d6) Matt Wills *2021-05-24 13:25:28*
+33: v3.1.8 of Accounts API gateway controllers and interfaces
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33
+[0a1b7f53da3cc34](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0a1b7f53da3cc34) Matt Wills *2021-05-24 12:54:37*
+33: v3.1.8 of Payment API controllers and interfaces
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33
+[492016f2f9a6054](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/492016f2f9a6054) Matt Wills *2021-05-21 14:27:18*
+76: Migrated to v3.1.8 of uk-datamodel
+
+- Fixed compilation errors after moving to consolidated enums
+- Fixes prior to new v3.1.8 controller classes and interfaces
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/76
+[9f3308ce4919304](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/9f3308ce4919304) Matt Wills *2021-05-18 10:12:41*
+32: Removed accidental import of org.bouncycastle.asn1.x500.style.RFC4519Style.postalAddress
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
+[764b09728e0b43b](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/764b09728e0b43b) Matt Wills *2021-05-17 09:59:54*
+32: v3.1.7 Discovery config
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
+[708ca312a764b16](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/708ca312a764b16) Matt Wills *2021-05-14 10:31:10*
+32: Bumped version of parent pom to include v3.1.7 of Events/Funds datamodel
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
+[7e7eac2b578b928](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/7e7eac2b578b928) Matt Wills *2021-05-14 09:14:32*
+32: v3.1.7 of Events and Funds API
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
+[6891d6ec4fbeb64](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/6891d6ec4fbeb64) Matt Wills *2021-05-12 11:54:03*
+32: Bumped parent pom to release version
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/32
+[9daa4c020e616a9](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/9daa4c020e616a9) Matt Wills *2021-05-12 11:53:24*
+32: Additional changes after regeneration of v3.1.7 datamodel (using Open API spec)
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/32
+[0336d2691fa87ce](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0336d2691fa87ce) Matt Wills *2021-05-12 11:53:24*
+32: v3.1.7 of Payments API controllers
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/32
+[79073ae9e7c4814](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/79073ae9e7c4814) JamieB *2021-05-11 08:02:35*
+Release candidate: prepare for next development iteration
 [d46d7cb97ca4a0c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d46d7cb97ca4a0c) JamieB *2021-05-11 07:23:52*
 34: Use forgerock spring-security-multi-auth
 
@@ -280,61 +318,6 @@ Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/32
 Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/16
 [8fed42b0aaa563e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/8fed42b0aaa563e) JamieB *2021-03-18 17:34:43*
 Release candidate: prepare for next development iteration
-## 1.2.2
-### GitHub [#342](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/342) Release/1.1.118
-[141816573d0231d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/141816573d0231d) Jorge Sanchez Perez *2021-02-22 15:07:48*
-Release/1.1.118 (#342)
-
-* Bumped versions
-- Bumped starter parent version 1.1.86
-- Bumped clients version 1.0.45
-- Bumped common version 1.0.90
-- Bumped auth version 1.0.66
-- Bumped jwkms version 1.1.77
-
-* Release candidate: prepare release 1.1.118
-
-* Release candidate: prepare for next development iteration
-### GitHub [#346](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/346) 201: Analytics empty data
-[c0e3227e4ed0b8c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c0e3227e4ed0b8c) Jorge Sanchez Perez *2021-03-11 08:46:35*
-201: Analytics empty data (#346)
-
-* 201: Analytics empty data
-- Bumped `ob-common` version 1.1.0
-- Added new dependency `ob-common-annotations`
-- Refactorisation of classes to use the new origin of annotation `OpenBankingAPI`
-- Bumped `ob-clients` version 1.1.0
-- Bumped `ob-auth` version 1.0.67
-- Bumped `ob-jwkms` version 1.1.78
-- Upgrade minor version to 1.2.0-SNAPSHOT
-- Prepare for the next release
-
-* Changelog updated
-### GitHub [#350](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/350) Release/1.2.0
-[32efab6fcf30f25](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/32efab6fcf30f25) Jorge Sanchez Perez *2021-03-11 09:18:43*
-Release/1.2.0 (#350)
-
-* Release candidate: prepare release 1.2.0
-
-* Release candidate: prepare for next development iteration
-### GitHub [#354](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/354) Release/1.2.1
-[8e85606d358c96d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/8e85606d358c96d) Jorge Sanchez Perez *2021-03-18 09:49:29*
-Release/1.2.1 (#354)
-
-* Release candidate: prepare release 1.2.1
-
-* Release candidate: prepare for next development iteration
-[d24b7341d82295e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d24b7341d82295e) JamieB *2021-03-18 17:34:37*
-Release candidate: prepare release 1.2.2
-[49c8d51b3ae697f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/49c8d51b3ae697f) JamieB *2021-03-18 17:12:30*
-721: Need a default spring value for all spring config
-
-So that this can run even if no spring config server is available the
-rs.data.upload.limit.documents spring config value. This was causing
-failure of integration tests in the obri project when no spring config
-was available.
-
-Issue: https://github.com/ForgeCloud/ob-deploy/issues/721
 [b78ec6751ee3bc4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/b78ec6751ee3bc4) jorgesanchezperez *2021-03-17 17:31:18*
 Deleted application.yml file from rs-mock-store-server library
 [0049d9050fa579c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/0049d9050fa579c) jorgesanchezperez *2021-03-17 17:29:06*
@@ -358,6 +341,23 @@ Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/20
 296 - Minor fixes and corrections
 [1e18b5080b61311](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/1e18b5080b61311) jorgesanchezperez *2021-02-17 15:20:00*
 Release candidate: prepare for next development iteration
+## 1.3.3
+[fd3ba6bccc88d73](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/fd3ba6bccc88d73) JamieB *2021-05-11 08:02:28*
+Release candidate: prepare release 1.3.3
+[c4f059c5d87c7c3](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c4f059c5d87c7c3) JamieB *2021-05-11 07:39:18*
+34: Empty commit to force codefresh build
+## 1.2.2
+[d24b7341d82295e](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/d24b7341d82295e) JamieB *2021-03-18 17:34:37*
+Release candidate: prepare release 1.2.2
+[49c8d51b3ae697f](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/49c8d51b3ae697f) JamieB *2021-03-18 17:12:30*
+721: Need a default spring value for all spring config
+
+So that this can run even if no spring config server is available the
+rs.data.upload.limit.documents spring config value. This was causing
+failure of integration tests in the obri project when no spring config
+was available.
+
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/721
 ## 1.1.117
 ### GitHub [#314](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/314) 14: payment refunds - Domestic payments
 [7990cc32fc3f982](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/7990cc32fc3f982) Jorge Sanchez Perez *2021-01-11 10:09:45*

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApi.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApi.java
@@ -52,7 +52,7 @@ public interface AccessTokenApi {
     )
     @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII')")
     ResponseEntity getAccessToken(
-            @RequestBody MultiValueMap paramMap,
+            @RequestBody MultiValueMap<String, String> paramMap,
 
             @ApiParam(value = "Authorization header")
             @RequestHeader(value = "Authorization", required = false) String authorization,

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApiController.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApiController.java
@@ -23,82 +23,83 @@ package com.forgerock.openbanking.aspsp.as.api.accesstoken;
 import com.forgerock.openbanking.am.gateway.AMASPSPGateway;
 import com.forgerock.openbanking.am.gateway.AMGateway;
 import com.forgerock.openbanking.am.services.AMGatewayService;
-import com.forgerock.openbanking.analytics.services.TokenUsageService;
-import com.forgerock.openbanking.aspsp.as.service.JwtOverridingService;
+import com.forgerock.openbanking.aspsp.as.service.MatlsRequestVerificationService;
+import com.forgerock.openbanking.aspsp.as.service.PairClientIDAuthMethod;
 import com.forgerock.openbanking.aspsp.as.service.headless.accesstoken.HeadLessAccessTokenService;
-import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
+import com.forgerock.openbanking.common.services.JwtOverridingService;
 import com.forgerock.openbanking.constants.OIDCConstants;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
-import com.forgerock.openbanking.model.Tpp;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
 import com.forgerock.openbanking.model.error.OBRIErrorType;
 import com.forgerock.openbanking.model.oidc.AccessTokenResponse;
-import com.nimbusds.jwt.JWTParser;
-import com.nimbusds.jwt.SignedJWT;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.MultiValueMap;
 
 import javax.servlet.http.HttpServletRequest;
-import java.nio.charset.Charset;
 import java.security.Principal;
-import java.text.ParseException;
-import java.util.Base64;
 import java.util.UUID;
 
 @Controller
 @Slf4j
 public class AccessTokenApiController implements AccessTokenApi {
 
-    private AMASPSPGateway amGateway;
-    private HeadLessAccessTokenService headLessAccessTokenService;
-    private TppStoreService tppStoreService;
-    private AMGatewayService amGatewayService;
-    private JwtOverridingService jwtOverridingService;
-    private TokenUsageService tokenUsageService;
+    private final AMASPSPGateway amGateway;
+    private final HeadLessAccessTokenService headLessAccessTokenService;
+    private final AMGatewayService amGatewayService;
+    private final JwtOverridingService jwtOverridingService;
+    private final MatlsRequestVerificationService matlsRequestVerificationService;
 
-    private static final String CLIENT_ASSERTION = "client_assertion";
     private static final String GRANT_TYPE = "grant_type";
-    private static final String CLIENT_ID = "client_id";
-    private static final String BASIC = "Basic";
+
 
     @Autowired
     public AccessTokenApiController(AMASPSPGateway amGateway, HeadLessAccessTokenService headLessAccessTokenService,
-                                    TppStoreService tppStoreService, AMGatewayService amGatewayService,
-                                    JwtOverridingService jwtOverridingService, TokenUsageService tokenUsageService) {
+                                    AMGatewayService amGatewayService, JwtOverridingService jwtOverridingService,
+                                    MatlsRequestVerificationService matlsRequestVerificationService) {
         this.amGateway = amGateway;
         this.headLessAccessTokenService = headLessAccessTokenService;
-        this.tppStoreService = tppStoreService;
         this.amGatewayService = amGatewayService;
         this.jwtOverridingService = jwtOverridingService;
-        this.tokenUsageService = tokenUsageService;
+        this.matlsRequestVerificationService = matlsRequestVerificationService;
     }
 
     @Override
     public ResponseEntity getAccessToken(MultiValueMap paramMap, String authorization, Principal principal,
                                          HttpServletRequest request) throws OBErrorResponseException, OBErrorException {
-
-        PairClientIDAuthMethod clientIDAuthMethod = verifyMATLSMatchesRequest(paramMap, authorization, principal);
+        log.debug("getAccessToken(), paramMap {}", paramMap);
+        PairClientIDAuthMethod clientIDAuthMethod =
+                matlsRequestVerificationService.verifyMATLSMatchesRequest(paramMap, authorization, principal);
 
         AMGateway amGateway = this.amGateway;
         //The token endpoint can also be used as audience, as per OIDC spec
-        if (clientIDAuthMethod.authMethod == OIDCConstants.TokenEndpointAuthMethods.PRIVATE_KEY_JWT) {
-            amGateway = amGatewayService.getAmGateway((String) paramMap.getFirst(CLIENT_ASSERTION));
+        if (clientIDAuthMethod.getAuthMethod() == OIDCConstants.TokenEndpointAuthMethods.PRIVATE_KEY_JWT) {
+            String  clientAssertion = (String) paramMap.getFirst(OIDCConstants.OIDCClaim.CLIENT_ASSERTION);
+            if(clientAssertion == null || clientAssertion.isBlank() || clientAssertion.isEmpty()){
+                log.debug("getAccessToken() clientAssertion was null or blank");
+                throw new OBErrorResponseException(
+                        OBRIErrorType.ACCESS_TOKEN_INVALID.getHttpStatus(),
+                        OBRIErrorResponseCategory.ACCESS_TOKEN,
+                        OBRIErrorType.ACCESS_TOKEN_INVALID.toOBError1("No client_assertion in body"
+                ));
+            }
+            amGateway = amGatewayService.getAmGateway(clientAssertion);
         }
+
         // can throw a UnsupportedOIDCGrantTypeException
-        OIDCConstants.GrantType grantType = OIDCConstants.GrantType.fromType((String) paramMap.getFirst(GRANT_TYPE));
-        ResponseEntity responseEntity;
+        OIDCConstants.GrantType grantType =
+                OIDCConstants.GrantType.fromType((String) paramMap.getFirst(OIDCConstants.OIDCClaim.GRANT_TYPE));
+        ResponseEntity<AccessTokenResponse> responseEntity;
+
         switch (grantType) {
             case HEADLESS_AUTH:
-                responseEntity = headLessAccessTokenService.getAccessToken(amGateway, clientIDAuthMethod, paramMap, request);
+                responseEntity = headLessAccessTokenService.getAccessToken(amGateway, clientIDAuthMethod, paramMap,
+                        request);
                 break;
             case CLIENT_CREDENTIAL:
             case AUTHORIZATION_CODE:
@@ -108,121 +109,32 @@ public class AccessTokenApiController implements AccessTokenApi {
                 //proxy to AM
                 ResponseEntity responseFromAM = amGateway.toAM(request, new HttpHeaders(),
                         new ParameterizedTypeReference<AccessTokenResponse>() {}, paramMap);
-                responseEntity = ResponseEntity.status(responseFromAM.getStatusCode()).body(responseFromAM.getBody());
+                log.debug("getAccessToken() response from AM; {}", responseFromAM);
+                if(!responseFromAM.getStatusCode().is2xxSuccessful() && !responseFromAM.getStatusCode().is3xxRedirection()){
+                    log.warn("getAccessToken() Un-successful call to AM to get access token. Status code: {}, body " +
+                            "{}",responseFromAM.getStatusCode(), responseFromAM.getBody() );
+                    throw new OBErrorResponseException(
+                            OBRIErrorType.ACCESS_TOKEN_INVALID.getHttpStatus(),
+                            OBRIErrorResponseCategory.ACCESS_TOKEN,
+                            OBRIErrorType.ACCESS_TOKEN_INVALID.toOBError1(responseFromAM.getBody()));
+                }
+                AccessTokenResponse accessTokenResponse = (AccessTokenResponse) responseFromAM.getBody();
+                log.debug("getAccessToken() accessTokenResponse from AM is {}", accessTokenResponse);
+                responseEntity = ResponseEntity.status(responseFromAM.getStatusCode()).body(accessTokenResponse);
+                log.debug("getAccessToken() new reponse to return is {}", responseEntity);
         }
 
-        //Rewriting the response as we need to re-sign the id token
-        if (responseEntity.getStatusCode() == HttpStatus.OK) {
-            AccessTokenResponse accessTokenResponse = (AccessTokenResponse) responseEntity.getBody();
-            if (accessTokenResponse.getIdToken() != null) {
-                responseEntity = rewriteIdToken(accessTokenResponse);
-            }
-            tokenUsageService.incrementTokenUsage(accessTokenResponse);
-        }
-        return responseEntity;
-    }
-
-    private ResponseEntity rewriteIdToken(AccessTokenResponse accessTokenResponse) throws OBErrorResponseException {
         try {
-            accessTokenResponse.setId_token(jwtOverridingService.rewriteJWS(accessTokenResponse.getIdToken()));
-            return ResponseEntity.status(HttpStatus.OK).body(accessTokenResponse);
-        } catch (ParseException e) {
+            responseEntity = jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity);
+        } catch (JwtOverridingService.AccessTokenReWriteException e) {
+            log.debug("Failed to rewrite the access token response's id_token.", e);
             String supportUID = UUID.randomUUID().toString();
-            log.error("Error when parsing ID token {}. Support UID {}", accessTokenResponse.getIdToken(), supportUID,  e);
             throw new OBErrorResponseException(
                     OBRIErrorType.ACCESS_TOKEN_INVALID_ID_TOKEN.getHttpStatus(),
                     OBRIErrorResponseCategory.ACCESS_TOKEN,
                     OBRIErrorType.ACCESS_TOKEN_INVALID_ID_TOKEN.toOBError1(supportUID));
         }
-    }
 
-    private PairClientIDAuthMethod verifyMATLSMatchesRequest(MultiValueMap paramMap, String authorization, Principal principal)
-            throws OBErrorResponseException {
-        UserDetails currentUser = (UserDetails) ((Authentication) principal).getPrincipal();
-        String tppIdFromMATLS = currentUser.getUsername();
-        //the X509 authentication already check that the TPP exist
-        Tpp tpp = tppStoreService.findByClientId(tppIdFromMATLS).get();
-        PairClientIDAuthMethod pairClientIDAuthMethod = new PairClientIDAuthMethod();
-
-        if (paramMap.get(CLIENT_ASSERTION) != null) {
-            String clientAssertion = (String) paramMap.getFirst(CLIENT_ASSERTION);
-            log.debug("Read client ID from client assertion found: {}", clientAssertion);
-            try {
-                SignedJWT jws = (SignedJWT) JWTParser.parse(clientAssertion);
-                pairClientIDAuthMethod.clientId = jws.getJWTClaimsSet().getSubject();
-                Object clientIDFromBody = paramMap.getFirst(CLIENT_ID);
-                if (clientIDFromBody != null
-                        && !pairClientIDAuthMethod.clientId.equals(clientIDFromBody)) {
-                    log.error("Client ID from the request body {} is not matching the client assertion sub {}", clientIDFromBody, pairClientIDAuthMethod.clientId);
-                    throw new OBErrorResponseException(
-                            OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.getHttpStatus(),
-                            OBRIErrorResponseCategory.ACCESS_TOKEN,
-                            OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.toOBError1(clientIDFromBody, pairClientIDAuthMethod.clientId));
-                }
-                pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.PRIVATE_KEY_JWT;
-            } catch (ParseException e) {
-                log.error("Parse client assertion error", e);
-                throw new OBErrorResponseException(
-                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ASSERTION_FORMAT_INVALID.getHttpStatus(),
-                        OBRIErrorResponseCategory.ACCESS_TOKEN,
-                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ASSERTION_FORMAT_INVALID.toOBError1(clientAssertion));
-            }
-        } else if (authorization != null) {
-            log.debug("Read client ID from client authorisation header: {}", authorization);
-            pairClientIDAuthMethod.clientId = clientIDFromBasic(authorization);
-            Object clientIDFromBody = paramMap.getFirst(CLIENT_ID);
-            if (clientIDFromBody != null
-                    && !pairClientIDAuthMethod.clientId.equals(clientIDFromBody)) {
-                log.error("Client ID from the request body {} is not matching the client secret basic {}", clientIDFromBody, pairClientIDAuthMethod.clientId);
-                throw new OBErrorResponseException(
-                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.getHttpStatus(),
-                        OBRIErrorResponseCategory.ACCESS_TOKEN,
-                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.toOBError1(clientIDFromBody, pairClientIDAuthMethod.clientId));
-            }
-            pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.CLIENT_SECRET_BASIC;
-        } else if (paramMap.get("client_secret") != null) {
-            log.debug("Read client ID from client body parameter 'client_id'");
-            pairClientIDAuthMethod.clientId = (String) paramMap.getFirst(CLIENT_ID);
-            pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.CLIENT_SECRET_POST;
-        } else {
-            log.debug("Read client ID from client body parameter 'client_id'");
-            pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.TLS_CLIENT_AUTH;
-            pairClientIDAuthMethod.clientId = (String) paramMap.getFirst(CLIENT_ID);
-        }
-        // can throw UnsupportedOIDCAuthMethodsException
-        OIDCConstants.TokenEndpointAuthMethods authMethodsFromTpp = OIDCConstants.TokenEndpointAuthMethods.fromType(tpp.getRegistrationResponse().getTokenEndpointAuthMethod());
-
-        if (!authMethodsFromTpp.equals(pairClientIDAuthMethod.authMethod)) {
-            throw new OBErrorResponseException(
-                    OBRIErrorType.ACCESS_TOKEN_WRONG_AUTH_METHOD.getHttpStatus(),
-                    OBRIErrorResponseCategory.ACCESS_TOKEN,
-                    OBRIErrorType.ACCESS_TOKEN_WRONG_AUTH_METHOD.toOBError1(pairClientIDAuthMethod.authMethod.type, authMethodsFromTpp.type));
-        }
-
-        if (!tpp.getClientId().equals(pairClientIDAuthMethod.clientId)) {
-            throw new OBErrorResponseException(
-                    OBRIErrorType.ACCESS_TOKEN_CREDENTIAL_NOT_MATCHING_CLIENT_CERTS.getHttpStatus(),
-                    OBRIErrorResponseCategory.ACCESS_TOKEN,
-                    OBRIErrorType.ACCESS_TOKEN_CREDENTIAL_NOT_MATCHING_CLIENT_CERTS.toOBError1(tpp.getClientId(), pairClientIDAuthMethod.clientId, pairClientIDAuthMethod.authMethod.type));
-        }
-        return pairClientIDAuthMethod;
-    }
-
-    private String clientIDFromBasic(String authorization) {
-        if (authorization != null && authorization.startsWith(BASIC)) {
-            // Authorization: Basic base64credentials
-            String base64Credentials = authorization.substring(BASIC.length()).trim();
-            String credentials = new String(Base64.getDecoder().decode(base64Credentials),
-                    Charset.forName("UTF-8"));
-            // credentials = username:password
-            final String[] values = credentials.split(":", 2);
-            return values[0];
-        }
-        return null;
-    }
-
-    public class PairClientIDAuthMethod {
-        public String clientId;
-        public OIDCConstants.TokenEndpointAuthMethods authMethod;
+        return responseEntity;
     }
 }

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/authorisation/redirect/AuthorisationApiController.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/authorisation/redirect/AuthorisationApiController.java
@@ -26,6 +26,7 @@ import com.forgerock.openbanking.analytics.model.entries.TokenUsage;
 import com.forgerock.openbanking.analytics.services.TokenUsageService;
 import com.forgerock.openbanking.aspsp.as.api.oauth2.discovery.DiscoveryConfig;
 import com.forgerock.openbanking.aspsp.as.service.headless.authorisation.HeadLessAuthorisationService;
+import com.forgerock.openbanking.common.error.exception.AccessTokenReWriteException;
 import com.forgerock.openbanking.common.services.JwtOverridingService;
 import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
 import com.forgerock.openbanking.constants.OIDCConstants;
@@ -215,7 +216,7 @@ public class AuthorisationApiController implements AuthorisationApi {
             try {
                 responseEntity = this.jwtOverridingService.rewriteIdTokenFragmentInLocationHeader(responseEntity);
                 tokenUsageService.incrementTokenUsage(TokenUsage.ID_TOKEN);
-            } catch (JwtOverridingService.AccessTokenReWriteException e) {
+            } catch (AccessTokenReWriteException e) {
                 String supportUID = UUID.randomUUID().toString();
                 log.info("getAuthorisation() Failed to re-write the id_token", e);
                 throw new OBErrorResponseException(
@@ -276,7 +277,6 @@ public class AuthorisationApiController implements AuthorisationApi {
             Tpp tpp = byClientId.get();
 
             log.debug("Validate the request parameter signature");
-            SignedJWT validatedJwt = null;
             boolean validated = false;
             OIDCRegistrationResponse registrationResponse = tpp.getRegistrationResponse();
             if (registrationResponse != null) {

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/MatlsRequestVerificationService.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/MatlsRequestVerificationService.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.as.service;
+
+import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
+import com.forgerock.openbanking.constants.OIDCConstants;
+import com.forgerock.openbanking.exceptions.OBErrorResponseException;
+import com.forgerock.openbanking.model.Tpp;
+import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
+import com.forgerock.openbanking.model.error.OBRIErrorType;
+import com.forgerock.openbanking.model.oidc.OIDCRegistrationResponse;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+
+import java.nio.charset.Charset;
+import java.security.Principal;
+import java.text.ParseException;
+import java.util.Base64;
+
+@Service
+@Slf4j
+public class MatlsRequestVerificationService {
+
+
+    private static TppStoreService tppStoreService;
+    private static final String CLIENT_ID = "client_id";
+    private static final String BASIC = "Basic";
+
+    public MatlsRequestVerificationService(TppStoreService tppStoreService){
+        this.tppStoreService = tppStoreService;
+    }
+
+    public PairClientIDAuthMethod verifyMATLSMatchesRequest(MultiValueMap paramMap, String authorization,
+                                                                                     Principal principal)
+            throws OBErrorResponseException {
+        UserDetails currentUser = (UserDetails) ((Authentication) principal).getPrincipal();
+        String tppIdFromMATLS = currentUser.getUsername();
+        //the X509 authentication already check that the TPP exist
+        Tpp tpp = tppStoreService.findByClientId(tppIdFromMATLS).get();
+        PairClientIDAuthMethod pairClientIDAuthMethod = new PairClientIDAuthMethod();
+
+        if (paramMap.get(OIDCConstants.OIDCClaim.CLIENT_ASSERTION) != null) {
+            String clientAssertion = (String) paramMap.getFirst(OIDCConstants.OIDCClaim.CLIENT_ASSERTION);
+            if(clientAssertion == null || clientAssertion.isEmpty() || clientAssertion.isBlank()){
+                throw new OBErrorResponseException(
+                        OBRIErrorType.ACCESS_TOKEN_INVALID.getHttpStatus(),
+                        OBRIErrorResponseCategory.ACCESS_TOKEN,
+                        OBRIErrorType.ACCESS_TOKEN_INVALID.toOBError1("No client_assertion in body"));
+            }
+
+            log.debug("Read client ID from client assertion found: {}", clientAssertion);
+            try {
+                SignedJWT jws = (SignedJWT) JWTParser.parse(clientAssertion);
+                pairClientIDAuthMethod.clientId = jws.getJWTClaimsSet().getSubject();
+                Object clientIDFromBody = paramMap.getFirst(CLIENT_ID);
+                if (clientIDFromBody != null
+                        && !pairClientIDAuthMethod.clientId.equals(clientIDFromBody)) {
+                    log.error("Client ID from the request body {} is not matching the client assertion sub {}",
+                            clientIDFromBody, pairClientIDAuthMethod.clientId);
+                    throw new OBErrorResponseException(
+                            OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.getHttpStatus(),
+                            OBRIErrorResponseCategory.ACCESS_TOKEN,
+                            OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.toOBError1(clientIDFromBody, pairClientIDAuthMethod.clientId));
+                }
+                pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.PRIVATE_KEY_JWT;
+            } catch (ParseException e) {
+                log.error("Parse client assertion error", e);
+                throw new OBErrorResponseException(
+                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ASSERTION_FORMAT_INVALID.getHttpStatus(),
+                        OBRIErrorResponseCategory.ACCESS_TOKEN,
+                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ASSERTION_FORMAT_INVALID.toOBError1(clientAssertion));
+            }
+        } else if (authorization != null) {
+            log.debug("Read client ID from client authorisation header: {}", authorization);
+            pairClientIDAuthMethod.clientId = clientIDFromBasic(authorization);
+            Object clientIDFromBody = paramMap.getFirst(CLIENT_ID);
+            if (clientIDFromBody != null
+                    && !pairClientIDAuthMethod.clientId.equals(clientIDFromBody)) {
+                log.error("Client ID from the request body {} is not matching the client secret basic {}", clientIDFromBody, pairClientIDAuthMethod.clientId);
+                throw new OBErrorResponseException(
+                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.getHttpStatus(),
+                        OBRIErrorResponseCategory.ACCESS_TOKEN,
+                        OBRIErrorType.ACCESS_TOKEN_CLIENT_ID_MISS_MATCH.toOBError1(clientIDFromBody, pairClientIDAuthMethod.clientId));
+            }
+            pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.CLIENT_SECRET_BASIC;
+        } else if (paramMap.get("client_secret") != null) {
+            log.debug("Read client ID from client body parameter 'client_id'");
+            pairClientIDAuthMethod.clientId = (String) paramMap.getFirst(CLIENT_ID);
+            pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.CLIENT_SECRET_POST;
+        } else {
+            log.debug("Read client ID from client body parameter 'client_id'");
+            pairClientIDAuthMethod.authMethod = OIDCConstants.TokenEndpointAuthMethods.TLS_CLIENT_AUTH;
+            pairClientIDAuthMethod.clientId = (String) paramMap.getFirst(CLIENT_ID);
+        }
+        // can throw UnsupportedOIDCAuthMethodsException
+        OIDCRegistrationResponse registrationResponse = tpp.getRegistrationResponse();
+        String tokenEndpointAuthMethod = registrationResponse.getTokenEndpointAuthMethod();
+        OIDCConstants.TokenEndpointAuthMethods authMethodsFromTpp = OIDCConstants.TokenEndpointAuthMethods.fromType(tokenEndpointAuthMethod);
+
+        if (!authMethodsFromTpp.equals(pairClientIDAuthMethod.authMethod)) {
+            throw new OBErrorResponseException(
+                    OBRIErrorType.ACCESS_TOKEN_WRONG_AUTH_METHOD.getHttpStatus(),
+                    OBRIErrorResponseCategory.ACCESS_TOKEN,
+                    OBRIErrorType.ACCESS_TOKEN_WRONG_AUTH_METHOD.toOBError1(pairClientIDAuthMethod.authMethod.type, authMethodsFromTpp.type));
+        }
+
+        if (!tpp.getClientId().equals(pairClientIDAuthMethod.clientId)) {
+            throw new OBErrorResponseException(
+                    OBRIErrorType.ACCESS_TOKEN_CREDENTIAL_NOT_MATCHING_CLIENT_CERTS.getHttpStatus(),
+                    OBRIErrorResponseCategory.ACCESS_TOKEN,
+                    OBRIErrorType.ACCESS_TOKEN_CREDENTIAL_NOT_MATCHING_CLIENT_CERTS.toOBError1(tpp.getClientId(), pairClientIDAuthMethod.clientId, pairClientIDAuthMethod.authMethod.type));
+        }
+        return pairClientIDAuthMethod;
+    }
+
+    private String clientIDFromBasic(String authorization) {
+        if (authorization != null && authorization.startsWith(BASIC)) {
+            // Authorization: Basic base64credentials
+            String base64Credentials = authorization.substring(BASIC.length()).trim();
+            String credentials = new String(Base64.getDecoder().decode(base64Credentials),
+                    Charset.forName("UTF-8"));
+            // credentials = username:password
+            final String[] values = credentials.split(":", 2);
+            return values[0];
+        }
+        return null;
+    }
+
+}

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/PairClientIDAuthMethod.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/PairClientIDAuthMethod.java
@@ -20,26 +20,11 @@
  */
 package com.forgerock.openbanking.aspsp.as.service;
 
-import com.forgerock.openbanking.am.config.AMOpenBankingConfiguration;
-import com.forgerock.openbanking.jwt.services.CryptoApiClient;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import com.forgerock.openbanking.constants.OIDCConstants;
+import lombok.Data;
 
-import java.text.ParseException;
-
-@Service
-public class JwtOverridingService {
-
-    @Autowired
-    private CryptoApiClient cryptoApiClient;
-    @Autowired
-    private AMOpenBankingConfiguration amOpenBankingConfiguration;
-
-    public String rewriteJWS(String jws) throws ParseException {
-
-        JWTClaimsSet jwtClaimsSet = SignedJWT.parse(jws).getJWTClaimsSet();
-        return cryptoApiClient.signClaims(amOpenBankingConfiguration.getIssuerID(), jwtClaimsSet, false);
-    }
+@Data
+public class PairClientIDAuthMethod {
+    public String clientId;
+    public OIDCConstants.TokenEndpointAuthMethods authMethod;
 }

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/headless/accesstoken/HeadLessAccessTokenService.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/headless/accesstoken/HeadLessAccessTokenService.java
@@ -33,53 +33,85 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+
+import static com.forgerock.openbanking.constants.OIDCConstants.OIDCClaim;
 
 @Service
 @Slf4j
 public class HeadLessAccessTokenService {
 
-    @Autowired
-    private AuthorisationApi authorisationApi;
+    private final AuthorisationApi authorisationApi;
 
-    public ResponseEntity getAccessToken(AMGateway amGateway,  PairClientIDAuthMethod clientIDAuthMethod,
-                                         MultiValueMap paramMap, HttpServletRequest request
-    ) throws OBErrorResponseException, OBErrorException {
+    @Autowired
+    public HeadLessAccessTokenService(AuthorisationApi authorisationApi) {
+        this.authorisationApi = authorisationApi;
+    }
+
+
+    public ResponseEntity<AccessTokenResponse> getAccessToken(AMGateway amGateway,  PairClientIDAuthMethod clientIDAuthMethod,
+                                         MultiValueMap<String, String> paramMap, HttpServletRequest request)
+            throws OBErrorResponseException, OBErrorException {
         ResponseEntity authorisation = authorisationApi.getAuthorisation(
-                (String) paramMap.getFirst("response_type"),
-                (String) paramMap.getFirst("client_id"),
-                (String) paramMap.getFirst("state"),
-                (String) paramMap.getFirst("nonce"),
-                (String) paramMap.getFirst("scope"),
-                (String) paramMap.getFirst("redirect_uri"),
-                (String) paramMap.getFirst("request"),
+                paramMap.getFirst(OIDCClaim.RESPONSE_TYPE),
+                paramMap.getFirst(OIDCClaim.CLIENT_ID),
+                paramMap.getFirst(OIDCClaim.STATE),
+                paramMap.getFirst(OIDCClaim.NONCE),
+                paramMap.getFirst(OIDCClaim.SCOPE),
+                paramMap.getFirst(OIDCClaim.REDIRECT_URI),
+                paramMap.getFirst(OIDCClaim.REQUEST),
                 true,
-                (String) paramMap.getFirst("username"),
-                (String) paramMap.getFirst("password"),
+                paramMap.getFirst(OIDCClaim.USERNAME),
+                paramMap.getFirst(OIDCClaim.PASSWORD),
                 "",
                 null,
                 request
         );
 
-        String location = authorisation.getHeaders().getFirst(org.apache.http.HttpHeaders.LOCATION);
-        String code = getCode(location);
+        HttpStatus statusCode = authorisation.getStatusCode();
+        if(!statusCode.is3xxRedirection() && !statusCode.is2xxSuccessful()){
+            log.warn("getAccessToken() authorisation failed. Response was '{}' ", authorisation);
+            throw new OBErrorResponseException(
+                    OBRIErrorType.HEAD_LESS_AUTH_AS_ERROR_RECEIVED.getHttpStatus(),
+                    OBRIErrorResponseCategory.HEADLESS_AUTH,
+                    OBRIErrorType.HEAD_LESS_AUTH_AS_ERROR_RECEIVED.toOBError1(
+                            authorisation.getStatusCode(), authorisation.getBody(), authorisation.getHeaders()));
+        }
 
-        return exchangeCode(amGateway, clientIDAuthMethod, paramMap, request, code);
+        String location = authorisation.getHeaders().getFirst(org.apache.http.HttpHeaders.LOCATION);
+        if(location == null || location.isBlank()){
+            throw new OBErrorResponseException(
+                    OBRIErrorType.HEAD_LESS_AUTH_TPP_URI_INCORRECT.getHttpStatus(),
+                    OBRIErrorResponseCategory.HEADLESS_AUTH,
+                    OBRIErrorType.HEAD_LESS_AUTH_TPP_URI_INCORRECT.toOBError1(location));
+        }
+        String code = getAuthorizationCode(location);
+
+        return exchangeAuthorizationCodeForAccessToken(amGateway, clientIDAuthMethod, paramMap, request, code);
     }
 
-    private String getCode(String location) throws OBErrorResponseException {
+    /**
+     * Get the authorizationCode from the location header. This method expects to find the code in the URL fragment
+     * of the location header.
+     * @param location the location parameter of the OAuth2 redirect from the auth server to the client
+     * @return the Authorization Code or null if this can't be obtained from the location string passed in
+     * @throws OBErrorResponseException If the location doesn't contain a valid code fragment
+     */
+    private String getAuthorizationCode(String location) throws OBErrorResponseException {
         try {
             URL url = new URL(location);
             if (url.getRef() == null) {
+                log.error("getAuthorizationCode() The location '{}' doesn't have an anchor fragment", location);
                 //We received an error.
                 // Ex: https://www.google.com?error_description=JWT%20invalid.%20Expiration%20time%20incorrect.&state=10d260bf-a7d9-444a-92d9-7b7a5f088208&error=invalid_request_object
                 Map<String, String> query = ParseUriUtils.parseQueryOrFragment(url.getQuery());
@@ -90,14 +122,16 @@ public class HeadLessAccessTokenService {
                                 query.get("error"), query.get("error_description"), query.get("state")));
             }
             Map<String, String> fragment = ParseUriUtils.parseQueryOrFragment(url.getRef());
-            if (!fragment.containsKey("code")) {
-                log.error("The location '{}' doesn't have an code", location);
+            String authCode = fragment.get("code");
+            if ( authCode == null || authCode.isBlank()) {
+                log.error("getAuthorizationCode() The location '{}' doesn't have a code value in the fragment",
+                        location);
                 throw new OBErrorResponseException(
                         OBRIErrorType.HEAD_LESS_AUTH_TPP_URI_NO_CODE.getHttpStatus(),
                         OBRIErrorResponseCategory.HEADLESS_AUTH,
                         OBRIErrorType.HEAD_LESS_AUTH_TPP_URI_NO_CODE.toOBError1(location));
             }
-            return fragment.get("code");
+            return authCode;
         } catch (MalformedURLException e) {
             log.error("The location '{}' to the TPP, returned by AM, is not an URL", location, e);
             throw new OBErrorResponseException(
@@ -107,9 +141,12 @@ public class HeadLessAccessTokenService {
         }
     }
 
-    private ResponseEntity exchangeCode(AMGateway amGateway, PairClientIDAuthMethod tokenEndpointAuthMethods, MultiValueMap paramMap, HttpServletRequest request, String code) throws OBErrorResponseException {
-        StringBuilder body = new StringBuilder();
-        body.append("grant_type=authorization_code");
+    private ResponseEntity<AccessTokenResponse> exchangeAuthorizationCodeForAccessToken(AMGateway amGateway,
+                                                                   PairClientIDAuthMethod tokenEndpointAuthMethods,
+                                                                   MultiValueMap paramMap, HttpServletRequest request,
+                                                                   String code) throws OBErrorResponseException {
+        StringBuilder requestBody = new StringBuilder();
+        requestBody.append("grant_type=authorization_code");
 
         Map<String, String> parameters = paramMap.toSingleValueMap();
         switch (tokenEndpointAuthMethods.authMethod) {
@@ -117,39 +154,55 @@ public class HeadLessAccessTokenService {
                 //Would be in the request header already
                 break;
             case TLS_CLIENT_AUTH:
-                body.append("&client_id=" + encode(parameters.get("client_id")));
+                requestBody.append("&client_id=").append(encode(parameters.get("client_id")));
                 break;
             case CLIENT_SECRET_POST:
-                body.append("&client_id=" + encode(parameters.get("client_id")));
-                body.append("&client_secret=" + encode(parameters.get("client_secret")));
+                requestBody.append("&client_id=").append(encode(parameters.get("client_id")));
+                requestBody.append("&client_secret=").append(encode(parameters.get("client_secret")));
                 break;
             case CLIENT_SECRET_JWT:
                 throw new RuntimeException("Not Implemented");
             case PRIVATE_KEY_JWT:
-                body.append("&client_assertion_type=" + encode(parameters.get("client_assertion_type")));
-                body.append("&client_assertion=" + encode(parameters.get("client_assertion")));
+                requestBody.append("&client_assertion_type=").append(encode(parameters.get("client_assertion_type")));
+                requestBody.append("&client_assertion=").append(encode(parameters.get("client_assertion")));
                 break;
         }
 
-        body.append("&redirect_uri=" + encode(parameters.get("redirect_uri")));
-        body.append("&code=" + encode(code));
+        requestBody.append("&redirect_uri=").append(encode(parameters.get("redirect_uri")));
+        requestBody.append("&code=").append(encode(code));
 
         HttpHeaders httpHeaders = new HttpHeaders();
         //httpHeaders.add("Content-Type", "application/x-www-form-urlencoded");
         ResponseEntity responseFromAM = amGateway.toAM(request, httpHeaders,
-                new ParameterizedTypeReference<AccessTokenResponse>() {}, body.toString());
-        return ResponseEntity.status(responseFromAM.getStatusCode()).body(responseFromAM.getBody());
+                new ParameterizedTypeReference<AccessTokenResponse>() {}, requestBody.toString());
+        HttpStatus statusCode = responseFromAM.getStatusCode();
+
+        if (!statusCode.is2xxSuccessful() && !statusCode.is3xxRedirection()) {
+            log.warn("getAccessToken() unsuccessful call to headlessAuthTokenService. StatusCode: {}, body: {}",
+                    statusCode, responseFromAM.getBody());
+            throw new OBErrorResponseException(
+                    OBRIErrorType.ACCESS_TOKEN_INVALID.getHttpStatus(),
+                    OBRIErrorResponseCategory.ACCESS_TOKEN,
+                    OBRIErrorType.ACCESS_TOKEN_INVALID.toOBError1(responseFromAM.getBody())
+            );
+        }
+
+        Object responseBody = responseFromAM.getBody();
+        if( responseBody instanceof AccessTokenResponse){
+            ResponseEntity<AccessTokenResponse> responseEntity =
+                    new ResponseEntity<>((AccessTokenResponse)responseFromAM.getBody(),
+                            responseFromAM.getStatusCode());
+            return responseEntity;
+        } else {
+            throw new OBErrorResponseException(
+                    OBRIErrorType.ACCESS_TOKEN_INVALID.getHttpStatus(),
+                    OBRIErrorResponseCategory.ACCESS_TOKEN,
+                    OBRIErrorType.ACCESS_TOKEN_INVALID.toOBError1(responseFromAM.getBody())
+            );
+        }
     }
 
-    private String encode(String value) throws OBErrorResponseException {
-        try {
-            return URLEncoder.encode(value, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            log.error("Couldn't encode the body parameter '{}'", value, e);
-            throw new OBErrorResponseException(
-                    OBRIErrorType.HEAD_LESS_AUTH_EXCHANGE_CODE_BODY_ERROR.getHttpStatus(),
-                    OBRIErrorResponseCategory.HEADLESS_AUTH,
-                    OBRIErrorType.HEAD_LESS_AUTH_EXCHANGE_CODE_BODY_ERROR.toOBError1(value));
-        }
+    private String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 }

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/headless/accesstoken/HeadLessAccessTokenService.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/service/headless/accesstoken/HeadLessAccessTokenService.java
@@ -21,8 +21,8 @@
 package com.forgerock.openbanking.aspsp.as.service.headless.accesstoken;
 
 import com.forgerock.openbanking.am.gateway.AMGateway;
-import com.forgerock.openbanking.aspsp.as.api.accesstoken.AccessTokenApiController;
 import com.forgerock.openbanking.aspsp.as.api.authorisation.redirect.AuthorisationApi;
+import com.forgerock.openbanking.aspsp.as.service.PairClientIDAuthMethod;
 import com.forgerock.openbanking.aspsp.as.service.headless.ParseUriUtils;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
@@ -51,7 +51,7 @@ public class HeadLessAccessTokenService {
     @Autowired
     private AuthorisationApi authorisationApi;
 
-    public ResponseEntity getAccessToken(AMGateway amGateway,  AccessTokenApiController.PairClientIDAuthMethod clientIDAuthMethod,
+    public ResponseEntity getAccessToken(AMGateway amGateway,  PairClientIDAuthMethod clientIDAuthMethod,
                                          MultiValueMap paramMap, HttpServletRequest request
     ) throws OBErrorResponseException, OBErrorException {
         ResponseEntity authorisation = authorisationApi.getAuthorisation(
@@ -107,7 +107,7 @@ public class HeadLessAccessTokenService {
         }
     }
 
-    private ResponseEntity exchangeCode(AMGateway amGateway, AccessTokenApiController.PairClientIDAuthMethod tokenEndpointAuthMethods, MultiValueMap paramMap, HttpServletRequest request, String code) throws OBErrorResponseException {
+    private ResponseEntity exchangeCode(AMGateway amGateway, PairClientIDAuthMethod tokenEndpointAuthMethods, MultiValueMap paramMap, HttpServletRequest request, String code) throws OBErrorResponseException {
         StringBuilder body = new StringBuilder();
         body.append("grant_type=authorization_code");
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApiControllerTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.as.api.accesstoken;
+
+import com.forgerock.openbanking.am.gateway.AMASPSPGateway;
+import com.forgerock.openbanking.am.services.AMGatewayService;
+import com.forgerock.openbanking.aspsp.as.service.MatlsRequestVerificationService;
+import com.forgerock.openbanking.aspsp.as.service.PairClientIDAuthMethod;
+import com.forgerock.openbanking.aspsp.as.service.headless.accesstoken.HeadLessAccessTokenService;
+import com.forgerock.openbanking.common.services.JwtOverridingService;
+import com.forgerock.openbanking.constants.OIDCConstants;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.exceptions.OBErrorResponseException;
+import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
+import com.forgerock.openbanking.model.oidc.AccessTokenResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class AccessTokenApiControllerTest {
+
+    @Mock
+    private AMASPSPGateway amGateway;
+    @Mock
+    private HeadLessAccessTokenService headLessAccessTokenService;
+    @Mock
+    private AMGatewayService amGatewayService;
+    @Mock
+    private JwtOverridingService jwtOverridingService;
+    @Mock
+    private MatlsRequestVerificationService matlsRequestVerificationService;
+
+    @InjectMocks
+    AccessTokenApiController accessTokenApiController;
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void getAccessToken() throws OBErrorResponseException, OBErrorException, JwtOverridingService.AccessTokenReWriteException {
+        // Given
+        MultiValueMap<String, String> params  = new LinkedMultiValueMap<>();
+        params.add(OIDCConstants.OIDCClaim.GRANT_TYPE, OIDCConstants.GrantType.CLIENT_CREDENTIAL.type);
+        String authorization = "AuthString";
+        Authentication principal = mock(Authentication.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        PairClientIDAuthMethod pairClientIDAuthMethod = mock(PairClientIDAuthMethod.class);
+        given(matlsRequestVerificationService.verifyMATLSMatchesRequest(params, authorization, principal))
+                .willReturn(pairClientIDAuthMethod);
+        HttpHeaders  httpHeaders = new HttpHeaders();
+        ParameterizedTypeReference<AccessTokenResponse> parameterizedTypeRef =
+                new ParameterizedTypeReference<AccessTokenResponse>() {};
+        ResponseEntity responseEntity = new ResponseEntity(null, httpHeaders, HttpStatus.FOUND);
+        given(amGateway.toAM(request, httpHeaders, parameterizedTypeRef, params)).willReturn(responseEntity);
+        ResponseEntity modifiedResponseEntity = new ResponseEntity(null, httpHeaders, HttpStatus.OK);
+        given(jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity)).willReturn(modifiedResponseEntity);
+
+        // When
+        ResponseEntity result = this.accessTokenApiController.getAccessToken(params, authorization, principal, request);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void failsWhenAMReturnsError_getAccessToken() throws OBErrorResponseException {
+        // Given
+        MultiValueMap<String, String> params  = new LinkedMultiValueMap<>();
+        params.add(OIDCConstants.OIDCClaim.GRANT_TYPE, OIDCConstants.GrantType.CLIENT_CREDENTIAL.type);
+        String authorization = "AuthString";
+        Authentication principal = mock(Authentication.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        PairClientIDAuthMethod pairClientIDAuthMethod = new PairClientIDAuthMethod();
+        given(matlsRequestVerificationService.verifyMATLSMatchesRequest(params, authorization, principal))
+                .willReturn(pairClientIDAuthMethod);
+        HttpHeaders  httpHeaders = new HttpHeaders();
+        ParameterizedTypeReference<AccessTokenResponse> parameterizedTypeRef =
+                new ParameterizedTypeReference<AccessTokenResponse>() {};
+        ResponseEntity responseEntity = new ResponseEntity("{\"error_description\":\"Client authentication failed\"," +
+                "\"error\":\"invalid_client\"}", httpHeaders, HttpStatus.BAD_REQUEST);
+        given(amGateway.toAM(request, httpHeaders, parameterizedTypeRef, params)).willReturn(responseEntity);
+
+
+        // When
+        OBErrorResponseException e = catchThrowableOfType(() -> this.accessTokenApiController.getAccessToken(params,
+                authorization, principal, request), OBErrorResponseException.class);
+
+        // Then
+        assertThat(e).isNotNull();
+        assertThat(e.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(e.getCategory()).isEqualTo(OBRIErrorResponseCategory.ACCESS_TOKEN);
+    }
+
+    @Test
+    public void failsWhenNoClientCredentials_getAccessToken() throws OBErrorResponseException {
+        // Given
+        MultiValueMap<String, String> params  = new LinkedMultiValueMap<>();
+        params.add(OIDCConstants.OIDCClaim.GRANT_TYPE, OIDCConstants.GrantType.CLIENT_CREDENTIAL.type);
+        String authorization = "AuthString";
+        Authentication principal = mock(Authentication.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        PairClientIDAuthMethod pairClientIDAuthMethod = mock(PairClientIDAuthMethod.class);
+        given(pairClientIDAuthMethod.getAuthMethod()).willReturn(OIDCConstants.TokenEndpointAuthMethods.PRIVATE_KEY_JWT);
+        given(matlsRequestVerificationService.verifyMATLSMatchesRequest(params, authorization, principal))
+                .willReturn(pairClientIDAuthMethod);
+
+        // When
+        OBErrorResponseException e = catchThrowableOfType(() -> this.accessTokenApiController.getAccessToken(params,
+                authorization, principal, request), OBErrorResponseException.class);
+
+        // Then
+        assertThat(e).isNotNull();
+        assertThat(e.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(e.getCategory()).isEqualTo(OBRIErrorResponseCategory.ACCESS_TOKEN);
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/service/headless/accesstoken/HeadLessAccessTokenServiceTest.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/service/headless/accesstoken/HeadLessAccessTokenServiceTest.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.as.service.headless.accesstoken;
+
+import com.forgerock.openbanking.am.gateway.AMGateway;
+import com.forgerock.openbanking.aspsp.as.api.authorisation.redirect.AuthorisationApi;
+import com.forgerock.openbanking.aspsp.as.service.PairClientIDAuthMethod;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.exceptions.OBErrorResponseException;
+import com.forgerock.openbanking.model.error.ErrorCode;
+import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
+import com.forgerock.openbanking.model.oidc.AccessTokenResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static com.forgerock.openbanking.constants.OIDCConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.BDDMockito.given;
+
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class HeadLessAccessTokenServiceTest {
+
+    @Mock
+    AuthorisationApi authorisationApi;
+    @Mock
+    AMGateway amGateway;
+
+    @InjectMocks
+    HeadLessAccessTokenService headlessAccessTokenService;
+
+    HttpServletRequest request;
+    ParameterizedTypeReference<AccessTokenResponse> typeReference;
+
+    @Before
+    public void setUp(){
+        this.typeReference = new ParameterizedTypeReference<>() {};
+    }
+
+    @Test
+    public void success_getAccessToken() throws OBErrorResponseException, OBErrorException, URISyntaxException {
+        // Given
+        PairClientIDAuthMethod clientIdAuthMethod = getClientIDAuthMethod(TokenEndpointAuthMethods.CLIENT_SECRET_BASIC);
+        MultiValueMap<String, String> params = getParamsMap(GrantType.HEADLESS_AUTH);
+        HttpHeaders httpHeaders =  new HttpHeaders();
+        httpHeaders.setLocation(new URI("http://acme.com/#code=access_code"));
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse();
+
+        ResponseEntity<AccessTokenResponse> responseEntity = new ResponseEntity<>(accessTokenResponse,
+                httpHeaders, HttpStatus.OK);
+        given(authorisationApi.getAuthorisation(params.getFirst(OIDCClaim.RESPONSE_TYPE),
+                params.getFirst(OIDCClaim.CLIENT_ID),
+                params.getFirst(OIDCClaim.STATE),
+                params.getFirst(OIDCClaim.NONCE),
+                params.getFirst(OIDCClaim.SCOPE),
+                params.getFirst(OIDCClaim.REDIRECT_URI),
+                params.getFirst(OIDCClaim.REQUEST),
+                true,
+                params.getFirst(OIDCClaim.USERNAME),
+                params.getFirst(OIDCClaim.PASSWORD),
+                "",
+                null,
+                request)).willReturn(responseEntity);
+        String requestBody = "grant_type=authorization_code&redirect_uri=https%3A%2F%2Facme.co.uk&code=access_code";
+        given(amGateway.toAM(request, new HttpHeaders(), this.typeReference, requestBody)).willReturn(responseEntity);
+
+        // When
+        ResponseEntity<AccessTokenResponse> response = headlessAccessTokenService.getAccessToken(amGateway,
+                clientIdAuthMethod, params, request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void failWhenNoLocationHeader_getAccessToken() throws OBErrorResponseException, OBErrorException {
+        // Given
+        PairClientIDAuthMethod clientIdAuthMethod = getClientIDAuthMethod(TokenEndpointAuthMethods.CLIENT_SECRET_BASIC);
+        MultiValueMap<String, String> params = getParamsMap(GrantType.HEADLESS_AUTH);
+        HttpHeaders httpHeaders =  new HttpHeaders();
+        //httpHeaders.setLocation(new URI("http://acme.com/#code=access_code"));
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse();
+
+        ResponseEntity<AccessTokenResponse> responseEntity = new ResponseEntity<>(accessTokenResponse,
+                httpHeaders, HttpStatus.OK);
+        given(authorisationApi.getAuthorisation(params.getFirst(OIDCClaim.RESPONSE_TYPE),
+                params.getFirst(OIDCClaim.CLIENT_ID),
+                params.getFirst(OIDCClaim.STATE),
+                params.getFirst(OIDCClaim.NONCE),
+                params.getFirst(OIDCClaim.SCOPE),
+                params.getFirst(OIDCClaim.REDIRECT_URI),
+                params.getFirst(OIDCClaim.REQUEST),
+                true,
+                params.getFirst(OIDCClaim.USERNAME),
+                params.getFirst(OIDCClaim.PASSWORD),
+                "",
+                null,
+                request)).willReturn(responseEntity);
+
+        // When
+        OBErrorResponseException exception =
+                catchThrowableOfType(() -> headlessAccessTokenService.getAccessToken(amGateway, clientIdAuthMethod,
+                        params, request), OBErrorResponseException.class);
+
+        // Then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getCategory()).isEqualTo(OBRIErrorResponseCategory.HEADLESS_AUTH);
+    }
+
+    @Test
+    public void failWhenNoAuthorisation_getAccessToken() throws OBErrorResponseException, OBErrorException {
+        // Given
+        PairClientIDAuthMethod clientIdAuthMethod = getClientIDAuthMethod(TokenEndpointAuthMethods.CLIENT_SECRET_BASIC);
+        MultiValueMap<String, String> params = getParamsMap(GrantType.HEADLESS_AUTH);
+        HttpHeaders httpHeaders =  new HttpHeaders();
+
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse();
+
+        ResponseEntity<String> responseEntity = new ResponseEntity<>("{\"error\":\"broken stuff\"}",
+                httpHeaders, HttpStatus.BAD_REQUEST);
+        given(authorisationApi.getAuthorisation(params.getFirst(OIDCClaim.RESPONSE_TYPE),
+                params.getFirst(OIDCClaim.CLIENT_ID),
+                params.getFirst(OIDCClaim.STATE),
+                params.getFirst(OIDCClaim.NONCE),
+                params.getFirst(OIDCClaim.SCOPE),
+                params.getFirst(OIDCClaim.REDIRECT_URI),
+                params.getFirst(OIDCClaim.REQUEST),
+                true,
+                params.getFirst(OIDCClaim.USERNAME),
+                params.getFirst(OIDCClaim.PASSWORD),
+                "",
+                null,
+                request)).willReturn(responseEntity);
+
+        // When
+        OBErrorResponseException exception =
+                catchThrowableOfType(() -> headlessAccessTokenService.getAccessToken(amGateway, clientIdAuthMethod,
+                        params, request), OBErrorResponseException.class);
+
+        // Then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getCategory()).isEqualTo(OBRIErrorResponseCategory.HEADLESS_AUTH);
+        assertThat(exception.getErrors().get(0).getErrorCode()).isEqualTo(ErrorCode.OBRI_HEADLESS_AS_ERROR.toString());
+    }
+
+    // ToDo: Extract to test helper class as also used in @AccessTokenApiControllerTest
+    private PairClientIDAuthMethod getClientIDAuthMethod(TokenEndpointAuthMethods clientIdAuthMethod) {
+        PairClientIDAuthMethod pairClientIDAuthMethod = new PairClientIDAuthMethod();
+        pairClientIDAuthMethod.setAuthMethod(clientIdAuthMethod);
+        return pairClientIDAuthMethod;
+    }
+
+    private MultiValueMap<String, String> getParamsMap(GrantType grantType) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add(OIDCClaim.RESPONSE_TYPE, ResponseType.CODE.toString());
+        params.add(OIDCClaim.CLIENT_ID, "test_client_id");
+        params.add(OIDCClaim.STATE, "test_state");
+        params.add(OIDCClaim.NONCE, "test_nonce");
+        params.add(OIDCClaim.SCOPE, "test_scope");
+        params.add(OIDCClaim.REDIRECT_URI, "https://acme.co.uk");
+        params.add(OIDCClaim.REQUEST, "test_request");
+        params.add(OIDCClaim.USERNAME, "test_username");
+        params.add(OIDCClaim.PASSWORD, "test_password");
+        params.add(OIDCClaim.GRANT_TYPE, grantType.type);
+        return params;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>spring-security-multi-auth-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.forgerock.openbanking</groupId>
+            <artifactId>forgerock-openbanking-am</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/AccessTokenReWriteException.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/AccessTokenReWriteException.java
@@ -18,13 +18,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.as.service;
+package com.forgerock.openbanking.common.error.exception;
 
-import com.forgerock.openbanking.constants.OIDCConstants.TokenEndpointAuthMethods;
-import lombok.Data;
+public class AccessTokenReWriteException extends Exception {
+    public AccessTokenReWriteException(String message) {
+        super(message);
+    }
 
-@Data
-public class PairClientIDAuthMethod {
-    public String clientId;
-    public TokenEndpointAuthMethods authMethod;
+    public AccessTokenReWriteException(String message, Exception cause) {
+        super(message, cause);
+    }
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/rcs/consentdecision/ConsentDecision.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/rcs/consentdecision/ConsentDecision.java
@@ -33,7 +33,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ConsentDecision {
-
     private String consentJwt;
     private String decision;
 }

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/JwtOverridingService.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/JwtOverridingService.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.services;
+
+import com.forgerock.openbanking.am.config.AMOpenBankingConfiguration;
+import com.forgerock.openbanking.jwt.services.CryptoApiClient;
+import com.forgerock.openbanking.model.oidc.AccessTokenResponse;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.text.ParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * JwtOverridingService provides an API that allows a JWT to be parsed and then rewritten and resigned with the
+ * signing key that the ASPSP has been configured with. This is necessary because we allow AM to process the /authorize
+ * requests, but AM, even if configured to sign with the correct OB Signing key, does not not respond with a jwt that
+ * contains the kid for the key, which means it can't be validated against the OB Sandbox Directory's jwks_uri. So we
+ * must validate, parse, then recreate the id_token, signing it with the OB Signing key (or what ever the
+ * deployment's signing key is configured to be), and assigning a correct kid in the jwk header.
+ */
+@Service
+@Slf4j
+public class JwtOverridingService {
+
+    public class AccessTokenReWriteException extends Exception{
+        public  AccessTokenReWriteException(String message){
+            super(message);
+        }
+
+        public AccessTokenReWriteException(String message, Exception cause){
+            super(message, cause);
+        }
+    };
+
+    private static Pattern ID_TOKEN_PATTERN = Pattern.compile("id_token=?([^&]+)?");
+
+    private CryptoApiClient cryptoApiClient;
+    private AMOpenBankingConfiguration amOpenBankingConfiguration;
+
+    @Autowired
+    public JwtOverridingService(CryptoApiClient cryptoApiClient, AMOpenBankingConfiguration amOpenBankingConfiguration) {
+        this.cryptoApiClient = cryptoApiClient;
+        this.amOpenBankingConfiguration = amOpenBankingConfiguration;
+    }
+
+    private String rewriteJWS(String jws) throws ParseException {
+
+        JWTClaimsSet jwtClaimsSet = SignedJWT.parse(jws).getJWTClaimsSet();
+        return cryptoApiClient.signClaims(amOpenBankingConfiguration.getIssuerID(), jwtClaimsSet, false);
+    }
+
+    /**
+     * rewriteAccessTokenResponseIdToken - creates a new id_token, signed with the correct ID and containing the
+     * correct kid in the header. This is required as currently AM uses a different algorithm to create the kid than
+     * the OB Directory does, so when signing with the OB Signing Key or an OBSeal then the key ID in the AM
+     * generated id_token doesn't match the kid in the OB Directory jwks_uri and hence the id_token can't be
+     * validated. To fix that we resign it using the crypto API which produces a verifyable token.
+     *
+     * @param responseEntity the response entity that contains the id_token. Note, the id_token will only exist if
+     *                       the request to get the access token contained the openid scope, which is not mandatory.
+     *                       If the response entity does not contain an id_token then there is nothing to be
+     *                       re-written and the responseEntity will be returned.
+     * @return Either the responseEntity passed to the method (if it contained no id_token to be re-written), or a
+     * new responseEntity containing a new id_token that is verifiable.
+     * @throws AccessTokenReWriteException
+     */
+    public ResponseEntity rewriteAccessTokenResponseIdToken(ResponseEntity responseEntity)
+            throws AccessTokenReWriteException {
+
+        if(responseEntity == null){
+            throw new AccessTokenReWriteException("rewriteAccessTokenResponseIdToken() responseEntity is null");
+        }
+
+        if(responseEntity.getStatusCode() != HttpStatus.OK){
+            log.debug("rewriteAccessTokenResponseIdToken() responseEntity does not have success status");
+            throw new AccessTokenReWriteException("Failed to rewrite access token response's id_token: responseEntity" +
+                    " status code was " + responseEntity.getStatusCode() + ". Expected 200 (OK)");
+        }
+
+        AccessTokenResponse accessTokenResponse = (AccessTokenResponse) responseEntity.getBody();
+        if(accessTokenResponse == null){
+            log.debug("rewriteAccessTokenResponseIdToken() Expected body in responseEntity '{}'",
+                    responseEntity.toString());
+            throw new AccessTokenReWriteException("Failed to rewrite access token response's id_token; responseEntity" +
+                    " has no body");
+        }
+
+        String id_token = accessTokenResponse.getId_token();
+        if(id_token == null){
+            log.debug("rewriteAccessTokenResponseIdToken() responseEntity body contains no id_token; '{}'",
+                    accessTokenResponse.toString());
+            return responseEntity;
+        } else {
+            try {
+                String rewrittenJWS = rewriteJWS(id_token);
+                if (rewrittenJWS == null || rewrittenJWS.isEmpty() || rewrittenJWS.isBlank()) {
+                    log.debug("rewriteAccessTokenResponseIdToken() rewrittenJWS is null or empty.");
+                    throw new AccessTokenReWriteException("Failed to rewrite access token response's id_token; re-written" +
+                            " JWS is null or empty");
+
+                }
+                accessTokenResponse.setId_token(rewrittenJWS);
+            } catch (ParseException e) {
+                log.debug("rewriteAccessTokenResponseIdToken() Failed to parse id_token: '{}'", id_token, e);
+                throw new AccessTokenReWriteException("Failed to rewrite access token response's id_token; Could not " +
+                        "parse id_token", e);
+            }
+
+            ResponseEntity rewrittenResponseEntity = ResponseEntity.status(HttpStatus.OK).body(accessTokenResponse);
+            log.trace("rewriteAccessTokenResponseIdToken() re-written responseEntity is '{}'", responseEntity.toString());
+            return rewrittenResponseEntity;
+        }
+
+    }
+
+    /**
+     * Rewrite the id_token fragment of a ResponseEntity such that it is replaced with a new id_token containing the
+     * same body, but that is signed by the ASPSP's signing key and contains the correct kid in the jwt header.
+     * @param responseEntity
+     * @return a new @ResponseEntity
+     * @throws AccessTokenReWriteException if there is no id_token in the Location header fragment that can be replaced, or if
+     * the id_token in that fragment can't be parsed.
+     */
+    public ResponseEntity rewriteIdTokenFragmentInLocationHeader(ResponseEntity responseEntity)
+            throws AccessTokenReWriteException {
+        if (responseEntity == null) {
+            log.debug("getFragmentIdTokenInLocationHeader(): responseEntity is null");
+            throw new AccessTokenReWriteException("Failed to find id_token to re-write: responseEntity is null");
+        }
+        log.trace("rewriteIdTokenFragmentInLocationHeader() responseEntity is '{}'", responseEntity);
+
+        if (responseEntity.getStatusCode() != HttpStatus.FOUND) {
+            log.debug("getFragmentIdTokenInLocationHeader(): responseEntity does not have a FOUND http Status; '{}'",
+                    responseEntity);
+            throw new AccessTokenReWriteException("Failed to find id_token to re-write: responseEntity does not have " +
+                    "a FOUND http status");
+        }
+
+        if (responseEntity.getHeaders().getLocation() == null) {
+            log.debug("getFragmentIdTokenInLocationHeader(): responseEntity has no location header: '{}'",
+                    responseEntity);
+            throw new AccessTokenReWriteException("Failed to find id_token to re-write: responseEntity has no " +
+                    "location header");
+        } else {
+            log.debug("getFragmentIdTokenInLocationHeader(): Location is: {}",
+                    responseEntity.getHeaders().getLocation());
+        }
+
+        String uriFragment = responseEntity.getHeaders().getLocation().getFragment();
+        if ( uriFragment == null || uriFragment.isEmpty() || uriFragment.isBlank() ){
+            log.debug("getFragmentIdTokenInLocationHeader(): Location has no fragment");
+            throw new AccessTokenReWriteException("Failed to find id_token to re-write: responseEntity's Location has" +
+                    " no fragment");
+        }
+
+        ResponseEntity rewrittenResponseEntity = null;
+        try {
+            String locationString = responseEntity.getHeaders().getLocation().toString();
+            Matcher matcher = ID_TOKEN_PATTERN.matcher(locationString);
+            while (matcher.find()) {
+                String oldIdToken = matcher.group(1);
+                String newIdToken = rewriteJWS(oldIdToken);
+                String newLocationHeaderValue = locationString.replaceAll(oldIdToken, newIdToken);
+                if (!newLocationHeaderValue.isEmpty() && !newLocationHeaderValue.isBlank()) {
+                    HttpHeaders writableHttpHeaders = HttpHeaders.writableHttpHeaders(responseEntity.getHeaders());
+                    writableHttpHeaders.set(HttpHeaders.LOCATION, newLocationHeaderValue);
+                    rewrittenResponseEntity = new ResponseEntity(responseEntity.getBody(), writableHttpHeaders,
+                            HttpStatus.FOUND);
+                } else {
+                    log.debug("rewriteIdTokenFragmentInLocationHeader() No new location header value.");
+                    throw new AccessTokenReWriteException("Failed to rewrite id_token: new Location header value is " +
+                            "null or empty");
+                }
+            }
+        } catch (ParseException e){
+            log.error("rewriteIdTokenFragmentInLocationHeader() Could not parse the JWT", e);
+            throw new AccessTokenReWriteException("Failed to parse the responseEntity's Location fragment id_token", e);
+        }
+
+        return rewrittenResponseEntity;
+    }
+
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/test/java/com/forgerock/openbanking/common/services/JwtOverridingServiceTest.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/test/java/com/forgerock/openbanking/common/services/JwtOverridingServiceTest.java
@@ -21,6 +21,7 @@
 package com.forgerock.openbanking.common.services;
 
 import com.forgerock.openbanking.am.config.AMOpenBankingConfiguration;
+import com.forgerock.openbanking.common.error.exception.AccessTokenReWriteException;
 import com.forgerock.openbanking.jwt.services.CryptoApiClient;
 import com.forgerock.openbanking.model.oidc.AccessTokenResponse;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -65,7 +66,7 @@ public class JwtOverridingServiceTest {
     }
 
     @Test
-    public void shouldRewriteAccessTokenResponseIdToken() throws JwtOverridingService.AccessTokenReWriteException {
+    public void shouldRewriteAccessTokenResponseIdToken() throws AccessTokenReWriteException {
         // Given
         this.amOpenBankingConfiguration.issuerId = "acme bank Ltd";
         HttpHeaders httpHeaders = new HttpHeaders();
@@ -100,9 +101,9 @@ public class JwtOverridingServiceTest {
 
 
         // Then
-        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+        AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
                 ()->this.jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity),
-                JwtOverridingService.AccessTokenReWriteException.class);
+                AccessTokenReWriteException.class);
 
         // When
         assertThat(accessTokenReWriteException.getMessage()).contains("Expected 200 (OK)");
@@ -117,9 +118,9 @@ public class JwtOverridingServiceTest {
 
 
         // Then
-        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+        AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
                 ()->this.jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity),
-                JwtOverridingService.AccessTokenReWriteException.class);
+                AccessTokenReWriteException.class);
 
         // When
         assertThat(accessTokenReWriteException.getMessage()).contains("responseEntity has no body");
@@ -127,7 +128,7 @@ public class JwtOverridingServiceTest {
 
     @Test
     public void shouldReturnOrignialWhenBodyHasNoIdToken_rewriteAccessTokenResponseIdToken() throws
-            JwtOverridingService.AccessTokenReWriteException {
+            AccessTokenReWriteException {
         // Given
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Location", "https://location");
@@ -152,16 +153,16 @@ public class JwtOverridingServiceTest {
 
 
         // Then
-        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+        AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
                 ()->this.jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity),
-                JwtOverridingService.AccessTokenReWriteException.class);
+                AccessTokenReWriteException.class);
 
         // When
         assertThat(accessTokenReWriteException.getMessage()).contains("Could not parse id_token");
     }
 
     @Test
-    public void rewriteIdTokenFragmentInLocationHeader() throws JwtOverridingService.AccessTokenReWriteException,
+    public void rewriteIdTokenFragmentInLocationHeader() throws AccessTokenReWriteException,
             URISyntaxException {
         // Given
         amOpenBankingConfiguration.issuerId = "acme bank Ltd";
@@ -201,9 +202,9 @@ public class JwtOverridingServiceTest {
         ResponseEntity responseEntity = new ResponseEntity(HttpStatus.OK);
 
         // When
-        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+        AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
                 ()->this.jwtOverridingService.rewriteIdTokenFragmentInLocationHeader(responseEntity),
-                JwtOverridingService.AccessTokenReWriteException.class );
+                AccessTokenReWriteException.class );
 
         // Then
         assertThat(accessTokenReWriteException.getMessage()).contains("does not have a FOUND http status");

--- a/forgerock-openbanking-uk-aspsp-common/src/test/java/com/forgerock/openbanking/common/services/JwtOverridingServiceTest.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/test/java/com/forgerock/openbanking/common/services/JwtOverridingServiceTest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.services;
+
+import com.forgerock.openbanking.am.config.AMOpenBankingConfiguration;
+import com.forgerock.openbanking.jwt.services.CryptoApiClient;
+import com.forgerock.openbanking.model.oidc.AccessTokenResponse;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class JwtOverridingServiceTest {
+
+    @Mock
+    JwtOverridingService jwtOverridingService;
+    @Mock
+    CryptoApiClient cryptoApiClient;
+    AMOpenBankingConfiguration amOpenBankingConfiguration;
+
+    @Before
+    public void setUp() throws Exception {
+        this.amOpenBankingConfiguration = new AMOpenBankingConfiguration();
+        this.jwtOverridingService = new JwtOverridingService(cryptoApiClient, amOpenBankingConfiguration);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void shouldRewriteAccessTokenResponseIdToken() throws JwtOverridingService.AccessTokenReWriteException {
+        // Given
+        this.amOpenBankingConfiguration.issuerId = "acme bank Ltd";
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Location", "https://location");
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse();
+        accessTokenResponse.setId_token("eyJraWQiOiIzYmEwYjRjMGRjOGNiOTg3YTE5ZjNiNDgwZDFiODlmMWNiODA4MDI5IiwiYWxnIjoi" +
+                "UFMyNTYifQ.eyJzdWIiOiJmMjU5MDlmZC01MzEwLTRiNjgtYTI5Yy0zM2QyYjE1OWMzNzUiLCJhdWQiOiJodHRwczpcL1wvYXMuY" +
+                "XNwc3AuZGV2LW9iLmZvcmdlcm9jay5maW5hbmNpYWw6ODA3NFwvb2F1dGgyIiwiaXNzIjoiZjI1OTA5ZmQtNTMxMC00YjY4LWEyO" +
+                "WMtMzNkMmIxNTljMzc1IiwiZXhwIjoxNjIxNDEwODU1LCJpYXQiOjE2MjE0MTA1NTUsImp0aSI6IjgzMDEwYzU4LTczNDYtNGJjM" +
+                "S05OTVhLTg4NDI4NTRhMGEzOSJ9.PTnkBmKeWhT1kLlOkVJGrBKJHBksY16ynzP1KvHzwcYFMm6ixNd4iDc2aosSI7vH9ufamnR0" +
+                "O9UoZzi3uWflWq9B2ah8m8rNNWYr-Y3B4Ev_nrKDDgozWZ_u0PY5Tzau0TVcVYyRkNTIXoVk-hYVLjuxZiMPQm7Ceid-KemK6Y04" +
+                "UAiwGZou4KIKWXjGySOBlJEZO42LTZk0UKAC8AeXlQCo_QSzOchrD8wmJOeCH59VooZku5eubviKZ1UKo0hkDxLg13IjER-dansJ" +
+                "tHqCcDCVV9n04Rvvs88yvvCWTcRsdEpUUg-e-sGVUR2ER9UyQMyY012_fA-R7W8H4jv_iQ");
+        ResponseEntity responseEntity = new ResponseEntity(accessTokenResponse, httpHeaders, HttpStatus.OK);
+        when(this.cryptoApiClient.signClaims(anyString(), any(JWTClaimsSet.class), anyBoolean())).thenReturn(
+                "RewrittenIdToken");
+
+        // Then
+        ResponseEntity<AccessTokenResponse> rewrittenResponseEntity =
+                this.jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity);
+
+        // When
+        assertThat(rewrittenResponseEntity.getBody().getId_token()).isEqualTo("RewrittenIdToken");
+    }
+
+    @Test
+    public void shouldFailWhenStatusNotOK_rewriteAccessTokenResponseIdToken() {
+        // Given
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Location", "https://location");
+        ResponseEntity responseEntity = new ResponseEntity(HttpStatus.FOUND);
+
+
+        // Then
+        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+                ()->this.jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity),
+                JwtOverridingService.AccessTokenReWriteException.class);
+
+        // When
+        assertThat(accessTokenReWriteException.getMessage()).contains("Expected 200 (OK)");
+    }
+
+    @Test
+    public void shouldFailWhenNoBody_rewriteAccessTokenResponseIdToken() {
+        // Given
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Location", "https://location");
+        ResponseEntity responseEntity = new ResponseEntity(HttpStatus.OK);
+
+
+        // Then
+        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+                ()->this.jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity),
+                JwtOverridingService.AccessTokenReWriteException.class);
+
+        // When
+        assertThat(accessTokenReWriteException.getMessage()).contains("responseEntity has no body");
+    }
+
+    @Test
+    public void shouldReturnOrignialWhenBodyHasNoIdToken_rewriteAccessTokenResponseIdToken() throws
+            JwtOverridingService.AccessTokenReWriteException {
+        // Given
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Location", "https://location");
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse();
+        ResponseEntity responseEntity = new ResponseEntity(accessTokenResponse, httpHeaders, HttpStatus.OK);
+
+        // Then
+        ResponseEntity result  = jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity);
+
+        // When
+        assertThat(result).isSameAs(responseEntity);
+    }
+
+    @Test
+    public void shouldFailWhenBodyHasInvalidIdToken_rewriteAccessTokenResponseIdToken() {
+        // Given
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Location", "https://location");
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse();
+        accessTokenResponse.setId_token("InvalidToken");
+        ResponseEntity responseEntity = new ResponseEntity(accessTokenResponse, httpHeaders, HttpStatus.OK);
+
+
+        // Then
+        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+                ()->this.jwtOverridingService.rewriteAccessTokenResponseIdToken(responseEntity),
+                JwtOverridingService.AccessTokenReWriteException.class);
+
+        // When
+        assertThat(accessTokenReWriteException.getMessage()).contains("Could not parse id_token");
+    }
+
+    @Test
+    public void rewriteIdTokenFragmentInLocationHeader() throws JwtOverridingService.AccessTokenReWriteException,
+            URISyntaxException {
+        // Given
+        amOpenBankingConfiguration.issuerId = "acme bank Ltd";
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setLocation(new URI("https://location#id_token=eyJ0eXAiOiJKV1QiLCJraWQiOiJzUUhYOHlnT3JGcHBsZ09ZZ" +
+                "kxpQUNTNzJOMG89IiwiYWxnIjoiUFMyNTYifQ.eyJzdWIiOiJBQUNfZGZkMzI4NGEtMTkxYy00ODA0LTlmZmItNTFlNGRjZTljN" +
+                "jkwIiwiYXVkaXRUcmFja2luZ0lkIjoiZmRhYmM2MWEtYmZjOS00OWNlLThmZTUtODczOGQzMGExMmY5LTkyMzE5NyIsImlzcyI6" +
+                "Imh0dHBzOi8vYXMuYXNwc3Auc2FuZGJveC5sbG95ZHNiYW5raW5nLmNvbS9vYXV0aDIiLCJ0b2tlbk5hbWUiOiJpZF90b2tlbiI" +
+                "sIm5vbmNlIjoiYjc3Y2ZjYzItYmI4Yi00Zjc2LTlhOGYtNGM1N2M5ZjJmNjhiIiwiYWNyIjoidXJuOm9wZW5iYW5raW5nOnBzZD" +
+                "I6c2NhIiwiYXVkIjoiNjUwOTE2OTYtOWRmYi00NDIxLWI1MTYtZGUwYzk3ZWI5ODc0IiwiY19oYXNoIjoiczVNUXBjWVZaNmY0c" +
+                "WE5QmxsdzZaQSIsIm9wZW5iYW5raW5nX2ludGVudF9pZCI6IkFBQ19kZmQzMjg0YS0xOTFjLTQ4MDQtOWZmYi01MWU0ZGNlOWM2" +
+                "OTAiLCJzX2hhc2giOiJ2NWgwTUFUTS13NEVGWXRCcEVtemR3IiwiYXpwIjoiNjUwOTE2OTYtOWRmYi00NDIxLWI1MTYtZGUwYzk" +
+                "3ZWI5ODc0IiwiYXV0aF90aW1lIjoxNjE4NTcwODM2LCJyZWFsbSI6Ii9vcGVuYmFua2luZyIsImV4cCI6MTYxODU3ODQ1OCwidG" +
+                "9rZW5UeXBlIjoiSldUVG9rZW4iLCJpYXQiOjE2MTg1NzQ4NTh9.VnxIks-Vm56NjhNrxGxlyDczazJj1c5R8n4YVKjsmq10WT0m" +
+                "C8nnUuMsuVhqn2k6J2KUqTgvN_JGaxTsAfDVtyIbpieRiuJoNFF6xBTCPArp4V5qm4rff6imKUYTBFj0zzbnacMjA048LkbLWEl" +
+                "JhXNbiwUQJ-PbMzkCLRAbH2p5LYJTZUwDKsupD-uLxbkiwCGXy4Oa-yCwEh_nMwQoA1XUdBfhFMf0i4kjg5z6W01x8P4CC04iVb" +
+                "gKeqBrwREfknw6aZ2zoGaUYtyaPVhmkrnR3cDGFCKPc5De0TUdI3iSRUIDYOtCKs1M-ZAshdBc0B6A2Vz2aJEOXgo16_yREA"));
+        ResponseEntity responseEntity = new ResponseEntity(httpHeaders, HttpStatus.FOUND);
+
+        when(this.cryptoApiClient.signClaims(anyString(), any(JWTClaimsSet.class), anyBoolean())).thenReturn(
+                "RewrittenIdToken");
+
+
+        // When
+        ResponseEntity newResponseEntity =
+                this.jwtOverridingService.rewriteIdTokenFragmentInLocationHeader(responseEntity);
+
+        // Then
+        assertThat(newResponseEntity.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        assertThat(newResponseEntity.getHeaders().getLocation()).hasFragment("id_token=RewrittenIdToken");
+    }
+
+    @Test
+    public void shouldFailWhenStatusNotFound_rewriteIdTokenFragmentInLocationHeader() {
+        // Given
+        amOpenBankingConfiguration.issuerId = "acme bank Ltd";
+        ResponseEntity responseEntity = new ResponseEntity(HttpStatus.OK);
+
+        // When
+        JwtOverridingService.AccessTokenReWriteException accessTokenReWriteException = catchThrowableOfType(
+                ()->this.jwtOverridingService.rewriteIdTokenFragmentInLocationHeader(responseEntity),
+                JwtOverridingService.AccessTokenReWriteException.class );
+
+        // Then
+        assertThat(accessTokenReWriteException.getMessage()).contains("does not have a FOUND http status");
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/autoaccept/AutodecisionsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/autoaccept/AutodecisionsApiController.java
@@ -63,22 +63,32 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @Slf4j
 public class AutodecisionsApiController implements AutodecisionsApi {
 
+    private final RcsService rcsService;
+    private final  RcsConfiguration rcsConfiguration;
+    private final  AMOpenBankingConfiguration amOpenBankingConfiguration;
+    private final  RCSErrorService rcsErrorService;
+    private final  UserProfileService userProfileService;
+    private final  IntentTypeService intentTypeService;
+    private final  AccountStoreService accountsService;
+    private final  UserDataService userDataService;
+
     @Autowired
-    private RcsService rcsService;
-    @Autowired
-    private RcsConfiguration rcsConfiguration;
-    @Autowired
-    private AMOpenBankingConfiguration amOpenBankingConfiguration;
-    @Autowired
-    private RCSErrorService rcsErrorService;
-    @Autowired
-    private UserProfileService userProfileService;
-    @Autowired
-    private IntentTypeService intentTypeService;
-    @Autowired
-    private AccountStoreService accountsService;
-    @Autowired
-    private UserDataService userDataService;
+    public AutodecisionsApiController(RcsService rcsService, RcsConfiguration rcsConfiguration,
+                                      AMOpenBankingConfiguration amOpenBankingConfiguration,
+                                      RCSErrorService rcsErrorService, UserProfileService userProfileService,
+                                      IntentTypeService intentTypeService, AccountStoreService accountsService,
+                                      UserDataService userDataService) {
+        this.rcsService = rcsService;
+        this.rcsConfiguration = rcsConfiguration;
+        this.amOpenBankingConfiguration = amOpenBankingConfiguration;
+        this.rcsErrorService = rcsErrorService;
+        this.userProfileService = userProfileService;
+        this.intentTypeService = intentTypeService;
+        this.accountsService = accountsService;
+        this.userDataService = userDataService;
+    }
+
+
 
     @Override
     public ResponseEntity<RedirectionAction> autoAccept(
@@ -129,6 +139,7 @@ public class AutodecisionsApiController implements AutodecisionsApi {
                 throw new OBErrorException(OBRIErrorType.RCS_CONSENT_RESPONSE_FAILURE);
             }
 
+            // TODO: Determine if the id_token needs re-writing!
             String location = responseEntity.getHeaders().getFirst(HttpHeaders.LOCATION);
             log.debug("The redirection to the consent page should be in the location '{}'", location);
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/RCSConsentDecisionApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/RCSConsentDecisionApiController.java
@@ -28,6 +28,7 @@ import com.forgerock.openbanking.aspsp.rs.rcs.services.RCSErrorService;
 import com.forgerock.openbanking.aspsp.rs.rcs.services.RcsService;
 import com.forgerock.openbanking.common.conf.RcsConfiguration;
 import com.forgerock.openbanking.common.constants.RCSConstants;
+import com.forgerock.openbanking.common.error.exception.AccessTokenReWriteException;
 import com.forgerock.openbanking.common.model.rcs.RedirectionAction;
 import com.forgerock.openbanking.common.model.rcs.consentdecision.ConsentDecision;
 import com.forgerock.openbanking.common.services.JwtOverridingService;
@@ -213,7 +214,7 @@ public class RCSConsentDecisionApiController implements RCSConsentDecisionApi {
                 try {
                     rewrittenResponseEntity =
                             jwtOverridingService.rewriteIdTokenFragmentInLocationHeader(responseEntity);
-                } catch (JwtOverridingService.AccessTokenReWriteException e){
+                } catch (AccessTokenReWriteException e){
                     log.info("decisionAccountSharing() Failed to re-write id_token", e);
                     throw new OBErrorException(OBRIErrorType.RCS_CONSENT_RESPONSE_FAILURE);
                 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/singlepayments/SinglePaymentConsentDecisionDelegate.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/singlepayments/SinglePaymentConsentDecisionDelegate.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Slf4j
+public
 class SinglePaymentConsentDecisionDelegate implements ConsentDecisionDelegate {
 
     private AccountStoreService accountsService;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/services/IntentTypeService.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/services/IntentTypeService.java
@@ -99,7 +99,7 @@ public class IntentTypeService {
                 return accountAccessConsentDecisionApiController.create(intentId);
             case PAYMENT_SINGLE_REQUEST:
                 log.debug("It's a payment consent request");
-            return singlePaymentConsentDecisionService.create(intentId);
+                return singlePaymentConsentDecisionService.create(intentId);
             case PAYMENT_INTERNATIONAL_CONSENT:
                 log.debug("It's a international payment consent request");
                 return internationalPaymentConsentDecisionFactory.create(intentId);

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/test/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/RCSConsentDecisionApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/test/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/RCSConsentDecisionApiControllerTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.rcs.api.rcs.decisions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.openbanking.am.config.AMOpenBankingConfiguration;
+import com.forgerock.openbanking.am.services.UserProfileService;
+import com.forgerock.openbanking.aspsp.rs.rcs.api.rcs.decisions.singlepayments.SinglePaymentConsentDecisionDelegate;
+import com.forgerock.openbanking.aspsp.rs.rcs.services.IntentTypeService;
+import com.forgerock.openbanking.aspsp.rs.rcs.services.RCSErrorService;
+import com.forgerock.openbanking.aspsp.rs.rcs.services.RcsService;
+import com.forgerock.openbanking.common.conf.RcsConfiguration;
+import com.forgerock.openbanking.common.constants.RCSConstants;
+import com.forgerock.openbanking.common.model.rcs.RedirectionAction;
+import com.forgerock.openbanking.common.model.rcs.consentdecision.ConsentDecision;
+import com.forgerock.openbanking.common.services.JwtOverridingService;
+import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.jwt.services.CryptoApiClient;
+import com.forgerock.openbanking.model.Tpp;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.forgerock.openbanking.aspsp.rs.rcs.api.rcs.JwtTestHelper.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class RCSConsentDecisionApiControllerTest {
+
+    @Mock
+    private CryptoApiClient cryptoApiClient;
+    @Mock
+    private RcsService rcsService;
+    @Mock
+    private RcsConfiguration rcsConfiguration;
+    @Mock
+    private RCSErrorService rcsErrorService;
+    @Mock
+    private UserProfileService userProfileService;
+    @Mock
+    private IntentTypeService intentTypeService;
+    @Mock
+    private TppStoreService tppStoreService;
+    @Mock
+    private JwtOverridingService jwtOverridingService;
+
+    private final AMOpenBankingConfiguration amOpenBankingConfiguration = new AMOpenBankingConfiguration();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Class under test
+    private RCSConsentDecisionApiController consentDecisionApiController;
+
+
+    @Before
+    public void setUp() throws Exception {
+        this.consentDecisionApiController = new RCSConsentDecisionApiController(cryptoApiClient,rcsService,
+                rcsConfiguration,amOpenBankingConfiguration, rcsErrorService, objectMapper, userProfileService,
+                intentTypeService, tppStoreService, jwtOverridingService);
+
+        SinglePaymentConsentDecisionDelegate singlePaymentConsentDecisionDelegate =
+                mock(SinglePaymentConsentDecisionDelegate.class);
+        when(intentTypeService.getConsentDecision(anyString())).thenReturn(singlePaymentConsentDecisionDelegate);
+        when(singlePaymentConsentDecisionDelegate.getTppIdBehindConsent()).thenReturn("TppId");
+        when(singlePaymentConsentDecisionDelegate.getUserIDBehindConsent()).thenReturn("username");
+
+        Tpp tpp = mock(Tpp.class);
+        Optional<Tpp> isTpp = Optional.of(tpp);
+        when(this.tppStoreService.findById(anyString())).thenReturn(isTpp);
+        when(tpp.getClientId()).thenReturn("98311305-1c4f-4ffb-8af4-90c9b220e365");
+
+        amOpenBankingConfiguration.userProfileId = "username";
+        amOpenBankingConfiguration.endpointUserProfile = "endpointUserProfile";
+        amOpenBankingConfiguration.cookieName = "cookieName";
+        Map<String, String> profile = new HashMap<String, String>();
+        profile.put(amOpenBankingConfiguration.userProfileId, "username");
+        when(this.userProfileService.getProfile(anyString(), anyString(), anyString())).thenReturn(profile);
+
+        ResponseEntity responseEntity = mock(ResponseEntity.class);
+        when(this.rcsService.sendRCSResponseToAM(anyString(), any(RedirectionAction.class))).thenReturn(responseEntity);
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.FOUND);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Location", "https://www.google.com#code=oq62Wr-V0E7cnuIl5rDSwscCyVo&id_token" +
+                "=eyJ0eXAiOiJKV1QiLCJraWQiOiJzUUhYOHlnT3JGcHBsZ09ZZkxpQUNTNzJOMG89IiwiYWxnIjoiUFMyNTYifQ.eyJzdWIiOiJ" +
+                "BQUNfM2ZkODYwYjktOGZlYS00NWMwLThiNTItNDJkNjM1YWRjYzRjIiwiYXVkaXRUcmFja2luZ0lkIjoiZmRhYmM2MWEtYmZjOS" +
+                "00OWNlLThmZTUtODczOGQzMGExMmY5LTIyNTczNDgiLCJpc3MiOiJodHRwczovL2FzLmFzcHNwLnNhbmRib3gubGxveWRzYmFua" +
+                "2luZy5jb20vb2F1dGgyIiwidG9rZW5OYW1lIjoiaWRfdG9rZW4iLCJub25jZSI6IjEwZDI2MGJmLWE3ZDktNDQ0YS05MmQ5LTdi" +
+                "N2E1ZjA4ODIwOCIsImF1ZCI6IjE3ZTI5NmYyLTNkMDctNDMxMS05ZDAwLTk4ZDY3YjUyNTk4MCIsImNfaGFzaCI6IjB4UDJseGh" +
+                "qek1GOTlmakhmel92dWciLCJhY3IiOiJ1cm46b3BlbmJhbmtpbmc6cHNkMjpzY2EiLCJvcGVuYmFua2luZ19pbnRlbnRfaWQiOi" +
+                "JBQUNfM2ZkODYwYjktOGZlYS00NWMwLThiNTItNDJkNjM1YWRjYzRjIiwic19oYXNoIjoiWE5TdVJac0pVb1pjdjdZOTBoNFpfU" +
+                "SIsImF6cCI6IjE3ZTI5NmYyLTNkMDctNDMxMS05ZDAwLTk4ZDY3YjUyNTk4MCIsImF1dGhfdGltZSI6MTYyMDkxOTc2MiwicmVh" +
+                "bG0iOiIvb3BlbmJhbmtpbmciLCJleHAiOjE2MjA5MjM0MDIsInRva2VuVHlwZSI6IkpXVFRva2VuIiwiaWF0IjoxNjIwOTE5ODA" +
+                "yfQ.U7zDwtrnE2ocbpcbhOc3f-j6ve0EKoh6S9n8qVH69-zezg0Qcro3PTd59gEA6L0kz5ror6epScSaWy-6rKClCr8sFqA_Fx9" +
+                "W5qe5K-WUFTWMtfX2ncIwf-RJzxazzfxkpIrKfVhi6R96qpi7RYSZ3GWUfxBm2za24ZvyUNVR5c9ptlyke5h4Wq1QZkaiHv02VT" +
+                "EO2GbumtWIWYfpl84FepZvDm6E6O7K0KCTs8G--jrCnZljwL-qSgWEUkIDja4eaz4KYdZ7-U-CUVzdoMaxhZY5CbM09PRRPsiuy" +
+                "vsZ6FVGx6YGHUN-BDIFssy6hpD53Dp2HGbCxZ0unBU50Q9N3w&state=10d260bf-a7d9-444a-92d9-7b7a5f088208");
+        URI rewrittenUri = new URI("https://www.google.com#code=oq62Wr-V0E7cnuIl5rDSwscCyVo&id_token" +
+                "=re-writtenIdToken");
+
+        HttpHeaders rewrittenHeaders = new HttpHeaders();
+        rewrittenHeaders.add("Location", "https://www.google.com#code=oq62Wr-V0E7cnuIl5rDSwscCyVo&id_token=re" +
+                        "-writtenIdToken");
+        ResponseEntity rewrittenResponseEntity = new ResponseEntity(null, rewrittenHeaders, HttpStatus.FOUND);
+        when(jwtOverridingService.rewriteIdTokenFragmentInLocationHeader(any(ResponseEntity.class)))
+                .thenReturn(rewrittenResponseEntity);
+
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void decisionAccountSharing() throws OBErrorException, JsonProcessingException {
+        // Given
+        String signedJwtEncoded = toEncodedSignedTestJwt("jwt/singlePaymentConsentRequestPayload.json");
+        String ssoToken = "dlkjdsflkjdlsfhlkfdk";
+        ConsentDecision consentDecision = new ConsentDecision();
+        consentDecision.setDecision(RCSConstants.Decision.ALLOW);
+        consentDecision.setConsentJwt(signedJwtEncoded);
+        String consentDecisionSerialized = objectMapper.writeValueAsString(consentDecision);
+
+        // When
+        ResponseEntity responseEntity = consentDecisionApiController.decisionAccountSharing(consentDecisionSerialized,
+                ssoToken);
+
+        // Then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isNotNull();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        RedirectionAction redirectAction = (RedirectionAction) responseEntity.getBody();
+        assertThat(redirectAction).isNotNull();
+        assertThat(redirectAction.getRedirectUri()).contains("re-writtenIdToken");
+    }
+
+    private static String toEncodedSignedTestJwt(final String jwtPayloadFilePath) {
+        return utf8FileToString
+                .andThen(jsonStringToClaimsSet)
+                .andThen(claimsSetToRsa256Jwt)
+                .andThen(signJwt)
+                .andThen(serializeJwt)
+                .apply(jwtPayloadFilePath);
+    }
+}


### PR DESCRIPTION
Re-sign the id token that get's passed to the redirect URI after consent
has been given via the hybrid flow.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/745