### PR TITLE
794: UI redirection customer experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Git Changelog Maven plugin changelog
 Changelog of Git Changelog Maven plugin.
 ## Unreleased
+[eef7145f5305af3](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/eef7145f5305af3) JamieB *2021-10-12 06:53:39*
+Release candidate: prepare for next development iteration
+## 1.5.4
+[ac7a863a04bc5e0](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/ac7a863a04bc5e0) JamieB *2021-10-11 15:57:23*
+802: Use latest commons and parent
+
+Allow creation of OBRIRoles from PSD2Role
+Also;
+Pulls in 1.0.3 of spring-security-mult-auth that has improved logging
+
+Issue: ForgeCloud/ob-deploy#802
+[870b8d2c984ebb2](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/870b8d2c984ebb2) JamieB *2021-10-12 06:53:35*
+Release candidate: prepare release 1.5.4
 [104306b2f933965](https://github.com/OpenBankingToolkit/openbanking-aspsp/commit/104306b2f933965) JamieB *2021-09-24 12:45:20*
 Release candidate: prepare for next development iteration
 ## 1.5.3

--- a/forgerock-openbanking-ui/README.md
+++ b/forgerock-openbanking-ui/README.md
@@ -1,4 +1,18 @@
-## Running docker image
+## Run the app
+- bank (default angular app)
+- manual-onboarding
+### Run local app
+- `npm run build.{app/project}.themes`
+- `npm run serve.{app/project}`
+```shell
+# bank app
+npm run build.bank.themes
+npm run serve.bank
+# manual-onboading app
+npm run build.manual-onboarding.themes
+npm run serve.manual-onboarding
+```
+### Running docker image
 
 <https://hub.docker.com/repository/docker/openbankingtoolkit/openbanking-bank-ui> & <https://hub.docker.com/repository/docker/openbankingtoolkit/openbanking-register-ui> is a built version of the Analytics app with only the Forgerock template.
 
@@ -13,13 +27,14 @@ docker run -it -p <PORT>:80 -e TEMPLATE=<TEMPLATE_NAME> -e DOMAIN=<DOMAIN> openb
 docker run -it -p <PORT>:80 -e TEMPLATE=<TEMPLATE_NAME> -e DOMAIN=<DOMAIN> openbankingtoolkit/openbanking-register-ui
 ```
 
-## Building the app with your theme
+## Build
+### Building the app with your theme
 
 Create a new theme: <https://github.com/OpenBankingToolkit/openbanking-toolkit/wiki/Create-a-new-Theme>
 
 Then build the docker image
 
-## Building your own docker image
+### Building your own docker image
 
 ```bash
 # Build Analytics

--- a/forgerock-openbanking-ui/angular.json
+++ b/forgerock-openbanking-ui/angular.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
+  "defaultProject": "bank",
   "newProjectRoot": "projects",
   "projects": {
     "bank": {
@@ -174,6 +175,5 @@
         }
       }
     }
-  },
-  "defaultProject": "forgerock-openbanking-ui"
+  }
 }

--- a/forgerock-openbanking-ui/package-lock.json
+++ b/forgerock-openbanking-ui/package-lock.json
@@ -15221,6 +15221,11 @@
         "set-immediate-shim": "~1.0.1"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "karma-source-map-support": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz",

--- a/forgerock-openbanking-ui/package.json
+++ b/forgerock-openbanking-ui/package.json
@@ -57,6 +57,7 @@
     "date-fns": "^2.9.0",
     "debug": "^4.1.1",
     "file-saver": "^2.0.0",
+    "jwt-decode": "^3.1.2",
     "lodash-es": "^4.17.15",
     "ngx-build-plus": "^9.0.6",
     "ngx-clipboard": "^12.3.1",

--- a/forgerock-openbanking-ui/projects/bank/src/app/app.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/app.component.ts
@@ -1,10 +1,12 @@
-import { Component, Inject } from '@angular/core';
+import {ChangeDetectorRef, Component, Inject, OnInit} from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Platform } from '@angular/cdk/platform';
 import { TranslateService } from '@ngx-translate/core';
 
 import { ForgerockSplashscreenService } from '@forgerock/openbanking-ngx-common/services/forgerock-splashscreen';
 import { ForgerockGDPRService } from '@forgerock/openbanking-ngx-common/gdpr';
+import {ActivatedRoute} from "@angular/router";
+import {ForgerockMessagesService} from "@forgerock/openbanking-ngx-common/services/forgerock-messages";
 
 @Component({
   selector: 'app-root',
@@ -12,12 +14,40 @@ import { ForgerockGDPRService } from '@forgerock/openbanking-ngx-common/gdpr';
     <router-outlet></router-outlet>
   `
 })
-export class AppComponent {
+export class AppComponent implements OnInit{
+  loading: boolean;
+  error: Error;
+  ngOnInit(): void {
+    console.log("APP")
+    this.route.fragment.subscribe((fragment: string) => {
+      if(fragment && fragment.includes("error_description")){
+        const urlSearchParams = new URLSearchParams(fragment)
+        const error = {
+          message: urlSearchParams.get("error_description"),
+          error: urlSearchParams.get("error")
+        };
+        console.log(`segments: ${fragment}`);
+        this.messages.error(error.message, null, {duration: 0});
+        this.error = new Error(error.error);
+        this.loading = false;
+        this.cdr.detectChanges();
+      }
+    })
+    this.route.queryParams.subscribe(
+      params => {
+        console.log((params))
+      }
+    );
+
+  }
   constructor(
     @Inject(DOCUMENT) private document: any,
     private splashscreenService: ForgerockSplashscreenService,
     private translateService: TranslateService,
     private platform: Platform,
+    private route: ActivatedRoute,
+    private messages: ForgerockMessagesService,
+    private cdr: ChangeDetectorRef,
     private gdprService: ForgerockGDPRService
   ) {
     this.splashscreenService.init();

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/account/account.component.scss
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/account/account.component.scss
@@ -1,10 +1,10 @@
 :host {
   mat-checkbox {
     height: 35px;
-    /deep/ .mat-checkbox-layout {
+    :host ::ng-deep .mat-checkbox-layout {
       width: 100%;
     }
-    /deep/ .mat-checkbox-label {
+    :host ::ng-deep .mat-checkbox-label {
       flex: 1;
     }
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/account/account.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/account/account.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
 import { FormControl, FormGroup } from '@angular/forms';
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 function validateCheckboxRequired(c: FormControl) {
   return Object.values(c.value).filter(v => v === true).length
@@ -82,7 +83,7 @@ export class AccountComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       sharedAccounts: Object.keys(this.form.value).filter(k => this.form.value[k])
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/reject/reject.component.html
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/reject/reject.component.html
@@ -1,0 +1,6 @@
+<div>
+  <form ngNoForm #rejectFormPost name="rejectFormPost" action="{{response.decisionResponse?.redirectUri}}"
+        method="POST">
+    <input name="consent_response" type="hidden" value="{{response.decisionResponse?.consentJwt}}"/>
+  </form>
+</div>

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/reject/reject.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/reject/reject.component.ts
@@ -1,0 +1,63 @@
+import {
+  AfterViewChecked,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
+import {FormGroup} from "@angular/forms";
+import {ApiResponses} from 'bank/src/app/types/api';
+import {ForgerockMessagesService} from '@forgerock/openbanking-ngx-common/services/forgerock-messages';
+
+@Component({
+  selector: 'app-reject',
+  templateUrl: './reject.component.html',
+  styleUrls: ['./reject.component.scss']
+})
+export class RejectComponent implements OnInit, AfterViewChecked {
+  error: Error;
+  form: FormGroup = new FormGroup({});
+  @ViewChild('rejectFormPost') rejectFormPost: ElementRef;
+  @Input() response: ApiResponses.ConsentDetailsResponse;
+  _loading = false;
+  @Input() set loading(isLoading: boolean) {
+    this.form[isLoading ? 'disable' : 'enable']();
+    this._loading = isLoading;
+  }
+
+  constructor(
+    private cdr: ChangeDetectorRef,
+    private messages: ForgerockMessagesService
+  ) {
+  }
+
+  @Output() formSubmit = new EventEmitter<String>()
+
+  ngOnInit() {
+    console.log("reject component")
+    console.table(`reject: ${this.response.decisionResponse}`);
+    if (!this.response.decisionResponse) {
+      return;
+    }
+  }
+
+  ngAfterViewChecked(): void {
+    console.log("ngAfterViewChecked");
+    if (this.response.decisionResponse) {
+      console.log("submit reject form")
+      this.rejectFormPost.nativeElement.submit();
+    }
+  }
+
+  displayError(er: string) {
+    this.messages.error(er);
+    this.error = new Error(er);
+    this.loading = false;
+    this.cdr.detectChanges();
+  }
+
+}

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/submit-box/submit-box.component.html
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/submit-box/submit-box.component.html
@@ -12,7 +12,7 @@
         color="accent"
         type="submit"
         [disabled]="form.invalid || form.disabled"
-        (click)="accept.emit()"
+        (click)="submit($event)"
       >
         <mat-spinner diameter="20" *ngIf="loading"></mat-spinner>
         {{ proceedLabel | translate }}

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/submit-box/submit-box.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/components/submit-box/submit-box.component.ts
@@ -39,4 +39,19 @@ export class SubmitBoxComponent implements OnInit {
       }
     });
   }
+
+  submit(e: Event) {
+    console.log("submit");
+    e.stopPropagation();
+    const dialogRef = this.dialog.open(ForgerockConfirmDialogComponent, {
+      data: {
+        text: this.translate.instant('COMPONENT.ACCEPT.CONFIRM')
+      }
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.accept.emit();
+      }
+    });
+  }
 }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/consent.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/consent.component.ts
@@ -9,6 +9,8 @@ import {ApiService} from 'bank/src/app/services/api.service';
 import {ApiResponses} from 'bank/src/app/types/api';
 import {ForgerockMessagesService} from '@forgerock/openbanking-ngx-common/services/forgerock-messages';
 import {IConsentEventEmitter} from '../../types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
+import jwtDecode from "jwt-decode";
 
 @Component({
   selector: 'app-consent',
@@ -20,22 +22,32 @@ export class ConsentComponent implements OnInit {
   loading: boolean;
   error: Error;
   response: ApiResponses.ConsentDetailsResponse;
+  private redirect_uri: string;
 
   constructor(
     private route: ActivatedRoute,
     private api: ApiService,
     private cdr: ChangeDetectorRef,
     private messages: ForgerockMessagesService
-  ) {}
+  ) {
+  }
 
   ngOnInit() {
+    let redirect_uri: string;
     console.log("consent component")
-    const { consent_request: consentRequest } = this.route.snapshot.queryParams;
+    const {consent_request: consentRequest} = this.route.snapshot.queryParams;
 
     if (!consentRequest) {
       this.error = new Error('Missing consent request');
       this.cdr.detectChanges();
       return;
+    } else {
+      const consentApprovalRedirectUri = jwtDecode(consentRequest)["consentApprovalRedirectUri"];
+      const m = consentApprovalRedirectUri.match("redirect_uri=([^&]+).*$");
+      if (m.length > 0) {
+        redirect_uri = m[1];
+        console.log("redirect_uri = " + redirect_uri);
+      }
     }
 
     this.api
@@ -47,6 +59,9 @@ export class ConsentComponent implements OnInit {
             window.location.href = data.redirectUri;
           } else {
             this.response = data;
+            if (redirect_uri) {
+              this.updateUserActions(false, false, false, redirect_uri);
+            }
             this.cdr.detectChanges();
           }
         },
@@ -69,33 +84,57 @@ export class ConsentComponent implements OnInit {
   }
 
   onFormSubmit(values: IConsentEventEmitter) {
-    const { consent_request: consentJwt } = this.route.snapshot.queryParams;
+    const {consent_request: consentJwt} = this.route.snapshot.queryParams;
     const requestBody = {
       consentJwt,
       ...values
     };
 
-    if (!this.response || !this.response.decisionAPIUri) return;
+    if (!this.response || !this.response.decisionAPIUri){
+      return;
+    }
+
     this.loading = true;
 
-    if(requestBody.decision === 'deny'){
+    if (requestBody.decision === ConsentDecision.DENY) {
       console.log(`User cancels intentType: ${this.response.intentType}`)
-      this.response.canceledByUser = true;
-      this.loading = false;
-      this.cdr.detectChanges();
-      return;
+      this.updateUserActions(false, true);
     } else {
-      this.api
-        .postConsentDecision(this.response.decisionAPIUri, requestBody)
-        .pipe(withErrorHandling)
-        .subscribe(
-          (data: any) => {
+      console.log(`User accepts intentType: ${this.response.intentType}`)
+      this.updateUserActions(true);
+    }
+    this.api
+      .postConsentDecision(this.response.decisionAPIUri, requestBody)
+      .pipe(withErrorHandling)
+      .subscribe(
+        (data: ApiResponses.ConsentDecisionResponse) => {
+          console.log("apiresponses")
+          console.table(data);
+          if (data.consentJwt && data.redirectUri) {
+            this.response.decisionResponse = data;
+            this.loading = false;
+            this.cdr.detectChanges();
+          } else if (data.redirectUri) {
             window.location.href = data.redirectUri;
-          },
-          (er: any) => {
-            this.displayError(er);
           }
-        );
+        },
+        (er: any) => {
+          this.displayError(er);
+        }
+      );
+  }
+
+  updateUserActions(accept: boolean = false, reject: boolean = false, cancel: boolean = false, redirectUri: string = null) {
+    if (!this.response.userActions) {
+      this.response.userActions = {};
+    }
+    this.response.userActions.acceptedByUser = accept;
+    this.response.userActions.rejectedByUser = reject;
+    this.response.userActions.canceledByUser = cancel;
+    this.response.userActions.cancelRedirectUri = redirectUri;
+    // to avoid reload the view each time that we push data on userActions when accept, cancel or reject happens
+    if (accept || reject || cancel) {
+      this.cdr.detach();
     }
   }
 }
@@ -120,7 +159,8 @@ function withErrorHandlingForRCSBadRequest(obs: Observable<any>) {
       if (redirectUri) {
         window.location.href = redirectUri;
       }
-      return throwError(apiError || anyError);
+      const specificError = _get(er, 'error.Errors[0].Message', 'Undefined')
+      return throwError(apiError + ": " + specificError || anyError + ": " + specificError);
     })
   );
 }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/consent.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/consent.component.ts
@@ -22,7 +22,6 @@ export class ConsentComponent implements OnInit {
   loading: boolean;
   error: Error;
   response: ApiResponses.ConsentDetailsResponse;
-  private redirect_uri: string;
 
   constructor(
     private route: ActivatedRoute,

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/consent.module.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/consent.module.ts
@@ -25,6 +25,7 @@ import { ConsentBoxComponentModule } from './components/consent-box/consent-box.
 import { SubmitBoxComponentModule } from './components/submit-box/submit-box.module';
 import { AccountSelectionComponentModule } from './components/account-selection/account-selection.module';
 import { AccountCheckboxModule } from './components/account-checkbox/account-checkbox.module';
+import { RejectComponent } from './components/reject/reject.component';
 
 @NgModule({
   imports: [
@@ -53,7 +54,8 @@ import { AccountCheckboxModule } from './components/account-checkbox/account-che
     FilePaymentComponent,
     DynamicComponent,
     PermissionsComponent,
-    CancelComponent
+    CancelComponent,
+    RejectComponent
   ],
   entryComponents: [
     SinglePaymentComponent,
@@ -66,7 +68,8 @@ import { AccountCheckboxModule } from './components/account-checkbox/account-che
     InternationalStandingOrderComponent,
     FundsConfirmationComponent,
     FilePaymentComponent,
-    CancelComponent
+    CancelComponent,
+    RejectComponent
   ],
   exports: [
     ConsentComponent,
@@ -82,7 +85,8 @@ import { AccountCheckboxModule } from './components/account-checkbox/account-che
     FilePaymentComponent,
     DynamicComponent,
     PermissionsComponent,
-    CancelComponent
+    CancelComponent,
+    RejectComponent
   ]
 })
 export class ConsentModule {}

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/domestic-payment/domestic-payment.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/domestic-payment/domestic-payment.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, Validators, FormControl } from '@angular/forms';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-domestic-payment',
@@ -67,7 +68,7 @@ export class DomesticPaymentComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.ts
@@ -4,6 +4,7 @@ import _get from 'lodash-es/get';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-domestic-schedule-payment',
@@ -80,7 +81,7 @@ export class DomesticSchedulePaymentComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
@@ -4,6 +4,7 @@ import _get from 'lodash-es/get';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-domestic-standing-order-payment',
@@ -105,7 +106,7 @@ export class DomesticStandingOrderComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/dynamic/dynamic.component.scss
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/dynamic/dynamic.component.scss
@@ -31,7 +31,7 @@
         margin: 0 0.9em 0 0;
       }
     }
-    /deep/ .secondary-text {
+    :host ::ng-deep .secondary-text {
       color: mat-color($foreground, secondary-text);
     }
 
@@ -125,13 +125,13 @@
         height: 40px;
       }
     }
-    /deep/ .mat-radio-label {
+    :host ::ng-deep .mat-radio-label {
       width: 100%;
     }
-    /deep/ .mat-radio-label-content {
+    :host ::ng-deep .mat-radio-label-content {
       flex: 1;
     }
-    /deep/ .button-cancel {
+    :host ::ng-deep .button-cancel {
       min-height: 65px;
       white-space: normal;
     }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/dynamic/dynamic.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/dynamic/dynamic.component.ts
@@ -28,6 +28,7 @@ import {InternationalStandingOrderComponent} from 'bank/src/app/pages/consent/in
 import {FundsConfirmationComponent} from 'bank/src/app/pages/consent/funds-confirmation/funds-confirmation.component';
 import {FilePaymentComponent} from 'bank/src/app/pages/consent/file-payment/file-payment.component';
 import {CancelComponent} from "bank/src/app/pages/consent/components/cancel/cancel.component";
+import {RejectComponent} from "bank/src/app/pages/consent/components/reject/reject.component";
 
 const log = debug('consent:DynamicComponent');
 
@@ -39,21 +40,25 @@ const log = debug('consent:DynamicComponent');
   encapsulation: ViewEncapsulation.None
 })
 export class DynamicComponent implements OnInit, OnChanges {
-  constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
+  constructor(private componentFactoryResolver: ComponentFactoryResolver) {
+  }
 
   @Input() response: ApiResponses.ConsentDetailsResponse;
   @Input() loading: boolean;
   @Output() formSubmit: EventEmitter<any> = new EventEmitter<any>();
-  @ViewChild('dynamicTarget', { read: ViewContainerRef, static: true })
+  @ViewChild('dynamicTarget', {read: ViewContainerRef, static: true})
   dynamicTarget: ViewContainerRef;
   componentRef: ComponentRef<any>;
 
-  ngOnInit() {}
+  ngOnInit() {
+  }
 
   ngOnChanges(changes: any) {
     console.log("Dynamic component")
-    if(this.response.canceledByUser){
+    if (this.response.canceledByUser) {
       this.createComponent(CancelComponent);
+    } else if (this.response.userActions?.rejectedByUser) {
+      this.createComponent(RejectComponent);
     }
     if (changes.loading && !changes.loading.firstChange) {
       this.componentRef.instance.loading = changes.loading.currentValue;

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/file-payment/file-payment.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/file-payment/file-payment.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormControl, Validators } from '@angular/forms';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-file-payment',
@@ -83,7 +84,7 @@ export class FilePaymentComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/funds-confirmation/funds-confirmation.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/funds-confirmation/funds-confirmation.component.ts
@@ -4,6 +4,7 @@ import _get from 'lodash-es/get';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-funds-confirmation',
@@ -77,7 +78,7 @@ export class FundsConfirmationComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: _get(this.response, 'accounts[0].id', '')
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/international-payment/international-payment.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/international-payment/international-payment.component.ts
@@ -4,6 +4,7 @@ import _get from 'lodash-es/get';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-international-payment',
@@ -136,7 +137,7 @@ export class InternationalPaymentComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
@@ -4,6 +4,7 @@ import _get from 'lodash-es/get';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-international-schedule-payment',
@@ -147,7 +148,7 @@ export class InternationalSchedulePaymentComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
@@ -4,6 +4,7 @@ import _get from 'lodash-es/get';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-international-standing-order-payment',
@@ -106,7 +107,7 @@ export class InternationalStandingOrderComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/permissions/permissions.component.scss
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/permissions/permissions.component.scss
@@ -7,19 +7,19 @@
     mat-expansion-panel {
       box-shadow: none;
       margin: 0;
-      /deep/ mat-expansion-panel-header {
+      :host ::ng-deep mat-expansion-panel-header {
         padding: 0 5px;
         .mat-expansion-indicator {
           margin-right: 10px;
         }
       }
-      /deep/ .mat-expansion-panel-content {
+      :host ::ng-deep .mat-expansion-panel-content {
         background-color: mat-color($background, background);
         border-left-width: 3px;
         border-left-style: solid;
         border-left-color: mat-color($accent);
       }
-      /deep/ .mat-expansion-panel-body {
+      :host ::ng-deep .mat-expansion-panel-body {
         padding: 13px;
       }
     }

--- a/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/single-payment/single-payment.component.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/pages/consent/single-payment/single-payment.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormControl, Validators } from '@angular/forms';
 
 import { ApiResponses } from 'bank/src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from 'bank/src/app/types/consentItem';
+import {ConsentDecision} from "bank/src/app/types/ConsentDecision";
 
 @Component({
   selector: 'app-consent-single-payment',
@@ -67,7 +68,7 @@ export class SinglePaymentComponent implements OnInit {
 
   submit(allowing = false) {
     this.formSubmit.emit({
-      decision: allowing ? 'allow' : 'deny',
+      decision: allowing ? ConsentDecision.ALLOW : ConsentDecision.DENY,
       accountId: this.form.value.selectedAccount
     });
   }

--- a/forgerock-openbanking-ui/projects/bank/src/app/types/ConsentDecision.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/types/ConsentDecision.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export enum ConsentDecision {
+  ALLOW = 'allow',
+  DENY = 'deny'
+}

--- a/forgerock-openbanking-ui/projects/bank/src/app/types/api.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/types/api.ts
@@ -54,6 +54,22 @@ export module ApiResponses {
     requestedExecutionDateTime?: string;
     currencyOfTransfer?: string;
     expirationDateTime?: string;
+    // special ui treatment
+    userActions?:UserActions;
+    decisionResponse?: ConsentDecisionResponse;
+  }
+
+  export interface ConsentDecisionResponse {
+    consentJwt: string;
+    requestMethod: string;
+    redirectUri: string
+  }
+
+  export interface UserActions {
+    acceptedByUser?: boolean;
+    rejectedByUser?: boolean;
+    canceledByUser?: boolean;
+    cancelRedirectUri?: string;
   }
 }
 

--- a/forgerock-openbanking-ui/projects/bank/src/assets/i18n/en.json
+++ b/forgerock-openbanking-ui/projects/bank/src/assets/i18n/en.json
@@ -9,7 +9,7 @@
   "COMPONENT": {
     "CANCEL": {
       "APPLICATION": "Application requesting access",
-      "CONFIRM": "Are you sure you want to cancel?",
+      "CONFIRM": "Are you sure you want to cancel and reject the consent?",
       "CANCEL_CONFIRMATION": "Canceled by user: {{username}}",
       "CONSENTS": {
         "ACCOUNT_ACCESS_CONSENT": "Account sharing",
@@ -23,6 +23,9 @@
         "PAYMENT_FILE_CONSENT": "File payment",
         "FUNDS_CONFIRMATION_CONSENT": "Funds confirmation"
       }
+    },
+    "ACCEPT": {
+      "CONFIRM": "Are you sure you want to accept the consent?"
     }
   },
   "GDPR": {

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApiController.java
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/as/api/accesstoken/AccessTokenApiController.java
@@ -155,12 +155,16 @@ public class AccessTokenApiController implements AccessTokenApi {
                 log.debug("getAccessToken() response from AM; {}", responseFromAM);
                 HttpStatus statusCode = responseFromAM.getStatusCode();
                 if (!statusCode.is2xxSuccessful() && !statusCode.is3xxRedirection()) {
+                    String responseAMBody = responseFromAM.getBody().toString();
+                    if(responseFromAM.getBody() instanceof byte[]) {
+                        responseAMBody = new String((byte[]) responseFromAM.getBody());
+                    }
                     log.warn("getAccessToken() Un-successful call to AM to get access token. Status code: {}, body " +
-                            "{}", responseFromAM.getStatusCode(), responseFromAM.getBody());
+                            "{}", responseFromAM.getStatusCode(), responseAMBody);
                     throw new OBErrorResponseException(
                             OBRIErrorType.ACCESS_TOKEN_INVALID.getHttpStatus(),
                             OBRIErrorResponseCategory.ACCESS_TOKEN,
-                            OBRIErrorType.ACCESS_TOKEN_INVALID.toOBError1(responseFromAM.getBody()));
+                            OBRIErrorType.ACCESS_TOKEN_INVALID.toOBError1(responseAMBody));
                 }
                 AccessTokenResponse accessTokenResponse = (AccessTokenResponse) responseFromAM.getBody();
                 log.debug("getAccessToken() accessTokenResponse from AM is {}", accessTokenResponse);

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/test/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/RCSConsentDecisionApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/test/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/decisions/RCSConsentDecisionApiControllerTest.java
@@ -116,10 +116,6 @@ public class RCSConsentDecisionApiControllerTest {
         Map<String, String> profile = new HashMap<String, String>();
         profile.put(amOpenBankingConfiguration.userProfileId, "username");
         given(this.userProfileService.getProfile(anyString(), anyString(), anyString())).willReturn(profile);
-
-        ResponseEntity responseEntity = mock(ResponseEntity.class);
-        given(this.rcsService.sendRCSResponseToAM(anyString(), any(RedirectionAction.class))).willReturn(responseEntity);
-        given(responseEntity.getStatusCode()).willReturn(HttpStatus.FOUND);
         HttpHeaders headers = new HttpHeaders();
         headers.add("Location", "https://www.google.com#code=oq62Wr-V0E7cnuIl5rDSwscCyVo&id_token" +
                 "=eyJ0eXAiOiJKV1QiLCJraWQiOiJzUUhYOHlnT3JGcHBsZ09ZZkxpQUNTNzJOMG89IiwiYWxnIjoiUFMyNTYifQ.eyJzdWIiOiJ" +
@@ -135,6 +131,10 @@ public class RCSConsentDecisionApiControllerTest {
                 "W5qe5K-WUFTWMtfX2ncIwf-RJzxazzfxkpIrKfVhi6R96qpi7RYSZ3GWUfxBm2za24ZvyUNVR5c9ptlyke5h4Wq1QZkaiHv02VT" +
                 "EO2GbumtWIWYfpl84FepZvDm6E6O7K0KCTs8G--jrCnZljwL-qSgWEUkIDja4eaz4KYdZ7-U-CUVzdoMaxhZY5CbM09PRRPsiuy" +
                 "vsZ6FVGx6YGHUN-BDIFssy6hpD53Dp2HGbCxZ0unBU50Q9N3w&state=10d260bf-a7d9-444a-92d9-7b7a5f088208");
+
+        ResponseEntity responseEntity = new ResponseEntity(null, headers, HttpStatus.FOUND);
+        given(this.rcsService.sendRCSResponseToAM(anyString(), any(RedirectionAction.class))).willReturn(responseEntity);
+
         URI rewrittenUri = new URI("https://www.google.com#code=oq62Wr-V0E7cnuIl5rDSwscCyVo&id_token" +
                 "=re-writtenIdToken");
         HttpHeaders rewrittenHeaders = new HttpHeaders();
@@ -171,4 +171,5 @@ public class RCSConsentDecisionApiControllerTest {
         assertThat(redirectAction).isNotNull();
         assertThat(redirectAction.getRedirectUri()).contains("re-writtenIdToken");
     }
+
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/test/java/com/forgerock/openbanking/aspsp/rs/rcs/services/RCSErrorServiceTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/test/java/com/forgerock/openbanking/aspsp/rs/rcs/services/RCSErrorServiceTest.java
@@ -27,6 +27,7 @@ import com.forgerock.openbanking.integration.test.support.Tracer;
 import com.forgerock.openbanking.model.error.OBRIErrorType;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -60,7 +61,8 @@ public class RCSErrorServiceTest {
                 .encode()
                 .build();
 
-        assertThat(response.getStatusCode()).isEqualTo(obErrorException.getObriErrorType().getHttpStatus());
+        // we expect httpStatus.OK to redirect from UI
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         RedirectionAction body = Objects.requireNonNull(response.getBody());
         assertThat(body.getRedirectUri()).isEqualTo(uriComponents.toUriString());
     }


### PR DESCRIPTION
- Implemented new redirect behaviour (TPP `redirect_uri`) when:
    - An error happens calling AM to authorise the request with consent.
    - An error happens validating the JWT from the request with consent.
    - Other errors related with the request with consent.
- Implemented new UI behaviour to catch an redirect to TPP when an error is returned from backend when:
   - The user Reject the consent.
   - An error returned from backend (the http code will be Ok but with the URI with error description to redirect the response. 
- Issue: https://github.com/ForgeCloud/ob-deploy/issues/794