### PR TITLE
36: Further VRP request filters

### DIFF
--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpsApiController.java
@@ -123,6 +123,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi{
             f.validateRisk(obDomesticVRPRequest.getRisk());
             f.checkRequestAndConsentInitiationMatch(initiation, consent);
             f.checkRequestAndConsentRiskMatch(obDomesticVRPRequest, consent);
+            f.checkCreditorAccountIsInInstructionIfNotInConsent(new OBDomesticVRPRequest(), consent);
         });
         ResponseEntity responseEntity =  vrpPaymentsEndpointWrapper.execute((String tppId) -> {
             HttpHeaders additionalHeaders = new HttpHeaders();

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/DomesticVrpPaymentsEndpointWrapper.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/DomesticVrpPaymentsEndpointWrapper.java
@@ -32,6 +32,8 @@ import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.model.error.OBRIErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
 import uk.org.openbanking.datamodel.payment.OBRisk1;
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInitiation;
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
@@ -110,6 +112,15 @@ public class DomesticVrpPaymentsEndpointWrapper extends RSEndpointWrapper<Domest
         OBRisk1 consentRisk = toOBRisk1(frConsent.getRisk());
         if(!requestRisk.equals(consentRisk)){
             throw new OBErrorException(OBRIErrorType.REQUEST_VRP_RISK_DOESNT_MATCH_CONSENT);
+        }
+    }
+
+    public void checkCreditorAccountIsInInstructionIfNotInConsent(OBDomesticVRPRequest vrpRequest,
+                                                                  FRDomesticVRPConsent frConsent) throws OBErrorException {
+        if(frConsent.getVrpDetails().getData().getInitiation().getCreditorAccount() == null){
+            if(vrpRequest.getData().getInitiation().getCreditorAccount() == null){
+                throw new OBErrorException(OBRIErrorType.REQUEST_VRP_CREDITOR_ACCOUNT_NOT_SPECIFIED);
+            }
         }
     }
 


### PR DESCRIPTION
Add filters to ensure that Creditor is provided in the request if it
doesn't exist in the consent

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/36