### PR TITLE
859: Fix failing DataApiControlerIT tests

### DIFF
--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataApiController.java
@@ -205,8 +205,8 @@ public class DataApiController implements DataApi {
 
         if(rsConfiguration.isCustomerInfoEnabled()) {
             FRCustomerInfo requestCustomerInfo = userData.getCustomerInfo();
-            requestCustomerInfo.setUserID(username);
-            if (userData.getCustomerInfo() != null) {
+            if (requestCustomerInfo != null) {
+                requestCustomerInfo.setUserID(username);
                 FRCustomerInfo existingCustomerInfo = customerInfoRepository.findByUserID(username);
                 if(existingCustomerInfo != null){
                     requestCustomerInfo.setId(existingCustomerInfo.getId());

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataApiControllerIT.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/data/DataApiControllerIT.java
@@ -65,6 +65,7 @@ public class DataApiControllerIT {
     @Autowired
     private FRBalanceRepository frBalanceRepository;
 
+
     @Test
     public void shouldReturnPayloadTooLargeWhenCreatingNewData() throws Exception {
         // Given


### PR DESCRIPTION
When no Customer data exists in the source data there was a null
pointer when trying to set it's username!

Issue: https://github.com/ForgeCloud/ob-deploy/issues/859