### PR TITLE
859: Fix import of CustomerInfo data

### DIFF
--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/conf/discovery/RSAPIsConfigurationProperties.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/conf/discovery/RSAPIsConfigurationProperties.java
@@ -136,7 +136,7 @@ public class RSAPIsConfigurationProperties {
                     if (isVersionEnable(classOpenBankingAPI.obVersion())
                             && isAPIEnable(classOpenBankingAPI.obReference())
                             && isVersionOverrideEnable(classOpenBankingAPI.obVersion(), classOpenBankingAPI.obReference())) {
-                        log.trace("version is enabled, api is enabled and version everride enabled");
+                        log.trace("version is enabled, api is enabled and version override enabled");
                         Method[] methods = obInterface.getMethods();
                         for (Method method : methods) {
                             log.trace("processing method {}", method.getName());

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/resources/filtered/logback-spring.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/resources/filtered/logback-spring.xml
@@ -21,7 +21,8 @@
     <logger name="com.forgerock" level="DEBUG"/>
     <logger name="org.springframework" level="INFO"/>
     <logger name="org.forgerock.openbanking.commons.auth" level="TRACE"/>
-
+    <logger name="com.forgerock.openbanking.aspsp.rs.api.discovery" level="TRACE"/>
+    <logger name="com.forgerock.openbanking.common.conf.discovery" level="TRACE"/>
 
     <springProfile name="console-logging">
         <logger name="org.springframework" level="INFO"/>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataApiController.java
@@ -205,6 +205,7 @@ public class DataApiController implements DataApi {
 
         if(rsConfiguration.isCustomerInfoEnabled()) {
             FRCustomerInfo requestCustomerInfo = userData.getCustomerInfo();
+            requestCustomerInfo.setUserID(username);
             if (userData.getCustomerInfo() != null) {
                 FRCustomerInfo existingCustomerInfo = customerInfoRepository.findByUserID(username);
                 if(existingCustomerInfo != null){

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataUpdater.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataUpdater.java
@@ -110,6 +110,7 @@ public class DataUpdater {
         if (existingCustomerInfo != null) {
             FRCustomerInfo newCustomerInfo = userData.getCustomerInfo();
             if(newCustomerInfo != null) {
+                newCustomerInfo.setUserID(userData.getUserName());
                 if (!newCustomerInfo.getId().equals(existingCustomerInfo.getId())) {
                     String errorMessage = String.format("The customerInfo ID '%s' in the provided data does not match " +
                                     "that in the existing data '%s' for user '%s'", newCustomerInfo.getId(),

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/details/RCSCustomerInfoDetailsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/src/main/java/com/forgerock/openbanking/aspsp/rs/rcs/api/rcs/details/RCSCustomerInfoDetailsApi.java
@@ -98,7 +98,7 @@ public class RCSCustomerInfoDetailsApi implements RCSDetailsApi {
         accountRequestStoreService.save(customerInfoAccountConsent);
 
         log.debug("Populate the model with the customer info and consent data");
-        log.debug("get the customer info to add it in account consent data.");
+        log.debug("get the customer info for user {} to add it in account consent data.", username);
         FRCustomerInfo customerInfo = customerInfoRepository.findByUserID(username);
         log.debug("customer info data {}", customerInfo);
         if (customerInfo == null) {


### PR DESCRIPTION
When created via the import apis `/api/user/data`, the CustomerInfo did
not have the required `username` field in it. This needs to be added
from the UserData recived with the data. It's absence meant that the RCS
could not find the CustomerInfo for a specific PSU.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/859