### PR TITLE
422: Improve DELETE /register logging and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+[b0704b02d1c8154](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/b0704b02d1c8154) JamieB *2021-06-02 13:53:21*
+Release candidate: prepare for next development iteration
+## 1.4.4
+[41f8db04407bd5d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/41f8db04407bd5d) JamieB *2021-06-02 13:53:15*
+Release candidate: prepare release 1.4.4
+[431a39cb7f64e75](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/431a39cb7f64e75) JamieB *2021-06-02 13:48:15*
+749: set dev version to 1.4.4-SNAPSHOT before creating release
+
+Something odd has happened with the aspsp versions. We're using 1.4.3
+currently in openbanking-reference-implementation, but master has
+1.4.3-SNAPSHOT in the poms!!!
+
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/749
+[dc53032d15bc9f4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/dc53032d15bc9f4) JamieB *2021-06-02 13:09:25*
+Release candidate: rollback the release of 1.4.3
+[857948eaae36fee](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/857948eaae36fee) JamieB *2021-06-02 12:54:46*
+Release candidate: prepare release 1.4.3
+[c9b2efe15b39437](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c9b2efe15b39437) JamieB *2021-06-02 12:43:55*
+749: make x-headless-auth-enabled false default /authorize
+
+During refactoring for issue
+https://github.com/ForgeCloud/ob-deploy/issues/745 I inadvertantly
+removed the default value for the X_HEADLESS_AUTH_ENABLED setting. It
+should be false by default.
+
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/749
 [715919c227dde22](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/715919c227dde22) JamieB *2021-05-26 15:02:43*
 745: Addressed more comments
 [674b30928f499b0](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/674b30928f499b0) JamieB *2021-05-26 13:53:57*

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApi.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApi.java
@@ -26,6 +26,9 @@
 package com.forgerock.openbanking.aspsp.as.api.registration.dynamic;
 
 import com.forgerock.openbanking.aspsp.as.service.OIDCException;
+import com.forgerock.openbanking.common.error.exception.oauth2.OAuth2BearerTokenUsageInvalidTokenException;
+import com.forgerock.openbanking.common.error.exception.oauth2.OAuth2BearerTokenUsageMissingAuthInfoException;
+import com.forgerock.openbanking.common.error.exception.oauth2.OAuth2InvalidClientException;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.oidc.OIDCRegistrationResponse;
@@ -37,33 +40,63 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.security.Principal;
 
-
+/**
+ *
+ * Interface specifying endpoints that required to implement the Open Banking (OB) Dynamic
+ * Client Registration (DCR) specification.
+ *
+ * <ul>
+ *     <li> <a href=https://openbankinguk.github.io/dcr-docs-pub/v3.3/dynamic-client-registration.html>
+ *         Open Banking Dynamic Client Registration Specifications</a></li>
+ *     <li><a href=https://datatracker.ietf.org/doc/html/rfc7591>
+ *         The OAuth2 Dynamic Client Registration standard</a></li>
+ * </ul>
+ */
 @Api(value = "register", description = "the register API")
 @RequestMapping(value = "/open-banking/register")
 public interface DynamicRegistrationApi {
 
     @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
-    @ApiOperation(value = "Delete a client by way of Client ID", nickname = "registerClientIdDelete", notes = "", authorizations = {
-            @Authorization(value = "TPPOAuth2Security", scopes = {
-            })
-    }, tags={ "Client Registration","Optional", })
+    @ApiOperation(value = "Delete a client by way of Client ID", nickname = "registerClientIdDelete", notes = "",
+            authorizations = { @Authorization(value = "TPPOAuth2Security", scopes = {}) },
+            tags = {"Client " +"Registration", "Optional",})
     @ApiResponses(value = {
             @ApiResponse(code = 204, message = "Client deleted"),
             @ApiResponse(code = 401, message = "Request failed due to unknown or invalid Client or invalid access token"),
             @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client"),
-            @ApiResponse(code = 405, message = "The client does not have permission to read, update or delete the Client") })
+            @ApiResponse(code = 405, message = "The client does not have permission to read, update or delete the Client")})
+    @RequestMapping(value = "/",
+            method = RequestMethod.DELETE)
+    ResponseEntity<Void> unregister(
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = false)
+            String authorization,
+            Principal principal
+
+    ) throws  OAuth2BearerTokenUsageMissingAuthInfoException, OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException;
+
+    @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
+    @ApiOperation(
+            value = "Delete a client by way of Client ID", nickname = "registerClientIdDelete", notes = "",
+            authorizations = {@Authorization(value = "TPPOAuth2Security", scopes = {})},
+            tags = {"Client Registration", "Optional",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Client deleted"),
+            @ApiResponse(code = 401, message = "Request failed due to unknown or invalid Client or invalid access token"),
+            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client"),
+            @ApiResponse(code = 405, message = "The client does not have permission to read, update or delete the Client")})
     @RequestMapping(value = "/{ClientId}",
             method = RequestMethod.DELETE)
     ResponseEntity<Void> unregister(
-            @ApiParam(value = "The client ID",required=true)
-            @PathVariable("ClientId") String clientId,
-
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=false) String authorization,
-
+            @ApiParam(value = "The client ID", required = true)
+            @PathVariable("ClientId")
+            String clientId,
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = false)
+            String authorization,
             Principal principal
 
-    ) throws OBErrorResponseException;
+    ) throws  OAuth2BearerTokenUsageMissingAuthInfoException, OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException;
 
 
     @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
@@ -71,24 +104,24 @@ public interface DynamicRegistrationApi {
             @Authorization(value = "TPPOAuth2Security", scopes = {
 
             })
-    }, tags={ "Client Registration","Optional", })
+    }, tags = {"Client Registration", "Optional",})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Client registration", response = OIDCRegistrationResponse.class),
             @ApiResponse(code = 401, message = "Request failed due to unknown or invalid Client or invalid access token"),
-            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client") })
+            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client")})
     @RequestMapping(value = "/{ClientId}",
-            produces = { "application/json" },
+            produces = {"application/json"},
             method = RequestMethod.GET)
     ResponseEntity<OIDCRegistrationResponse> getRegisterResult(
-            @ApiParam(value = "The client ID",required=true)
+            @ApiParam(value = "The client ID", required = true)
             @PathVariable("ClientId") String clientId,
 
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=true) String authorization,
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
 
             Principal principal
 
-    ) throws OBErrorResponseException;
+    ) throws OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException, OAuth2BearerTokenUsageMissingAuthInfoException;
 
 
     @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
@@ -96,49 +129,30 @@ public interface DynamicRegistrationApi {
             @Authorization(value = "TPPOAuth2Security", scopes = {
 
             })
-    }, tags={ "Client Registration","Optional", })
+    }, tags = {"Client Registration", "Optional",})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Client registration", response = OIDCRegistrationResponse.class),
             @ApiResponse(code = 400, message = "Request failed due to client error", response = Void.class),
             @ApiResponse(code = 401, message = "Request failed due to unknown or invalid Client or invalid access token"),
-            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client") })
+            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client")})
     @RequestMapping(value = "/{ClientId}",
-            produces = { "application/json" },
-            consumes = { "application/jwt" },
+            produces = {"application/json"},
+            consumes = {"application/jwt"},
             method = RequestMethod.PUT)
     ResponseEntity<OIDCRegistrationResponse> updateClient(
-            @ApiParam(value = "The client ID",required=true)
+            @ApiParam(value = "The client ID", required = true)
             @PathVariable("ClientId") String clientId,
 
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=true) String authorization,
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
 
-            @ApiParam(value = "A request to register a Software Statement Assertion with an ASPSP"  )
+            @ApiParam(value = "A request to register a Software Statement Assertion with an ASPSP")
             @Valid
             @RequestBody String registrationRequestJwtSerialised,
 
             Principal principal
-    ) throws OBErrorResponseException, OBErrorException, OIDCException;
+    ) throws OBErrorException, OIDCException, OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException, OAuth2BearerTokenUsageMissingAuthInfoException;
 
-    @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
-    @ApiOperation(value = "Delete a client by way of Client ID", nickname = "registerClientIdDelete", notes = "", authorizations = {
-            @Authorization(value = "TPPOAuth2Security", scopes = {
-            })
-    }, tags={ "Client Registration","Optional", })
-    @ApiResponses(value = {
-            @ApiResponse(code = 204, message = "Client deleted"),
-            @ApiResponse(code = 401, message = "Request failed due to unknown or invalid Client or invalid access token"),
-            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client"),
-            @ApiResponse(code = 405, message = "The client does not have permission to read, update or delete the Client") })
-    @RequestMapping(value = "/",
-            method = RequestMethod.DELETE)
-    ResponseEntity<Void> unregister(
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=false) String authorization,
-
-            Principal principal
-
-    ) throws OBErrorResponseException;
 
 
     @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
@@ -146,21 +160,21 @@ public interface DynamicRegistrationApi {
             @Authorization(value = "TPPOAuth2Security", scopes = {
 
             })
-    }, tags={ "Client Registration","Optional", })
+    }, tags = {"Client Registration", "Optional",})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Client registration", response = OIDCRegistrationResponse.class),
             @ApiResponse(code = 401, message = "Request failed due to unknown or invalid Client or invalid access token"),
-            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client") })
+            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client")})
     @RequestMapping(value = "/",
-            produces = { "application/json" },
+            produces = {"application/json"},
             method = RequestMethod.GET)
     ResponseEntity<OIDCRegistrationResponse> getRegisterResult(
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=true) String authorization,
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
 
             Principal principal
 
-    ) throws OBErrorResponseException;
+    ) throws OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException, OAuth2BearerTokenUsageMissingAuthInfoException;
 
 
     @PreAuthorize("hasAnyAuthority('ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
@@ -168,43 +182,43 @@ public interface DynamicRegistrationApi {
             @Authorization(value = "TPPOAuth2Security", scopes = {
 
             })
-    }, tags={ "Client Registration","Optional", })
+    }, tags = {"Client Registration", "Optional",})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Client registration", response = OIDCRegistrationResponse.class),
             @ApiResponse(code = 400, message = "Request failed due to client error", response = Void.class),
             @ApiResponse(code = 401, message = "Request failed due to unknown or invalid Client or invalid access token"),
-            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client") })
+            @ApiResponse(code = 403, message = "The client does not have permission to read, update or delete the Client")})
     @RequestMapping(value = "/",
-            produces = { "application/json" },
-            consumes = { "application/jwt" },
+            produces = {"application/json"},
+            consumes = {"application/jwt"},
             method = RequestMethod.PUT)
     ResponseEntity<OIDCRegistrationResponse> updateClient(
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=true) String authorization,
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
 
-            @ApiParam(value = "A request to register a Software Statement Assertion with an ASPSP"  )
+            @ApiParam(value = "A request to register a Software Statement Assertion with an ASPSP")
             @Valid
             @RequestBody String registrationRequestJwtSerialised,
 
             Principal principal
-    ) throws OBErrorResponseException, OBErrorException, OIDCException;
+    ) throws OBErrorException, OIDCException, OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException, OAuth2BearerTokenUsageMissingAuthInfoException;
 
 
     @PreAuthorize("hasAnyAuthority('UNREGISTERED_TPP', 'ROLE_PISP', 'ROLE_AISP', 'ROLE_CBPII', 'ROLE_EIDAS')")
     @ApiOperation(value = "Register a client by way of a Software Statement Assertion", nickname = "registerPost",
-            notes = "Endpoint will be secured by way of Mutual Authentication over TLS", tags={ "Client Registration","Conditional", })
+            notes = "Endpoint will be secured by way of Mutual Authentication over TLS", tags = {"Client Registration", "Conditional",})
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "Client registration", response = OIDCRegistrationResponse.class),
-            @ApiResponse(code = 400, message = "Request failed due to client error", response = Void.class) })
+            @ApiResponse(code = 400, message = "Request failed due to client error", response = Void.class)})
     @RequestMapping(value = "/",
-            produces = { "application/json" },
-            consumes = { "application/jwt" },
+            produces = {"application/json"},
+            consumes = {"application/jwt"},
             method = RequestMethod.POST)
     ResponseEntity<OIDCRegistrationResponse> register(
-            @ApiParam(value = "A request to register a Software Statement Assertion with an ASPSP"  )
+            @ApiParam(value = "A request to register a Software Statement Assertion with an ASPSP")
             @Valid
             @RequestBody String registrationRequestJwtSerialised,
 
             Principal principal
-    ) throws OBErrorResponseException, OIDCException;
+    ) throws  OIDCException, OBErrorResponseException;
 }

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApiController.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApiController.java
@@ -21,15 +21,11 @@
 package com.forgerock.openbanking.aspsp.as.api.registration.dynamic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.forgerock.cert.Psd2CertInfo;
-import com.forgerock.cert.eidas.EidasCertType;
-import com.forgerock.cert.exception.InvalidEidasCertType;
-import com.forgerock.cert.exception.InvalidPsd2EidasCertificate;
-import com.forgerock.cert.exception.NoSuchRDNInField;
-import com.forgerock.cert.utils.CertificateUtils;
 import com.forgerock.openbanking.aspsp.as.service.OIDCException;
-import com.forgerock.openbanking.aspsp.as.service.SSAService;
 import com.forgerock.openbanking.aspsp.as.service.TppRegistrationService;
+import com.forgerock.openbanking.common.error.exception.oauth2.OAuth2BearerTokenUsageInvalidTokenException;
+import com.forgerock.openbanking.common.error.exception.oauth2.OAuth2BearerTokenUsageMissingAuthInfoException;
+import com.forgerock.openbanking.common.error.exception.oauth2.OAuth2InvalidClientException;
 import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
 import com.forgerock.openbanking.common.utils.extractor.TokenExtractor;
 import com.forgerock.openbanking.exceptions.OBErrorException;
@@ -41,37 +37,34 @@ import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
 import com.forgerock.openbanking.model.error.OBRIErrorType;
 import com.forgerock.openbanking.model.oidc.OIDCRegistrationRequest;
 import com.forgerock.openbanking.model.oidc.OIDCRegistrationResponse;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
+import com.forgerock.spring.security.multiauth.model.authentication.X509Authentication;
 import com.nimbusds.jose.shaded.json.JSONObject;
-import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jose.util.JSONObjectUtils;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import com.forgerock.spring.security.multiauth.model.authentication.X509Authentication;
 import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.client.HttpClientErrorException;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.security.Principal;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.text.ParseException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -79,6 +72,23 @@ import static com.forgerock.openbanking.common.utils.X509CertificateHelper.getCn
 import static com.forgerock.openbanking.constants.OpenBankingConstants.RegistrationTppRequestClaims;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.SSAClaims;
 
+/**
+ *
+ * Class to implement the Open Banking (OB) Dynamic Client Registration (DCR) specification. This spec in turn relies
+ * on many other standards; <p>
+ * <ul>
+ *     <li> <a href=https://openbankinguk.github.io/dcr-docs-pub/v3.3/dynamic-client-registration.html>
+ *         Open Banking Dynamic Client Registration Specifications</a></li>
+ *     <li><a href=https://datatracker.ietf.org/doc/html/rfc7591>
+ *         The OAuth2 Dynamic Client Registration standard</a></li>
+ *     <li><a href=https://www.rfc-editor.org/rfc/rfc6749>
+ *         The OAuth2 Authorization Framework</a></li>
+ *     <li><a href=https://datatracker.ietf.org/doc/html/rfc6750>
+ *         The OAuth2 Authorization Framework: Bearer Token Usage</a></li>
+ *     <li> <a href=https://www.ietf.org/rfc/rfc8705.html>
+ *         OAuth 2.0 Mutual TLS Authentication and Certificate bound access tokens</a></li>
+ * </ul>
+ */
 @Controller
 @Slf4j
 public class DynamicRegistrationApiController implements DynamicRegistrationApi {
@@ -89,7 +99,6 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
     private final TokenExtractor tokenExtractor;
     private final TppRegistrationService tppRegistrationService;
     private final List<String> supportedAuthMethod;
-    private final SSAService ssaService;
 
     @Autowired
     public DynamicRegistrationApiController(TppStoreService tppStoreService,
@@ -97,63 +106,103 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
                                             TokenExtractor tokenExtractor,
                                             TppRegistrationService tppRegistrationService,
                                             @Value("${dynamic-registration.supported-token-endpoint-auth-method}")
-                                            List<String> supportedAuthMethod,
-                                            SSAService ssaService){
+                                            List<String> supportedAuthMethod){
         this.tppStoreService = tppStoreService;
         this.objectMapper = objectMapper;
         this.tokenExtractor = tokenExtractor;
         this.tppRegistrationService = tppRegistrationService;
         this.supportedAuthMethod = supportedAuthMethod;
-        this.ssaService = ssaService;
     }
 
+    /**
+     * Implementation of the DELETE /register endpoint
+     *
+     * @param authorization the value of the authorization header - this must match the registration_access_token
+     *                      issued when the client registered. REQUIRED
+     * @param principal - the Principal of the certificate used in the TLS connection used to call the endpoint. This
+     *                 is used to identify the client that is making the request
+     * @return
+     * @throws OAuth2BearerTokenUsageMissingAuthInfoException
+     * @throws OAuth2InvalidClientException
+     */
     @Override
-    public ResponseEntity<Void> unregister(
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=false) String authorization,
-
-            Principal principal) throws OBErrorResponseException {
+    public ResponseEntity<Void> unregister(String authorization,Principal principal)
+            throws OAuth2BearerTokenUsageMissingAuthInfoException, OAuth2InvalidClientException,
+            OAuth2BearerTokenUsageInvalidTokenException {
+        log.debug("unregister() called with no clientId");
         return unregister(null, authorization, principal);
     }
 
+    /**
+     * Implementation of the DELETE /register endpoint
+     *
+     * @param clientId      the client Id to be unregistered
+     * @param authorization the value of the authorization header - this must match the registration_access_token
+     *        issued when the client registered.
+     * @param principal     the Principal of the certificate used in the TLS connection used to call the endpoint. This
+     *        is used to identify the client that is making the request
+     * @return A
+     * @throws OAuth2BearerTokenUsageMissingAuthInfoException
+     * @throws OAuth2InvalidClientException
+     * @throws OAuth2BearerTokenUsageInvalidTokenException
+     */
     @Override
-    public ResponseEntity<Void> unregister(
-            @ApiParam(value = "The client ID",required=false)
-            @PathVariable("ClientId") String clientId,
-
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=false) String authorization,
-
-            Principal principal) throws OBErrorResponseException {
+    public ResponseEntity<Void> unregister(String clientId, String authorization, Principal principal)
+            throws OAuth2BearerTokenUsageMissingAuthInfoException, OAuth2InvalidClientException,
+            OAuth2BearerTokenUsageInvalidTokenException {
+        log.debug("unregister() called for clientId; '{}'", clientId);
+        checkAuthArgs(principal, authorization);
         Tpp tpp = getTpp(principal);
-        verifyClientIDMatchTPP(tpp, clientId);
-        String accessToken = verifyAccessToken(tpp, authorization);
+
+        verifyTppClientIDMatchesRequestClientId(tpp, clientId);
+        String accessToken = verifyRegistrationAccessToken(tpp, authorization);
 
         tppRegistrationService.unregisterTpp(accessToken, tpp);
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * Implementation of the GET /register endpoint
+     * @param authorization the value of the authorization header - this must match the registration_access_token
+     *        issued when the client registered.
+     * @param principal     the Principal of the certificate used in the TLS connection used to call the endpoint. This
+     *        is used to identify the client that is making the request
+     * @return
+     * @throws OAuth2InvalidClientException
+     * @throws OAuth2BearerTokenUsageInvalidTokenException
+     * @throws OAuth2BearerTokenUsageMissingAuthInfoException
+     */
     @Override
-    public ResponseEntity<OIDCRegistrationResponse> getRegisterResult(
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=true) String authorization,
+    public ResponseEntity<OIDCRegistrationResponse> getRegisterResult( String authorization, Principal principal)
+            throws OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException,
+            OAuth2BearerTokenUsageMissingAuthInfoException {
 
-            Principal principal) throws OBErrorResponseException {
         return getRegisterResult(null, authorization, principal);
     }
 
+    /**
+     * Implementation of the GET /register endpoint
+     * @param clientId      the id of the client registration resource to be returned.
+     * @param authorization the value of the authorization header - this must match the registration_access_token
+     *        issued when the client registered.
+     * @param principal     the Principal of the certificate used in the TLS connection used to call the endpoint. This
+     *        is used to identify the client that is making the request
+     * @return
+     * @throws OAuth2InvalidClientException
+     * @throws OAuth2BearerTokenUsageInvalidTokenException
+     * @throws OAuth2BearerTokenUsageMissingAuthInfoException
+     */
     @Override
-    public ResponseEntity<OIDCRegistrationResponse> getRegisterResult(
-            @ApiParam(value = "The client ID",required=false)
-            @PathVariable("ClientId") String clientId,
+    public ResponseEntity<OIDCRegistrationResponse> getRegisterResult( String clientId, String authorization,
+                                                                       Principal principal)
+            throws OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException,
+            OAuth2BearerTokenUsageMissingAuthInfoException {
 
-            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750" ,required=true)
-            @RequestHeader(value="Authorization", required=true) String authorization,
-
-            Principal principal) throws OBErrorResponseException {
+        log.debug("getRegisterResultCalled for clientId {}, principal is {}", clientId, principal);
+        checkAuthArgs(principal, authorization);
         Tpp tpp = getTpp(principal);
-        verifyClientIDMatchTPP(tpp, clientId);
-        String accessToken = verifyAccessToken(tpp, authorization);
+        verifyTppClientIDMatchesRequestClientId(tpp, clientId);
+        String accessToken = verifyRegistrationAccessToken(tpp, authorization);
 
         return ResponseEntity.ok(tppRegistrationService.getOIDCClient(accessToken, tpp));
     }
@@ -168,7 +217,7 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
             @RequestBody String registrationRequestJwtSerialised,
 
             Principal principal
-    ) throws OBErrorResponseException, OBErrorException, OIDCException {
+    ) throws OBErrorException, OIDCException, OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException, OAuth2BearerTokenUsageMissingAuthInfoException {
         return updateClient(null, authorization, registrationRequestJwtSerialised, principal);
     }
 
@@ -185,12 +234,13 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
             @RequestBody String registrationRequestJwtSerialised,
 
             Principal principal
-    ) throws OBErrorResponseException, OBErrorException, OIDCException {
+    ) throws OBErrorException, OIDCException, OAuth2InvalidClientException, OAuth2BearerTokenUsageInvalidTokenException,
+            OAuth2BearerTokenUsageMissingAuthInfoException {
         X509Authentication currentUser = (X509Authentication) principal;
 
         Tpp tpp = getTpp(principal);
-        verifyClientIDMatchTPP(tpp, clientId);
-        String accessToken = verifyAccessToken(tpp, authorization);
+        verifyTppClientIDMatchesRequestClientId(tpp, clientId);
+        String accessToken = verifyRegistrationAccessToken(tpp, authorization);
         try {
             SignedJWT registrationRequestJws = SignedJWT.parse(registrationRequestJwtSerialised);
             String ssaSerialised = registrationRequestJws.getJWTClaimsSet()
@@ -337,69 +387,64 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
         }
     }
 
+
     /**
-     * generateSSAForEIDAS This was a guess at to how OBIE were going to use eIDAS certs as part of the OB ecosystem.
+     * <p>Checks that the arguments provided to a method that requires a BEARER authorization token and a principal
+     * are both provided and valid.</p>
      *
-     * The assumption wasthat a QWac would somehow be associated with a specific software statement. However, this was
-     * unrealistic because QWacs are issued to an organisation.
+     * <b>BEARER Authorization Errors</b>
      *
-     * Open Banking Implementation Entity now issue OBWac certificates and these identify the Organisation and not
-     * the software statement. This means that when a TPP uses an OBWac or a full QWac certificate, they must have
-     * registered with the Open Banking (test) Directory and MUST provide and SSA as apart of the registration flow.
+     * <p>
+     * If the authorize token is missing then we should return a OAuth2MissingAuthInfoException error in accord with
+     * <a href=https://datatracker.ietf.org/doc/html/rfc6750#section-3.1>The OAuth 2.0 Authorization Framework: Bearer
+     * Token Usage</a>.
+     * </p>
      *
-     * So, this method is depricated and should no longer be used.
-     * @deprecated
-     * @param currentUser
-     * @param registrationRequestJws
-     * @param oidcRegistrationRequest
-     * @return
-     * @throws OBErrorException
-     * @throws NoSuchRDNInField
-     * @throws CertificateEncodingException
+     * <b>M-TLS Principal Errors</b>
+     * <p>The principal is pulled out of the certificate and is used for M-TLS purposes - i.e. to identify the TPP. Here
+     * <a href=https://www.rfc-editor.org/rfc/rfc8705.html>RFC 8705
+     * OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens</a></p>
+     *
+     * <p>This says "If no certificate is presented, or that which is presented doesn't match that which is expected for
+     * the given client_id, the authorization server returns a normal OAuth 2.0 error response per <
+     * a href=https://www.rfc-editor.org/rfc/rfc6749#section-5.2>Section 5.2 of [RFC6749]</a> with the invalid_client
+     * error code to indicate failed client authentication."</p>
+     *
+     * @param principal - The Principal that is used for MATLS authentication to identify the TPP organisation
+     * @param authorization - the Authorization header from the request.
+     * @throws OAuth2BearerTokenUsageMissingAuthInfoException
      */
-    private String generateSSAForEIDAS(X509Authentication currentUser, SignedJWT registrationRequestJws, OIDCRegistrationRequest oidcRegistrationRequest) throws OBErrorException, NoSuchRDNInField, CertificateEncodingException {
-        try {
-            JWK jwk;
-
-            if (registrationRequestJws.getHeader().getJWK() != null) {
-                jwk = registrationRequestJws.getHeader().getJWK();
-            } else if (registrationRequestJws.getHeader().getX509CertChain() != null && !registrationRequestJws.getHeader().getX509CertChain().isEmpty()) {
-                List<X509Certificate> x509Certificates = new ArrayList<>();
-                for (Base64 c : registrationRequestJws.getHeader().getX509CertChain()) {
-                    X509Certificate x509Certificate = CertificateUtils.decodeCertificate(c.decode());
-                    x509Certificates.add(x509Certificate);
-                }
-
-                Psd2CertInfo signingCertPSD2Info = new Psd2CertInfo(x509Certificates);
-                if (!signingCertPSD2Info.isPsd2Cert()) {
-                    log.debug("Certificate received is not detected as a PSD2 certificates");
-                    throw new OBErrorException(OBRIErrorType.OBRI_REGISTRATION_NOT_PSD2);
-                }
-                if (signingCertPSD2Info.getEidasCertType().isPresent()) {
-                    log.debug("Certificate is not detected as a known EIDAS certificate");
-                    throw new OBErrorException(OBRIErrorType.OBRI_REGISTRATION_NOT_KNOWN_EIDAS);
-                }
-                if (signingCertPSD2Info.getEidasCertType().get() != EidasCertType.ESEAL) {
-                    log.debug("Certificate received is not a QSEAL, it's: {}", signingCertPSD2Info.getEidasCertType().get());
-                    throw new OBErrorException(OBRIErrorType.OBRI_REGISTRATION_NOT_QSEAL, signingCertPSD2Info.getEidasCertType().get().name());
-                }
-                jwk = JWK.parse(x509Certificates.get(0));
-
-            } else {
-                log.error("Failed to obtain the signing key from the registration request");
-                throw new OBErrorException(OBRIErrorType.OBRI_REGISTRATION_NO_SIGNING_KEYS);
-            }
-            String ssa = ssaService.generateSSAForEIDAS(currentUser, jwk, oidcRegistrationRequest.getRedirectUris());
-            oidcRegistrationRequest.setJwks(new JWKSet(jwk));
-            return ssa;
-        } catch (CertificateException | InvalidPsd2EidasCertificate | InvalidEidasCertType e) {
-            log.debug("Couldn't read PSD2 certificate", e);
-            throw new OBErrorException(OBRIErrorType.OBRI_REGISTRATION_EIDAS_CERTIFICATE_READ_ISSUE);
-        } catch (JOSEException e) {
-            log.error("Couldn't covert the PSD2 certs into a JWK", e);
-            throw new OBErrorException(OBRIErrorType.OBRI_REGISTRATION_EIDAS_CONVERT_TO_JWK);
+    private void checkAuthArgs(Principal principal, String authorization)
+            throws OAuth2BearerTokenUsageMissingAuthInfoException, OAuth2InvalidClientException {
+        if(getPrincipalName(principal).equalsIgnoreCase("anonymous")){
+            throw new OAuth2InvalidClientException("Mutual TLS failed - no principal found from request. This " +
+                    "endpoint must be called using SSL using an OBWac certificate which will be used by the ASPSP for" +
+                    " Mutual Authentication TLS");
+        }
+        if(StringUtils.isEmpty(authorization)){
+            throw new OAuth2BearerTokenUsageMissingAuthInfoException("No valid Bearer authorization header. " +
+                    "This should be set to the registration_access_token found in the response when you successfully " +
+                    "used the /register endpoint to perform dynamic client registration.");
         }
     }
+
+    /**
+     * Safe way to get the name from the principal. If the principal is null or empty, or the name of the principal
+     * is null or empty this method will return "Anonymous" instead.
+     * @param principal - the Principal from which to safely get the name
+     * @return A valid string. If no principal could be obtained this will be "Anonymous"
+     */
+    private String getPrincipalName(@Nullable Principal principal){
+        if(!StringUtils.isEmpty(principal)){
+            String principalName = principal.getName();
+            if(!StringUtils.isEmpty(principalName)){
+                return principalName;
+            }
+        }
+        return "Anonymous";
+    }
+
+
 
     private void verifyRegistrationRequest(
             boolean isEidasCert,
@@ -426,16 +471,35 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
         log.trace("{}:verifyRegistrationRequest() registration request is valid", this.getClass().getSimpleName());
     }
 
-    private void verifyClientIDMatchTPP(Tpp tpp, String oidcClient) throws OBErrorResponseException {
-        if (oidcClient != null && !tpp.getClientId().equals(oidcClient)) {
-            throw new OBErrorResponseException(
-                    OBRIErrorType.TPP_REGISTRATION_INVALID_OIDC_CLIENT.getHttpStatus(),
-                    OBRIErrorResponseCategory.TPP_REGISTRATION,
-                    OBRIErrorType.TPP_REGISTRATION_INVALID_OIDC_CLIENT.toOBError1(oidcClient, tpp.getClientId()));
+    /**
+     * verifyTppClientIDMatchesRequestClientId() tests to see if the tpp's clientId matches a specific client Id.
+     * The tpp is identified from the Principal of the request, which is derived from a certificate (MATLS). This
+     * method can test if the clientID for which the registration request is being made (taken from the request URL
+     * path for example) is the same clientId issued when the Tpp onboarded.
+     * @param tpp - The tpp that made the request as identified by MATLS, cookie etc.
+     * @param oidcClientIdFromRequest the OIDC clientId specified in the request (e.g. as a URI path element)
+     * @throws OBErrorResponseException - if the oidcClientIDFromRequest does not match the client Id registered when
+     * the TPP onboarded.
+     */
+    private void verifyTppClientIDMatchesRequestClientId(Tpp tpp, String oidcClientIdFromRequest)
+            throws OAuth2InvalidClientException {
+        log.debug("verifyTppClientIDMatchesRequestClientId() tpp is '{}', oidcClientIdFromRequest is '{}'",
+                tpp==null?"tpp is null!":tpp.toString(),oidcClientIdFromRequest);
+
+
+        if (oidcClientIdFromRequest == null || tpp == null || !tpp.getClientId().equals(oidcClientIdFromRequest)) {
+            log.info("verifyTppClientIDMatchesRequestClientId() the tpp's clientId '{}' does not match the "
+                            + "oidcClientIdFromRequest '{}'", tpp == null?"tpp is null":tpp.getClientId(),
+                            oidcClientIdFromRequest);
+            throw new OAuth2InvalidClientException("ClientId specified in the request url was {}. The ClientId " +
+                    "of the Tpp associated with your MATLS certificate used in this call was {}. Please use a " +
+                    "certificate associated with the Tpp that performed the registration.");
         }
+        log.debug("verifyTppClientIDMatchesRequestClientId() - clientIds match");
     }
 
-    private void verifyAuthenticationMethodSupported(OIDCRegistrationRequest oidcRegistrationRequest) throws OBErrorException {
+    private void verifyAuthenticationMethodSupported(OIDCRegistrationRequest oidcRegistrationRequest)
+            throws OBErrorException {
         if (!supportedAuthMethod.contains(oidcRegistrationRequest.getTokenEndpointAuthMethod())) {
             throw new OBErrorException(OBRIErrorType.TPP_REGISTRATION_INVALID_AUTH_METHOD,
                     oidcRegistrationRequest.getTokenEndpointAuthMethod()
@@ -443,25 +507,86 @@ public class DynamicRegistrationApiController implements DynamicRegistrationApi 
         }
     }
 
-    private Tpp getTpp( Principal principal) throws OBErrorResponseException {
+    /**
+     * getTpp returns the tpp associated with the principal. If not tpp can be found will throw.
+     * @param principal the principal as obtained from the client MATLS certificate used to make the request
+     * @return a Tpp object belonging to the principal. If no tpp can be found then will throw
+     * OAuth2InvalidClientException
+     * @throws OAuth2InvalidClientException
+     */
+    private Tpp getTpp( Principal principal) throws OAuth2InvalidClientException {
+        //Todo: this next line looks odd. findByClientId but passing the principal.getName which I would think would
+        // return the name pulled from the MATLS certificate?
         Optional<Tpp> optionalTpp = tppStoreService.findByClientId(principal.getName());
         if (!optionalTpp.isPresent()) {
-            throw new OBErrorResponseException(
-                    OBRIErrorType.TPP_REGISTRATION_NOT_REGISTERED.getHttpStatus(),
-                    OBRIErrorResponseCategory.TPP_REGISTRATION,
-                    OBRIErrorType.TPP_REGISTRATION_NOT_REGISTERED.toOBError1(principal.getName()));
+            log.info("getTpp() no tpp found for principal '{}'", principal==null?"Principal is null":
+                    principal.getName());
+            throw new OAuth2InvalidClientException("No tpp associated with the MATLS certificate used in the request." +
+                    " The certificate is associated with OrganisationId " + principal.getName() +". This Tpp is not " +
+                    "currently onboarded");
         }
         return optionalTpp.get();
     }
 
-    private String verifyAccessToken(Tpp tpp, String authorization) throws OBErrorResponseException {
-        String accessToken = tokenExtractor.extract(authorization);
-        if (!tpp.getRegistrationResponse().getRegistrationAccessToken().equals(tokenExtractor.extract(authorization))) {
-            throw new OBErrorResponseException(
-                    OBRIErrorType.TPP_REGISTRATION_INVALID_ACCESS_TOKEN.getHttpStatus(),
-                    OBRIErrorResponseCategory.TPP_REGISTRATION,
-                    OBRIErrorType.TPP_REGISTRATION_INVALID_ACCESS_TOKEN.toOBError1());
+    /**
+     * The registration_access_token was provided to the client in response to a successful registration request.
+     * @param tpp - the tpp associated with the MATLS client certificate used to make the request.
+     * @param authorization - the Authorization header value from the request
+     * @return the access token if valid
+     * @throws OBErrorResponseException
+     */
+    private String verifyRegistrationAccessToken(@NotNull Tpp tpp, String authorization)
+            throws OAuth2BearerTokenUsageMissingAuthInfoException,OAuth2BearerTokenUsageInvalidTokenException {
+        log.debug("verifyRegistrationAccessToken() tpp is '{}', authorization is '{}'", tpp==null?"null":tpp.toString(),
+                authorization);
+        // Told you tpp must not be null!
+        Objects.requireNonNull(tpp);
+
+        String accessToken = getAccessToken(authorization);
+        validateBearerTokenBelongsToTpp(accessToken, tpp);
+
+        log.debug("verifyRegistrationAccessToken() Tpp '{}' has valid accessToken.", tpp.getClientId());
+        return accessToken;
+    }
+
+
+    private String getAccessToken(String authorization) throws OAuth2BearerTokenUsageMissingAuthInfoException,
+            OAuth2BearerTokenUsageInvalidTokenException {
+        String accessToken = null;
+        if(StringUtils.isEmpty(authorization)){
+            throw new OAuth2BearerTokenUsageMissingAuthInfoException("AuthorizationHeader is empty. It should " +
+                    "contain a Bearer OAuth2 token. See rfc-6750");
+        } else {
+            try {
+                accessToken = tokenExtractor.extract(authorization);
+            } catch (AuthenticationServiceException re) {
+                String errorMessage = String.format("Failed to extract Bearer token from authorization header: " +
+                                "'%s'. Error was %s. Authorization header should contain an OAuth2 Bearer token. " +
+                                "See rfc-6750", authorization, re.getMessage());
+                log.debug("verifyRegistrationAccessToken() {}}", errorMessage);
+                throw new OAuth2BearerTokenUsageInvalidTokenException(errorMessage);
+            }
         }
         return accessToken;
+    }
+
+    private void validateBearerTokenBelongsToTpp(String accessToken, @NotNull Tpp tpp)
+            throws OAuth2BearerTokenUsageInvalidTokenException {
+        // Told you tpp must not be null!
+        Objects.requireNonNull(tpp);
+
+        boolean accessTokenBelongsToTpp = false;
+        Optional<String> registrationAccessToken = tpp.getRegistrationAccessToken();
+        if(registrationAccessToken.isPresent()) {
+            accessTokenBelongsToTpp = registrationAccessToken.get().equals(accessToken);
+        }
+        if(!accessTokenBelongsToTpp){
+            String errorMessage = "Authorization Bearer token is not the bearer token issued to the TPP " +
+                    "identified by the MATLS client certificate used to make this request. Please use the " +
+                    "registration_access_token that was provided in your successful request to the POST /register" +
+                    " endpoint. i.e. When you succesfully performed dynamic client registration.";
+            log.debug("verifyRegistrationAccessToken() {}", errorMessage);
+            throw new OAuth2BearerTokenUsageInvalidTokenException(errorMessage);
+        }
     }
 }

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/as/api/registration/dynamic/DynamicRegistrationApiControllerTest.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.as.api.registration.dynamic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.openbanking.aspsp.as.service.SSAService;
+import com.forgerock.openbanking.aspsp.as.service.TppRegistrationService;
+import com.forgerock.openbanking.common.error.exception.oauth2.*;
+import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
+import com.forgerock.openbanking.common.utils.extractor.TokenExtractor;
+import com.forgerock.openbanking.exceptions.OBErrorResponseException;
+import com.forgerock.openbanking.model.Tpp;
+import com.forgerock.openbanking.model.oidc.OIDCRegistrationResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationServiceException;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class DynamicRegistrationApiControllerTest {
+
+    @Mock
+    TppStoreService tppStoreService;
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @Mock
+    TokenExtractor tokenExtractor;
+
+    @Mock
+    TppRegistrationService tppRegistrationService;
+
+    List<String> supportedAuthMethod;
+
+    @Mock
+    SSAService ssaService;
+
+    private DynamicRegistrationApiController dynamicRegistrationApiController;
+    private final String clientId = "clientId";
+    private final String authorizationString = "Bearer tpps-registration-access-token";
+    private final String tppName = "tppName";
+    private final String principalName = "principalName";
+
+
+    @Before
+    public void setUp(){
+        dynamicRegistrationApiController = new DynamicRegistrationApiController(tppStoreService, objectMapper,
+                tokenExtractor, tppRegistrationService, supportedAuthMethod);
+    }
+
+    @Test
+    public void throwsOAuth2MissingAuthInfoExceptionWhenNoAuthenticationHeaderToken_unregister(){
+        // given
+        Principal principal = mock(Principal.class);
+        given(principal.getName()).willReturn(this.principalName);
+
+
+        // when
+        OAuth2BearerTokenUsageMissingAuthInfoException exception = catchThrowableOfType(()->
+                dynamicRegistrationApiController.unregister(clientId, null,
+                        principal), OAuth2BearerTokenUsageMissingAuthInfoException.class);
+        // then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getHttpStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(exception.getWwwAuthenticateResponseHeaderValue()).isEqualTo(
+                OAuth2Constants.OAUTH2_WWW_AUTHENTICATE_HEADER_VALUE_BEARER);
+    }
+
+    @Test
+    public void throwsOAuth2InvalidClientIdWhenPrincipalIsNull_unregister() {
+        // given
+        Principal principal = mock(Principal.class);
+
+        // when
+        OAuth2InvalidClientException exception = catchThrowableOfType(()->
+                dynamicRegistrationApiController.unregister(clientId, authorizationString,
+                null), OAuth2InvalidClientException.class);
+        // then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getHttpStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(exception.getRfc6750ErrorCode()).isEqualTo("invalid_client");
+    }
+
+    @Test
+    public void throwsOAuth2InvalidClientExceptionWhenClientIdIsNull_unregister() throws OBErrorResponseException {
+        // given
+        DynamicRegistrationApiController dynamicRegistrationApiController =
+                new DynamicRegistrationApiController(tppStoreService, objectMapper, tokenExtractor,
+                        tppRegistrationService, supportedAuthMethod);
+        String clientId = null;
+        Principal principal = mock(Principal.class);
+        given(principal.getName()).willReturn(tppName);
+        given(tppStoreService.findByClientId(tppName)).willReturn(Optional.of(this.getValidTpp()));
+
+        // when
+        OAuth2InvalidClientException exception = catchThrowableOfType(()->
+                dynamicRegistrationApiController.unregister(clientId, this.authorizationString,
+                        principal), OAuth2InvalidClientException.class);
+        // then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getHttpStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(exception.getRfc6750ErrorCode()).isEqualTo(OAuth2Exception.INVALID_CLIENT);
+    }
+
+    @Test
+    public void throwsOAuth2ClientExceptionWhenTppNotRegistered_unregister(){
+        // given
+        DynamicRegistrationApiController dynamicRegistrationApiController =
+                new DynamicRegistrationApiController(tppStoreService, objectMapper, tokenExtractor,
+                        tppRegistrationService, supportedAuthMethod);
+        String clientId = this.clientId;
+        Principal principal = mock(Principal.class);
+        given(principal.getName()).willReturn(tppName);
+        given(tppStoreService.findByClientId(tppName)).willReturn(Optional.empty());
+
+        // when
+        OAuth2InvalidClientException exception = catchThrowableOfType(()->
+                dynamicRegistrationApiController.unregister(clientId, this.authorizationString, principal),
+                OAuth2InvalidClientException.class);
+        // then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getHttpStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(exception.getRfc6750ErrorCode()).isEqualTo(OAuth2Exception.INVALID_CLIENT);
+    }
+
+    @Test
+    public void throwsOAuth2BearerTokenUsageInvalidTokenExceptionWhenInvalidAuthorizationString_unregister() {
+        // given
+        DynamicRegistrationApiController dynamicRegistrationApiController =
+                new DynamicRegistrationApiController(tppStoreService, objectMapper, tokenExtractor,
+                        tppRegistrationService, supportedAuthMethod);
+        String clientId = this.clientId;
+        Principal principal = mock(Principal.class);
+        given(principal.getName()).willReturn(tppName);
+        given(tppStoreService.findByClientId(tppName)).willReturn(Optional.of(this.getValidTpp()));
+        given(tokenExtractor.extract(this.authorizationString)).willThrow(new AuthenticationServiceException("test"));
+
+        // when
+        OAuth2BearerTokenUsageInvalidTokenException exception = catchThrowableOfType(()->
+                        dynamicRegistrationApiController.unregister(clientId, this.authorizationString, principal),
+                OAuth2BearerTokenUsageInvalidTokenException.class);
+        // then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getHttpStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(exception.getWwwAuthenticateResponseHeaderValue()).isNull();
+        assertThat(exception.getErrorCode()).isEqualTo(OAuth2BearerTokenUsageException.ErrorEnum.INVALID_TOKEN);
+    }
+
+    /**
+     * This tests the scenario when the tpp, as identified by MATLS, is requesting that a client id different from
+     * the one associated with the TPP associated with the client_id they are requesting to delete. i.e. when a tpp
+     * is requesting the deletion of a client registration they didn't make.
+     */
+    @Test
+    public void throwsOAuth2BearerTokenUsageInvalidTokenExceptionWhenNotOwner_unregister() {
+        // given
+        DynamicRegistrationApiController dynamicRegistrationApiController =
+                new DynamicRegistrationApiController(tppStoreService, objectMapper, tokenExtractor,
+                        tppRegistrationService, supportedAuthMethod);
+        String clientId = this.clientId;
+        Principal principal = mock(Principal.class);
+        given(principal.getName()).willReturn(tppName);
+        given(tppStoreService.findByClientId(tppName)).willReturn(Optional.of(this.getValidTpp()));
+        String accessToken = "not-the-tpps-registration-access-token";
+        given(tokenExtractor.extract(this.authorizationString)).willReturn(accessToken);
+
+        // when
+        OAuth2BearerTokenUsageInvalidTokenException exception = catchThrowableOfType(()->
+                        dynamicRegistrationApiController.unregister(clientId, this.authorizationString, principal),
+                OAuth2BearerTokenUsageInvalidTokenException.class);
+        // then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getHttpStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(exception.getWwwAuthenticateResponseHeaderValue()).isNull();
+        assertThat(exception.getErrorCode()).isEqualTo(OAuth2BearerTokenUsageException.ErrorEnum.INVALID_TOKEN);
+    }
+
+    /**
+     * This tests the scenario when the tpp, as identified by MATLS, is requesting that a client id different from
+     * the one associated with the TPP associated with the client_id they are requesting to delete. i.e. when a tpp
+     * is requesting the deletion of a client registration they didn't make.
+     */
+    @Test
+    public void successful_unregister() throws OAuth2BearerTokenUsageMissingAuthInfoException,
+            OAuth2BearerTokenUsageInvalidTokenException, OAuth2InvalidClientException {
+        // given
+        DynamicRegistrationApiController dynamicRegistrationApiController =
+                new DynamicRegistrationApiController(tppStoreService, objectMapper, tokenExtractor,
+                        tppRegistrationService, supportedAuthMethod);
+        String clientId = this.clientId;
+        Principal principal = mock(Principal.class);
+        given(principal.getName()).willReturn(tppName);
+        given(tppStoreService.findByClientId(tppName)).willReturn(Optional.of(this.getValidTpp()));
+        String accessToken = "tpps-registration-access-token";
+        given(tokenExtractor.extract(this.authorizationString)).willReturn(accessToken);
+
+        // when
+
+        ResponseEntity<?> unregisterResponse = dynamicRegistrationApiController.unregister(clientId,
+                this.authorizationString, principal);
+        // then
+        assertThat(unregisterResponse).isNotNull();
+        assertThat(unregisterResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void getRegisterResult() {
+    }
+
+    @Test
+    public void testGetRegisterResult() {
+    }
+
+    @Test
+    public void updateClient() {
+    }
+
+    @Test
+    public void testUpdateClient() {
+    }
+
+    @Test
+    public void register() {
+    }
+
+    private Tpp getValidTpp(){
+        OIDCRegistrationResponse registrationResponse = new OIDCRegistrationResponse();
+        registrationResponse.setRegistrationAccessToken("tpps-registration-access-token");
+        Tpp tpp =  new Tpp();
+        tpp.setRegistrationResponse(registrationResponse);
+        tpp.setClientId(this.clientId);
+        tpp.setName(this.tppName);
+        return tpp;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageErrorResponseBody.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageErrorResponseBody.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+/**
+ * Used to provide a response body that can carry the information found in an OAuth2BearerTokenUsageException @see
+ * com.forgerock.openbanking.common.error.exception.oauth2.OAuth2BearerTokenUsageException
+ */
+public class OAuth2BearerTokenUsageErrorResponseBody extends OAuth2ErrorAdviceResponseBody {
+
+    String error_code;
+
+    public OAuth2BearerTokenUsageErrorResponseBody(String errorCode, String testFacilityAdviceMessage){
+        super(testFacilityAdviceMessage);
+        this.error_code = errorCode;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageException.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageException.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Allows exceptions to be thrown that will result in error responses as defined in
+ * <a href=https://datatracker.ietf.org/doc/html/rfc6750#section-3.1>
+ *     The OAuth 2.0 Authorization Framework: Bearer Token Usage</a>
+ */
+public class OAuth2BearerTokenUsageException extends Exception{
+
+    public enum ErrorEnum {
+        INVALID_REQUEST("invalid_request"),
+
+        INVALID_TOKEN("invalid_token"),
+
+        INSUFFICIENT_SCOPE("insufficient_scope"),
+
+        MISSING_AUTH_INFO("missing_auth_information");
+
+        private final String value;
+
+        ErrorEnum(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static OAuth2BearerTokenUsageException.ErrorEnum fromValue(String text) {
+            for (OAuth2BearerTokenUsageException.ErrorEnum b : OAuth2BearerTokenUsageException.ErrorEnum.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+    }
+
+    private final HttpStatus httpStatusCode = HttpStatus.UNAUTHORIZED;
+
+    private final String wwwAuthenticateResponseHeaderValue;
+
+    private ErrorEnum errorCode;
+
+    public OAuth2BearerTokenUsageException(String message, String wwwAuthenticateResponseHeaderValue,
+                                           ErrorEnum errorCode){
+        super(message);
+        this.wwwAuthenticateResponseHeaderValue = wwwAuthenticateResponseHeaderValue;
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getHttpStatusCode() {
+        return this.httpStatusCode;
+    }
+
+    public String getWwwAuthenticateResponseHeaderValue() {
+        return this.wwwAuthenticateResponseHeaderValue;
+    }
+
+    public ErrorEnum getErrorCode() { return errorCode; }
+
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageInvalidTokenException.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageInvalidTokenException.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+public class OAuth2BearerTokenUsageInvalidTokenException extends OAuth2BearerTokenUsageException {
+    public OAuth2BearerTokenUsageInvalidTokenException(String message){
+        super(message, null, ErrorEnum.INVALID_TOKEN);
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageMissingAuthInfoException.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2BearerTokenUsageMissingAuthInfoException.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+/**
+ * <p></p>Allows exceptions to be thrown that will result in error responses as defined in
+ * <a href=https://datatracker.ietf.org/doc/html/rfc6750#section-3.1>
+ *     The OAuth 2.0 Authorization Framework: Bearer Token Usage</a></p><br>
+ *
+ * <p>This specific exception covers the error case described thus;</p>
+ * <p>If the request lacks any authentication information (e.g., the client
+ *    was unaware that authentication is necessary or attempted using an
+ *    unsupported authentication method), the resource server SHOULD NOT
+ *    include an error code or other error information.</p><br>
+ *    <br>
+ *    For example:<br>
+ *    <code>
+ *
+ *      HTTP/1.1 401 Unauthorized<br>
+ *      WWW-Authenticate: Bearer realm="example"
+ *      </code>
+ * </p>
+ */
+public class OAuth2BearerTokenUsageMissingAuthInfoException extends OAuth2BearerTokenUsageException {
+    public OAuth2BearerTokenUsageMissingAuthInfoException(String message){
+        super(message, OAuth2Constants.OAUTH2_WWW_AUTHENTICATE_HEADER_VALUE_BEARER,
+                ErrorEnum.MISSING_AUTH_INFO);
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2Constants.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2Constants.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+/**
+ * Constants related to OAuth2 requests and responses
+ */
+public class OAuth2Constants {
+
+    static public String OAUTH2_WWW_AUTHENTICATE_HEADER_NAME = "WWW-Authenticate";
+    static public String OAUTH2_WWW_AUTHENTICATE_HEADER_VALUE_BEARER = "Bearer realm=\"Open Banking test facility\", " +
+            "charset=\"UTF-8\"";
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2ErrorAdviceResponseBody.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2ErrorAdviceResponseBody.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+/**
+ * Base class for all OAuth2Error responses body classes. This adds a text field that provides advice that is clearly
+ * aimed at test facilities, and would not be seen in production systems.
+ */
+public class OAuth2ErrorAdviceResponseBody {
+
+    public String getTest_facility_advice() {
+        return test_facility_advice;
+    }
+
+    protected String test_facility_advice;
+
+    public OAuth2ErrorAdviceResponseBody(String testFacilityAdviceMessage){
+        this.test_facility_advice =  testFacilityAdviceMessage;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2ErrorResponseBody.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2ErrorResponseBody.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+/**
+ * Used for Json Serialisation of the body to be returned to the OAuth2Client
+ */
+public class OAuth2ErrorResponseBody extends OAuth2ErrorAdviceResponseBody{
+
+    public String getError_code() {
+        return error_code;
+    }
+
+    String error_code;
+
+    public OAuth2ErrorResponseBody(OAuth2Exception oAuth2Exception) {
+        super(oAuth2Exception.getMessage());
+        this.error_code = oAuth2Exception.getRfc6750ErrorCode();
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2Exception.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2Exception.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.http.HttpStatus;
+
+/**
+ * OAuth2 Exceptions as specified in <a href=https://www.rfc-editor.org/rfc/rfc6749#section-5.2>rfc6749 section 5.2</a>
+ */
+public class OAuth2Exception extends Exception {
+
+    public static final String INVALID_CLIENT = "invalid_client";
+
+    public String getRfc6750ErrorCode() {
+        return rfc6750ErrorCode;
+    }
+
+    public HttpStatus getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    @JsonProperty("error")
+    private final String rfc6750ErrorCode;
+
+    private final HttpStatus httpStatusCode;
+
+    public OAuth2Exception(String message, String rfc6750ErrorCode, HttpStatus httpStatusCode){
+        super(message);
+        this.rfc6750ErrorCode = rfc6750ErrorCode;
+        this.httpStatusCode = httpStatusCode;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2InvalidClientException.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2InvalidClientException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+import org.springframework.http.HttpStatus;
+
+public class OAuth2InvalidClientException extends OAuth2Exception {
+    public OAuth2InvalidClientException(String message){
+        super(message, OAuth2Exception.INVALID_CLIENT, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2RegistrationException.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/error/exception/oauth2/OAuth2RegistrationException.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.common.error.exception.oauth2;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+/**
+ * OAuth2 Dynamic Client Registration errors as specified by
+ * <a href=https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.2>OAuth 2.0 Dynamic Client Registration
+ * Protocol</a>
+ */
+@Slf4j
+public class OAuth2RegistrationException {
+
+    public enum ErrorEnum {
+        INVALID_REDIRECT_URI("invalid_redirect_uri"),
+
+        INVALID_CLIENT_METADATA("invalid_client_metadata"),
+
+        INVALID_SOFTWARE_STATEMENT("invalid_software_statement"),
+
+        UNAPPROVED_SOFTWARE_STATEMENT("unapproved_software_statement");
+
+        private String value;
+
+        ErrorEnum(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static ErrorEnum fromValue(String text) {
+            for (ErrorEnum b : ErrorEnum.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+    }
+
+    private final ErrorEnum errorCode;
+    private final String errorDescription;
+
+    /**
+     * Create an OAuth2RegistrationException containing an error and optionally an error description
+     * @param errorDescription - OPTIONAL.  Human-readable ASCII text description of the error used
+     *       for debugging.
+     * @param errorCode - REQUIRED.  Single ASCII error code string. - one of the public static definitions specified
+     *                 in this class
+     */
+    public OAuth2RegistrationException(String errorDescription, ErrorEnum errorCode){
+        this.errorCode = errorCode;
+        if(StringUtils.isEmpty(errorDescription)){
+            errorDescription = "";
+        }
+        this.errorDescription = errorDescription;
+    }
+
+    public ErrorEnum getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorDescription() {
+        return errorDescription;
+    }
+}

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/utils/extractor/JwtHeaderTokenExtractor.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/utils/extractor/JwtHeaderTokenExtractor.java
@@ -37,6 +37,10 @@ public class JwtHeaderTokenExtractor implements TokenExtractor {
             throw new AuthenticationServiceException("Invalid authorization header size.");
         }
 
+        if(!header.contains(HEADER_PREFIX)){
+            throw new AuthenticationServiceException("Header should be " + HEADER_PREFIX + " Token");
+        }
+
         return header.substring(HEADER_PREFIX.length(), header.length());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.0</ob-common.version>
+        <ob-common.version>1.2.1</ob-common.version>
         <ob-clients.version>1.2.0</ob-clients.version>
         <ob-jwkms.version>1.2.0</ob-jwkms.version>
         <ob-auth.version>1.1.0</ob-auth.version>


### PR DESCRIPTION
And general tidy and refactor. These Dynamic Client Registration
endpoints were returning Open Banking errors, when they should be
returning errors inline with teh OAuth2 specifications. Also I have
added a test_facility_advice field to the response to help reduce
support tickets for both our customers, and as a result, ourselves.

Still a long way to go on this.

Issue: https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/422