### PR TITLE
434-766: funds confirmation payments grant type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,64 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+### GitHub [#428](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/428) 426: [bank UI] Confirmation page when user Cancel the consent
+[bc8074b917f395a](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/bc8074b917f395a) Jorge Sanchez Perez *2021-06-16 14:49:06*
+426: [bank UI] Confirmation page when user Cancel the consent (#428)
+
+* 426: Confirmation page when user Cancel the consent
+- Cancel component added
+- Cancel component integrated
+- Confirmation window when user cancels the consent
+Issue: https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/426
+
+* delete comented source
+
+* delete cancel test, not necessary for simple component
+
+* delete imports declared but never used to pass lint
+### GitHub [#429](https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/429) 766: funds confirmation consent grant type
+[2564c3325ee278c](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/2564c3325ee278c) Jorge Sanchez Perez *2021-06-21 11:27:56*
+766: funds confirmation consent grant type (#429)
+
+* 766: funds confirmation consent grant type
+- Fix gran type for funds confirmation consents
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/766
+
+* Added expected Grant type
+
+* fix log expected scopes
+[c281da384dabbba](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c281da384dabbba) Matt Wills *2021-06-10 13:10:39*
+32: Version prefix in v3.1.7 and v3.1.8 Accounts API
+
+- Fix version prefix (from 'V' to 'v') in v3.1.7 and v3.1.8 Account API URLs
+
+Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/32
+[b0704b02d1c8154](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/b0704b02d1c8154) JamieB *2021-06-02 13:53:21*
+Release candidate: prepare for next development iteration
+## 1.4.4
+[41f8db04407bd5d](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/41f8db04407bd5d) JamieB *2021-06-02 13:53:15*
+Release candidate: prepare release 1.4.4
+[431a39cb7f64e75](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/431a39cb7f64e75) JamieB *2021-06-02 13:48:15*
+749: set dev version to 1.4.4-SNAPSHOT before creating release
+
+Something odd has happened with the aspsp versions. We're using 1.4.3
+currently in openbanking-reference-implementation, but master has
+1.4.3-SNAPSHOT in the poms!!!
+
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/749
+[dc53032d15bc9f4](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/dc53032d15bc9f4) JamieB *2021-06-02 13:09:25*
+Release candidate: rollback the release of 1.4.3
+[857948eaae36fee](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/857948eaae36fee) JamieB *2021-06-02 12:54:46*
+Release candidate: prepare release 1.4.3
+[c9b2efe15b39437](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/c9b2efe15b39437) JamieB *2021-06-02 12:43:55*
+749: make x-headless-auth-enabled false default /authorize
+
+During refactoring for issue
+https://github.com/ForgeCloud/ob-deploy/issues/745 I inadvertantly
+removed the default value for the X_HEADLESS_AUTH_ENABLED setting. It
+should be false by default.
+
+Issue: https://github.com/ForgeCloud/ob-deploy/issues/749
 [715919c227dde22](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/715919c227dde22) JamieB *2021-05-26 15:02:43*
 745: Addressed more comments
 [674b30928f499b0](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/674b30928f499b0) JamieB *2021-05-26 13:53:57*

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -217,6 +217,7 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
                 .xFapiFinancialId(xFapiFinancialId)
                 .payment(payment)
                 .principal(principal)
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -208,6 +208,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
                 .xFapiFinancialId(xFapiFinancialId)
                 .payment(payment)
                 .principal(principal)
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -209,6 +209,7 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .xFapiFinancialId(xFapiFinancialId)
                 .payment(payment)
                 .principal(principal)
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -147,6 +147,7 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -144,6 +144,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -148,6 +148,7 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -142,6 +142,7 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -145,6 +145,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_4/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -147,6 +147,7 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -145,6 +145,7 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -142,6 +142,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -146,6 +146,7 @@ public class InternationalScheduledPaymentConsentsApiController implements Inter
                 .payment(payment)
                 .principal(principal)
                 .obVersion(getOBVersion(request.getRequestURI()))
+                .isFundsConfirmationRequest(true)
                 .filters(f -> {
                     f.verifyConsentStatusForConfirmationOfFund();
                 })

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/FundsConfirmationConsentApiEndpointWrapper.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/FundsConfirmationConsentApiEndpointWrapper.java
@@ -63,7 +63,6 @@ public class FundsConfirmationConsentApiEndpointWrapper extends RSEndpointWrappe
 
         verifyAccessToken(Collections.singletonList(OpenBankingConstants.Scope.FUNDS_CONFIRMATIONS),
                 Arrays.asList(
-                        OIDCConstants.GrantType.AUTHORIZATION_CODE,
                         OIDCConstants.GrantType.CLIENT_CREDENTIAL
                 )
         );

--- a/integration-test-support/src/main/java/com/forgerock/openbanking/integration/test/support/JWT.java
+++ b/integration-test-support/src/main/java/com/forgerock/openbanking/integration/test/support/JWT.java
@@ -33,10 +33,7 @@ import com.nimbusds.jwt.SignedJWT;
 import uk.org.openbanking.OBConstants;
 
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.UUID;
+import java.util.*;
 
 public class JWT {
 
@@ -48,15 +45,15 @@ public class JWT {
         JsonObject idTokenClaims = Json.object()
                 .add(OpenBankingConstants.AMAccessTokenClaim.ID_TOKEN, Json.object()
                         .add(OpenBankingConstants.AMAccessTokenClaim.INTENT_ID, Json.object()
-                                .add("value", "test-tpp")));
+                                .add(SupportConstants.LITERAL_VALUE, SupportConstants.USER_AUDIENCE)));
         JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
-                .issuer("https://am.dev-ob.forgerock.financial:443/oauth2/auth")
+                .issuer(SupportConstants.ISSUER)
                 .claim(OBConstants.OIDCClaim.GRANT_TYPE, grantType.type)
                 .claim(OBConstants.OIDCClaim.SCOPE, Collections.singleton(scope))
                 .claim(OpenBankingConstants.AMAccessTokenClaim.CLAIMS, idTokenClaims.toString())
                 .expirationTime(Date.from(Instant.now().plusSeconds(300)))
-                .audience("test-tpp");
-        Arrays.stream(authorities).forEach(a -> builder.claim(OpenBankingConstants.SSOClaim.AUTHORITIES, Collections.singletonList("GROUP_FORGEROCK")));
+                .audience(SupportConstants.USER_AUDIENCE);
+        Arrays.stream(authorities).forEach(a -> builder.claim(OpenBankingConstants.SSOClaim.AUTHORITIES, SupportConstants.AUTHORITIES));
         JWTClaimsSet claims = builder.build();
         JWSHeader jwsHeader = new JWSHeader
                 .Builder(JWSAlgorithm.HS256)

--- a/integration-test-support/src/main/java/com/forgerock/openbanking/integration/test/support/SupportConstants.java
+++ b/integration-test-support/src/main/java/com/forgerock/openbanking/integration/test/support/SupportConstants.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.integration.test.support;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Constants to test support
+ */
+public interface SupportConstants {
+    String USER_AUDIENCE = "test-tpp";
+    String LITERAL_VALUE = "value";
+    String ISSUER = "https://am.dev-ob.forgerock.financial:443/oauth2/auth";
+    List AUTHORITIES = Collections.singletonList("GROUP_FORGEROCK");
+    String BEARER_PREFIX = "Bearer ";
+}


### PR DESCRIPTION
**Changes**
- Rollback grant type change for funds confirmations API
- Grant type fixed for payments/funds confirmation endpoints
- Fix applied on: Domestic payments, international payments and international scheduled payments

**Issues**:
- https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/434
- https://github.com/ForgeCloud/ob-deploy/issues/766