### PR TITLE
36: Add filters to test vrp Payments risk and initiation

### DIFF
--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -183,6 +183,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
             </plugin>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/DomesticVrpPaymentsEndpointWrapperTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/DomesticVrpPaymentsEndpointWrapperTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.wrappper.endpoints;
+
+import com.forgerock.openbanking.aspsp.rs.api.payment.verifier.OBRisk1Validator;
+import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPConsent;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRWriteDomesticVRPDataInitiation;
+import com.forgerock.openbanking.common.services.openbanking.converter.vrp.FRDomesticVRPConverters;
+import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.integration.test.support.FRVrpTestDataFactory;
+import com.forgerock.openbanking.model.error.OBRIErrorType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInitiation;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
+import uk.org.openbanking.testsupport.vrp.OBDomesticVRPCommonTestDataFactory;
+import uk.org.openbanking.testsupport.vrp.OBDomesticVRPRequestTestDataFactory;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.vrp.FRDomesticVRPConsentConverter.toOBRisk1;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DomesticVrpPaymentsEndpointWrapperTest {
+
+    @Mock
+    RSEndpointWrapperService endpointWrapperService;
+
+    @Mock
+    TppStoreService tppStoreService;
+
+    @Mock
+    OBRisk1Validator riskValidator;
+
+    @Test
+    public void success_validateRisk() throws OBErrorException {
+        // Given
+        DomesticVrpPaymentsEndpointWrapper domesticVrpPaymentsEndpointWrapper =
+                new DomesticVrpPaymentsEndpointWrapper(endpointWrapperService, tppStoreService, riskValidator);
+        OBDomesticVRPRequest vrpRequest = OBDomesticVRPRequestTestDataFactory.aValidOBDomesticVRPRequest();
+        FRDomesticVRPConsent vrpConsent = FRVrpTestDataFactory.aValidFRDomesticVRPConsent();
+        vrpRequest.setRisk(toOBRisk1(vrpConsent.getRisk()));
+
+        // When
+        domesticVrpPaymentsEndpointWrapper.checkRequestAndConsentRiskMatch(vrpRequest, vrpConsent);
+
+        // Then
+        // If no exception then we're good
+    }
+
+    @Test
+    public void fail_validateRisk() throws OBErrorException {
+        // Given
+        DomesticVrpPaymentsEndpointWrapper domesticVrpPaymentsEndpointWrapper =
+                new DomesticVrpPaymentsEndpointWrapper(endpointWrapperService, tppStoreService, riskValidator);
+        OBDomesticVRPRequest vrpRequest = OBDomesticVRPRequestTestDataFactory.aValidOBDomesticVRPRequest();
+        FRDomesticVRPConsent vrpConsent = FRVrpTestDataFactory.aValidFRDomesticVRPConsent();
+        vrpRequest.setRisk(toOBRisk1(vrpConsent.getRisk()));
+        vrpRequest.getRisk().setMerchantCategoryCode("mismatched Merchange Category Code");
+
+        // When
+        OBErrorException exception =
+                catchThrowableOfType(() ->
+                        domesticVrpPaymentsEndpointWrapper.checkRequestAndConsentRiskMatch(vrpRequest, vrpConsent),
+                        OBErrorException.class);
+
+        // Then
+        assertThat(exception.getObriErrorType()).isEqualTo(OBRIErrorType.REQUEST_VRP_RISK_DOESNT_MATCH_CONSENT);
+    }
+
+    @Test
+    public void success_checkRequestAndConsentInitiationMatch() throws OBErrorException {
+        // Given
+        DomesticVrpPaymentsEndpointWrapper domesticVrpPaymentsEndpointWrapper =
+                new DomesticVrpPaymentsEndpointWrapper(endpointWrapperService, tppStoreService, riskValidator);
+        OBDomesticVRPInitiation requestInitiation = OBDomesticVRPCommonTestDataFactory.aValidOBDomesticVRPInitiation();
+        FRDomesticVRPConsent frConsent = FRVrpTestDataFactory.aValidFRDomesticVRPConsent();
+        FRWriteDomesticVRPDataInitiation matchingInitiation =
+                (FRWriteDomesticVRPDataInitiation) FRDomesticVRPConverters.toFRDomesticVRPInitiation(requestInitiation);
+        frConsent.getVrpDetails().getData().setInitiation(matchingInitiation);
+
+        // When
+        domesticVrpPaymentsEndpointWrapper.checkRequestAndConsentInitiationMatch(requestInitiation, frConsent);
+
+        // Then
+        // If no exception then we're good!
+    }
+
+    @Test
+    public void fail_checkRequestAndConsentInitiationMatch() throws OBErrorException {
+        // Given
+        DomesticVrpPaymentsEndpointWrapper domesticVrpPaymentsEndpointWrapper =
+                new DomesticVrpPaymentsEndpointWrapper(endpointWrapperService, tppStoreService,
+                        riskValidator);
+          // Create the request data
+        OBDomesticVRPInitiation requestInitiation = OBDomesticVRPCommonTestDataFactory.aValidOBDomesticVRPInitiation();
+          // Create an FR Consent with slightly differing initiation data
+        FRDomesticVRPConsent frConsent = FRVrpTestDataFactory.aValidFRDomesticVRPConsent();
+        FRWriteDomesticVRPDataInitiation differentInitiationData =
+                (FRWriteDomesticVRPDataInitiation) FRDomesticVRPConverters.toFRDomesticVRPInitiation(requestInitiation);
+        differentInitiationData.getDebtorAccount().setIdentification("mismatched identification");
+        frConsent.getVrpDetails().getData().setInitiation(differentInitiationData);
+
+        // When
+        OBErrorException exception =
+                catchThrowableOfType(() -> domesticVrpPaymentsEndpointWrapper.checkRequestAndConsentInitiationMatch(
+                        requestInitiation, frConsent), OBErrorException.class);
+
+        // Then
+        assertThat(exception.getObriErrorType()).isEqualTo(OBRIErrorType.REQUEST_VRP_INITIATION_DOESNT_MATCH_CONSENT);
+    }
+}

--- a/integration-test-support/pom.xml
+++ b/integration-test-support/pom.xml
@@ -120,6 +120,10 @@
             <groupId>com.forgerock.spring.security</groupId>
             <artifactId>spring-security-multi-auth-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.jsonzou</groupId>
+            <artifactId>jmockdata</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/integration-test-support/src/main/java/com/forgerock/openbanking/integration/test/support/FRVrpTestDataFactory.java
+++ b/integration-test-support/src/main/java/com/forgerock/openbanking/integration/test/support/FRVrpTestDataFactory.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.common.model.openbanking.persistence.vrp.testdata;
+package com.forgerock.openbanking.integration.test.support;
 
 import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPConsent;
 import com.github.jsonzou.jmockdata.JMockData;

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.15-SNAPSHOT</ob-common.version>
+        <ob-common.version>1.2.16-SNAPSHOT</ob-common.version>
         <ob-clients.version>1.2.14</ob-clients.version>
         <ob-jwkms.version>1.2.13</ob-jwkms.version>
         <ob-auth.version>1.1.13</ob-auth.version>


### PR DESCRIPTION
In accord with this spec;
https://openbankinguk.github.io/read-write-api-site3/v3.1.8/resources-and-data-models/vrp/domestic-vrps.html#post-domestic-vrps

Each VRP request need to test that the initiation and risk objects match
those that were provided when the consent was created.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/36