### PR TITLE
870: Support TPP testing VRP periodic limits breaches

### DIFF
--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpsApi.java
@@ -200,6 +200,7 @@ public interface DomesticVrpsApi {
      * @param xFapiCustomerIpAddress The PSU&#39;s IP address if the PSU is currently logged in with the TPP. (optional)
      * @param xFapiInteractionId An RFC4122 UID used as a correlation id. (optional)
      * @param xCustomerUserAgent Indicates the user-agent that the PSU is using. (optional)
+     * @param xVrpLimitBreachResponseSimulation Custom header used to simulate a PeriodicLimit breach response for testing purposes. Values should be of the form PeriodType-PeriodAlignment e.g. Year-Calendar. (optional)
      * @return Default response (status code 201)
      *         or Bad request (status code 400)
      *         or Unauthorized (status code 401)
@@ -257,6 +258,9 @@ public interface DomesticVrpsApi {
 
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "Custom header used to simulate a PeriodicLimit breach response for testing purposes. Values should be of the form PeriodType-PeriodAlignment e.g. Year-Calendar.")
+            @RequestHeader(value = "x-vrp-limit-breach-response-simulation", required = false) String xVrpLimitBreachResponseSimulation,
 
             HttpServletRequest request,
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpsApiController.java
@@ -120,10 +120,14 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
      *
      *             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
      *             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+     *
+     *             @ApiParam(value = "Custom header used to simulate a PeriodicLimit breach response for testing purposes. Values should be of the form PeriodType-PeriodAlignment e.g. Year-Calendar.")
+     *             @RequestHeader(value = "x-vrp-limit-breach-response-simulation", required = false) String xVrpLimitBreachResponseSimulation
      */
     public ResponseEntity<OBDomesticVRPResponse> domesticVrpPost(
             String authorization, String xJwsSignature, OBDomesticVRPRequest obDomesticVRPRequest, String xFapiAuthDate,
             String xFapiCustomerIpAddress, String xFapiInteractionId, String xCustomerUserAgent,
+            String xVrpLimitBreachResponseSimulation,
             HttpServletRequest request, Principal principal
     ) throws OBErrorResponseException {
         log.debug("domesticVrpPost() Recieved OBDomesticVrpRequest {}", obDomesticVRPRequest);
@@ -143,7 +147,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
             f.validateRisk(obDomesticVRPRequest.getRisk());
             f.checkRequestAndConsentInitiationMatch(initiation, consent);
             f.checkRequestAndConsentRiskMatch(obDomesticVRPRequest, consent);
-            f.checkControlParameters(obDomesticVRPRequest, consent);
+            f.checkControlParameters(obDomesticVRPRequest, consent, xVrpLimitBreachResponseSimulation);
             f.checkCreditorAccountIsInInstructionIfNotInConsent(obDomesticVRPRequest, consent);
         });
         ResponseEntity responseEntity = vrpPaymentsEndpointWrapper.execute((String tppId) -> {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApi.java
@@ -200,6 +200,7 @@ public interface DomesticVrpsApi {
      * @param xFapiCustomerIpAddress The PSU&#39;s IP address if the PSU is currently logged in with the TPP. (optional)
      * @param xFapiInteractionId An RFC4122 UID used as a correlation id. (optional)
      * @param xCustomerUserAgent Indicates the user-agent that the PSU is using. (optional)
+     * @param xVrpLimitBreachResponseSimulation Custom header used to simulate a PeriodicLimit breach response for testing purposes. Values should be of the form PeriodType-PeriodAlignment e.g. Year-Calendar. (optional)
      * @return Default response (status code 201)
      *         or Bad request (status code 400)
      *         or Unauthorized (status code 401)
@@ -257,6 +258,9 @@ public interface DomesticVrpsApi {
 
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "Custom header used to simulate a PeriodicLimit breach response for testing purposes. Values should be of the form PeriodType-PeriodAlignment e.g. Year-Calendar.")
+            @RequestHeader(value = "x-vrp-limit-breach-response-simulation", required = false) String xVrpLimitBreachResponseSimulation,
 
             HttpServletRequest request,
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -121,10 +121,14 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
      *
      *             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
      *             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+     *
+     *             @ApiParam(value = "Custom header used to simulate a PeriodicLimit breach response for testing purposes. Values should be of the form PeriodType-PeriodAlignment e.g. Year-Calendar.")
+     *             @RequestHeader(value = "x-vrp-limit-breach-response-simulation", required = false) String xVrpLimitBreachResponseSimulation
      */
     public ResponseEntity<OBDomesticVRPResponse> domesticVrpPost(
             String authorization, String xJwsSignature, OBDomesticVRPRequest obDomesticVRPRequest, String xFapiAuthDate,
             String xFapiCustomerIpAddress, String xFapiInteractionId, String xCustomerUserAgent,
+            String xVrpLimitBreachResponseSimulation,
             HttpServletRequest request, Principal principal
     ) throws OBErrorResponseException {
         log.debug("domesticVrpPost() Recieved OBDomesticVrpRequest {}", obDomesticVRPRequest);
@@ -144,7 +148,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
             f.validateRisk(obDomesticVRPRequest.getRisk());
             f.checkRequestAndConsentInitiationMatch(initiation, consent);
             f.checkRequestAndConsentRiskMatch(obDomesticVRPRequest, consent);
-            f.checkControlParameters(obDomesticVRPRequest, consent);
+            f.checkControlParameters(obDomesticVRPRequest, consent, xVrpLimitBreachResponseSimulation);
             f.checkCreditorAccountIsInInstructionIfNotInConsent(obDomesticVRPRequest, consent);
         });
         ResponseEntity responseEntity = vrpPaymentsEndpointWrapper.execute((String tppId) -> {

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_8/vrp/DomesticVrpApiControllerTest.java
@@ -117,7 +117,7 @@ public class DomesticVrpApiControllerTest {
         // When
         ResponseEntity<OBDomesticVRPResponse> response = domesticVrpController.domesticVrpPost("test", "test_sig",
                 obDomesticVRPRequest,  new DateTime().toString(),
-                "127..0.0.1", "x-fapi-interaction_id", "user-agent", request, principal);
+                "127..0.0.1", "x-fapi-interaction_id", "user-agent", null, request, principal);
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpApiControllerTest.java
@@ -119,7 +119,7 @@ public class DomesticVrpApiControllerTest {
         // When
         ResponseEntity<OBDomesticVRPResponse> response = domesticVrpController.domesticVrpPost("test", "test_sig",
                 obDomesticVRPRequest,  new DateTime().toString(),
-                "127..0.0.1", "x-fapi-interaction_id", "user-agent", request, principal);
+                "127..0.0.1", "x-fapi-interaction_id", "user-agent", null, request, principal);
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApiControllerIT.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApiControllerIT.java
@@ -37,6 +37,8 @@ import com.forgerock.openbanking.integration.test.support.SpringSecForTest;
 import com.forgerock.openbanking.jwt.services.CryptoApiClient;
 import com.forgerock.openbanking.model.OBRIRole;
 import com.forgerock.openbanking.model.Tpp;
+import com.forgerock.openbanking.model.error.ErrorCode;
+import com.forgerock.openbanking.model.error.OBRIErrorType;
 import com.forgerock.openbanking.model.error.VRPErrorControlParametersFields;
 import com.github.jsonzou.jmockdata.JMockData;
 import com.nimbusds.jwt.SignedJWT;
@@ -45,6 +47,7 @@ import kong.unirest.JacksonObjectMapper;
 import kong.unirest.Unirest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.entity.ContentType;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,10 +60,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.org.openbanking.OBHeaders;
 import uk.org.openbanking.datamodel.account.Links;
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
 import uk.org.openbanking.datamodel.payment.OBRisk1;
 import uk.org.openbanking.datamodel.vrp.*;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVRPResponseTestDataFactory;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -311,6 +317,93 @@ public class DomesticVrpsApiControllerIT {
         assertThat(response.getParsingError().get().getOriginalBody()).contains(expectedMessage);
     }
 
+    @Test
+    public void simulateVrpLimitBreachResponse() throws Exception {
+        // Given
+        String jws = jws("payments", OIDCConstants.GrantType.AUTHORIZATION_CODE);
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
+        FRDomesticVRPConsent frDomesticVRPConsent = aValidFRDomesticVRPConsent(
+                IntentType.DOMESTIC_VRP_PAYMENT_CONSENT.generateIntentId(),
+                ConsentStatusCode.AUTHORISED
+        );
+
+        OBDomesticVRPConsentResponse consentResponse = FRDomesticVRPConsentConverter.toOBDomesticVRPConsentResponse(frDomesticVRPConsent);
+
+        OBDomesticVRPRequest request = buildAValidOBDomesticVRPRequest(consentResponse);
+
+        OBDomesticVRPResponse rsStoreResponse = aValidOBDomesticVRPResponse(request);
+        given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(rsStoreResponse));
+        Tpp tpp = new Tpp();
+        tpp.setAuthorisationNumber("test-tpp");
+        given(tppStoreService.findByClientId(any())).willReturn(Optional.of(tpp));
+        given(vrpPaymentConsentService.getVrpPaymentConsent(request.getData().getConsentId())).willReturn(frDomesticVRPConsent);
+
+        // When
+        HttpResponse<OBErrorResponse1> response = Unirest.post(HOST + port + VRP_CONTXT_PATH)
+                .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, IDEMPOTENCY_KEY)
+                .header(OBHeaders.X_JWS_SIGNATURE, jws)
+                .header(OBHeaders.AUTHORIZATION, "Bearer " + jws)
+                .header(OBHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .header("x-vrp-limit-breach-response-simulation", "Month-Calendar")
+                .body(request)
+                .asObject(OBErrorResponse1.class);
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        List<OBError1> errors = response.getBody().getErrors();
+        Assert.assertEquals("OBError1 objects in response", 1, errors.size());
+        OBError1 error = errors.get(0);
+        Assert.assertEquals(OBRIErrorType.REQUEST_VRP_CONTROL_PARAMETERS_PAYMENT_PERIODIC_LIMIT_BREACH.getCode().getValue(),
+                            error.getErrorCode());
+        Assert.assertEquals("Unable to complete payment due to payment limit breach, periodic limit of '10.01' 'GBP' for period 'Month' 'Calendar' has been breached",
+                            error.getMessage());
+    }
+
+    @Test
+    public void simulateVrpLimitBreachResponseInvalidHeader() throws Exception {
+        // Given
+        String jws = jws("payments", OIDCConstants.GrantType.AUTHORIZATION_CODE);
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
+        FRDomesticVRPConsent frDomesticVRPConsent = aValidFRDomesticVRPConsent(
+                IntentType.DOMESTIC_VRP_PAYMENT_CONSENT.generateIntentId(),
+                ConsentStatusCode.AUTHORISED
+        );
+
+        OBDomesticVRPConsentResponse consentResponse = FRDomesticVRPConsentConverter.toOBDomesticVRPConsentResponse(frDomesticVRPConsent);
+
+        OBDomesticVRPRequest request = buildAValidOBDomesticVRPRequest(consentResponse);
+
+        OBDomesticVRPResponse rsStoreResponse = aValidOBDomesticVRPResponse(request);
+        given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(rsStoreResponse));
+        Tpp tpp = new Tpp();
+        tpp.setAuthorisationNumber("test-tpp");
+        given(tppStoreService.findByClientId(any())).willReturn(Optional.of(tpp));
+        given(vrpPaymentConsentService.getVrpPaymentConsent(request.getData().getConsentId())).willReturn(frDomesticVRPConsent);
+
+        // When
+        HttpResponse<OBErrorResponse1> response = Unirest.post(HOST + port + VRP_CONTXT_PATH)
+                .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, IDEMPOTENCY_KEY)
+                .header(OBHeaders.X_JWS_SIGNATURE, jws)
+                .header(OBHeaders.AUTHORIZATION, "Bearer " + jws)
+                .header(OBHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .header("x-vrp-limit-breach-response-simulation", "badLimitBreachValue")
+                .body(request)
+                .asObject(OBErrorResponse1.class);
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        List<OBError1> errors = response.getBody().getErrors();
+        Assert.assertEquals("OBError1 objects in response", 1, errors.size());
+        OBError1 error = errors.get(0);
+        Assert.assertEquals(ErrorCode.OBRI_REQUEST_VRP_LIMIT_BREACH_SIMULATION_INVALID_HEADER_VALUE.getValue(), error.getErrorCode());
+        Assert.assertEquals("Invalid Header value 'badLimitBreachValue', unable to simulate the payment limitation breach",
+                error.getMessage());
+    }
+
     private FRDomesticVRPConsent aValidFRDomesticVRPConsent(String consentId, ConsentStatusCode consentStatusCode) {
         FRDomesticVRPConsentDetails details = toFRDomesticVRPConsentDetails(aValidOBDomesticVRPConsentRequest());
         FRDomesticVRPConsent consent = JMockData.mock(FRDomesticVRPConsent.class);
@@ -318,7 +411,7 @@ public class DomesticVrpsApiControllerIT {
         consent.setId(consentId);
         consent.setIdempotencyKey(UUID.randomUUID().toString());
         consent.setStatus(consentStatusCode);
-        consent.setObVersion(OBVersion.v3_1_8);
+        consent.setObVersion(OBVersion.v3_1_9);
         return consent;
     }
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PeriodicLimitBreachResponseSimulatorTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/wrappper/endpoints/PeriodicLimitBreachResponseSimulatorTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.wrappper.endpoints;
+
+import com.forgerock.openbanking.aspsp.rs.wrappper.endpoints.DomesticVrpPaymentsEndpointWrapper.PeriodicLimitBreachResponseSimulator;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPConsent;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPConsentDetails;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPConsentDetailsData;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPControlParameters;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRPeriodicLimits;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRPeriodicLimits.PeriodAlignmentEnum;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRPeriodicLimits.PeriodTypeEnum;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.model.error.ErrorCode;
+import com.forgerock.openbanking.model.error.OBRIErrorType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+
+public class PeriodicLimitBreachResponseSimulatorTest {
+    private final PeriodicLimitBreachResponseSimulator limitBreachSimulator = new PeriodicLimitBreachResponseSimulator();
+
+    @Test
+    public void testSimulateLimitBreach() {
+        final FRDomesticVRPConsent consent = createConsent(createPeriodicLimit("GBP", "20", PeriodTypeEnum.WEEK, PeriodAlignmentEnum.CONSENT),
+                createPeriodicLimit("GBP", "80", PeriodTypeEnum.MONTH, PeriodAlignmentEnum.CONSENT),
+                createPeriodicLimit("GBP", "500.00", PeriodTypeEnum.YEAR, PeriodAlignmentEnum.CONSENT));
+
+        OBErrorException obErrorException = Assert.assertThrows(OBErrorException.class,
+                () -> limitBreachSimulator.processRequest("Year-Consent", consent));
+        Assert.assertEquals(OBRIErrorType.REQUEST_VRP_CONTROL_PARAMETERS_PAYMENT_PERIODIC_LIMIT_BREACH.getCode().getValue(),
+                obErrorException.getOBError().getErrorCode());
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, obErrorException.getObriErrorType().getHttpStatus());
+        Assert.assertEquals("Unable to complete payment due to payment limit breach, periodic limit of '500.00' 'GBP' for period 'Year' 'Consent' has been breached",
+                obErrorException.getMessage());
+    }
+
+    @Test
+    public void testUnsupportedHeaderValueFails() {
+        String[] badHeaderValues = {
+                null, // NOTE: it is the job of the caller to check for nulls
+                "",
+                " ",
+                "a",
+                "badValue",
+        };
+        for (String badHeaderValue : badHeaderValues) {
+            OBErrorException obErrorException = Assert.assertThrows(OBErrorException.class,
+                    () -> limitBreachSimulator.processRequest(badHeaderValue,
+                            createConsent(createPeriodicLimit("GBP", "50.0", PeriodTypeEnum.DAY, PeriodAlignmentEnum.CALENDAR))));
+            Assert.assertEquals("Error processing header value: " + badHeaderValue,
+                                ErrorCode.OBRI_REQUEST_VRP_LIMIT_BREACH_SIMULATION_INVALID_HEADER_VALUE.getValue(),
+                                obErrorException.getOBError().getErrorCode());
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, obErrorException.getObriErrorType().getHttpStatus());
+            Assert.assertEquals("Invalid Header value '" + badHeaderValue+ "', unable to simulate the payment limitation breach",
+                                obErrorException.getMessage());
+        }
+    }
+
+    @Test
+    public void testSimulateLimitBreachHeaderValueNotInConsentFails() {
+        OBErrorException obErrorException = Assert.assertThrows(OBErrorException.class,
+                () -> limitBreachSimulator.processRequest("Year-Consent",
+                        createConsent(createPeriodicLimit("EUR", "50.00", PeriodTypeEnum.DAY, PeriodAlignmentEnum.CALENDAR),
+                                      createPeriodicLimit("EUR", "100.00", PeriodTypeEnum.MONTH, PeriodAlignmentEnum.CALENDAR))));
+        Assert.assertEquals(OBRIErrorType.REQUEST_VRP_LIMIT_BREACH_SIMULATION_NO_MATCHING_LIMIT_IN_CONSENT.getCode().getValue(),
+                obErrorException.getOBError().getErrorCode());
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, obErrorException.getObriErrorType().getHttpStatus());
+        Assert.assertEquals("No Periodic Limit found in the consent for Header value 'Year-Consent', unable to simulate the payment limitation breach",
+                obErrorException.getMessage());
+    }
+
+    @Test
+    public void testSimulateLimitBreachNoLimitsOnConsentFails() {
+        OBErrorException obErrorException = Assert.assertThrows(OBErrorException.class,
+                () -> limitBreachSimulator.processRequest("Month-Calendar", createConsent()));
+        Assert.assertEquals(OBRIErrorType.REQUEST_VRP_LIMIT_BREACH_SIMULATION_NO_MATCHING_LIMIT_IN_CONSENT.getCode().getValue(),
+                obErrorException.getOBError().getErrorCode());
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, obErrorException.getObriErrorType().getHttpStatus());
+        Assert.assertEquals("No Periodic Limit found in the consent for Header value 'Month-Calendar', unable to simulate the payment limitation breach",
+                obErrorException.getMessage());
+    }
+
+    private FRDomesticVRPConsent createConsent(FRPeriodicLimits... periodicLimits) {
+        final FRDomesticVRPConsent consent = new FRDomesticVRPConsent();
+        final FRDomesticVRPConsentDetails vrpDetails = new FRDomesticVRPConsentDetails();
+        final FRDomesticVRPConsentDetailsData data = new FRDomesticVRPConsentDetailsData();
+        final FRDomesticVRPControlParameters controlParameters = new FRDomesticVRPControlParameters();
+        if (periodicLimits != null) {
+            controlParameters.setPeriodicLimits(Arrays.asList(periodicLimits));
+        }
+        data.setControlParameters(controlParameters);
+        vrpDetails.setData(data);
+        consent.setVrpDetails(vrpDetails);
+        return consent;
+    }
+
+    private FRPeriodicLimits createPeriodicLimit(String currency, String amount, PeriodTypeEnum periodType,
+                                                 PeriodAlignmentEnum periodAlignment) {
+        final FRPeriodicLimits limit = new FRPeriodicLimits();
+        limit.setPeriodAlignment(periodAlignment);
+        limit.setPeriodType(periodType);
+        limit.setCurrency(currency);
+        limit.setAmount(amount);
+        return limit;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.4.0</ob-common.version>
-        <ob-clients.version>1.4.0</ob-clients.version>
-        <ob-jwkms.version>1.4.0</ob-jwkms.version>
-        <ob-auth.version>1.4.0</ob-auth.version>
+        <ob-common.version>1.4.1</ob-common.version>
+        <ob-clients.version>1.4.1</ob-clients.version>
+        <ob-jwkms.version>1.4.1</ob-jwkms.version>
+        <ob-auth.version>1.4.1</ob-auth.version>
         <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
         <main.basedir.license>${project.basedir}</main.basedir.license>
     </properties>


### PR DESCRIPTION
- Adding a simulator which can simulate a periodic limit breach response when the TPP requests it
- DomesticVrpApi has a new optional header: x-vrp-limit-breach-response-simulation which is used to control the simulator
- Simulator support is added for payment API versions 3.1.8 and 3.1.9

Issue: https://github.com/ForgeCloud/ob-deploy/issues/870