### PR TITLE
874: Allow multiple VRP payments for a consent

### DIFF
--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/persistence/vrp/FRDomesticVrpPaymentSubmission.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/model/openbanking/persistence/vrp/FRDomesticVrpPaymentSubmission.java
@@ -42,6 +42,12 @@ public class FRDomesticVrpPaymentSubmission implements PaymentSubmission {
     @Indexed
     public String id;
 
+    @Indexed
+    public String pispId;
+
+    @Indexed
+    public String idempotencyKey;
+
     public FRDomesticVRPRequest domesticVrpPayment;
 
     public OBDomesticVRPResponseData.StatusEnum status;

--- a/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/IdempotencyService.java
+++ b/forgerock-openbanking-uk-aspsp-common/src/main/java/com/forgerock/openbanking/common/services/openbanking/IdempotencyService.java
@@ -21,6 +21,8 @@
 package com.forgerock.openbanking.common.services.openbanking;
 
 import com.forgerock.openbanking.common.model.openbanking.persistence.payment.*;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPRequest;
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVrpPaymentSubmission;
 import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.VrpPaymentConsent;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
@@ -69,6 +71,12 @@ public class IdempotencyService {
         log.debug("Found an existing consent '{}' with the same x-idempotency-key '{}'.", existingConsent.getId(), xIdempotencyKey);
         checkIdempotencyKeyExpiry(xIdempotencyKey, existingConsent.getId(), existingConsent.getCreated());
         checkIdempotencyRequestBodyUnchanged(xIdempotencyKey, submittedRequestBody, existingConsentRequestBody.get(), existingConsent.getId());
+    }
+
+    public static void validateIdempotencyRequest(String xIdempotencyKey, FRDomesticVRPRequest newRequest, FRDomesticVrpPaymentSubmission existingSubmission) throws OBErrorResponseException {
+        log.debug("Found an existing vrpPayment '{}' with the same x-idempotency-key '{}", existingSubmission.getId(), xIdempotencyKey);
+        checkIdempotencyKeyExpiry(xIdempotencyKey, existingSubmission.getId(), new DateTime(existingSubmission.getCreated()));
+        checkIdempotencyRequestBodyUnchanged(xIdempotencyKey, newRequest, existingSubmission.getDomesticVrpPayment(), existingSubmission.getId());
     }
 
     /**

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApi.java
@@ -193,6 +193,7 @@ public interface DomesticVrpsApi {
      * Create a domestic VRP
      *
      * @param authorization An Authorisation Token as per https://tools.ietf.org/html/rfc6750 (required)
+     * @param xIdempotencyKey Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.  (required)
      * @param xJwsSignature A detached JWS signature of the body of the payload. (required)
      * @param obDomesticVRPRequest Default (required)
      * @param xFapiAuthDate The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are
@@ -238,6 +239,9 @@ public interface DomesticVrpsApi {
     ResponseEntity<OBDomesticVRPResponse> domesticVrpPost(
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours. ", required = true)
+            @RequestHeader(value = "x-idempotency-key", required = true) String xIdempotencyKey,
 
             @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -100,8 +100,11 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
 
     @Override
     /**
-     *         @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+     *             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
      *             @RequestHeader(value = "Authorization", required = true) String authorization,
+     *
+     *             @ApiParam(value = "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours. ", required = true)
+     *             @RequestHeader(value = "x-idempotency-key", required = true) String xIdempotencyKey,
      *
      *             @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
      *             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
@@ -126,8 +129,8 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
      *             @RequestHeader(value = "x-vrp-limit-breach-response-simulation", required = false) String xVrpLimitBreachResponseSimulation
      */
     public ResponseEntity<OBDomesticVRPResponse> domesticVrpPost(
-            String authorization, String xJwsSignature, OBDomesticVRPRequest obDomesticVRPRequest, String xFapiAuthDate,
-            String xFapiCustomerIpAddress, String xFapiInteractionId, String xCustomerUserAgent,
+            String authorization, String xIdempotencyKey, String xJwsSignature, OBDomesticVRPRequest obDomesticVRPRequest,
+            String xFapiAuthDate, String xFapiCustomerIpAddress, String xFapiInteractionId, String xCustomerUserAgent,
             String xVrpLimitBreachResponseSimulation,
             HttpServletRequest request, Principal principal
     ) throws OBErrorResponseException {
@@ -144,6 +147,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
         vrpPaymentsEndpointWrapper.payment(consent);
         vrpPaymentsEndpointWrapper.isAuthorizationCodeGrantType(true);
         vrpPaymentsEndpointWrapper.filters(f -> {
+            f.verifyIdempotencyKeyLength(xIdempotencyKey);
             f.verifyJwsDetachedSignature(xJwsSignature, request);
             f.validateRisk(obDomesticVRPRequest.getRisk());
             f.checkRequestAndConsentInitiationMatch(initiation, consent);

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpApiControllerTest.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/java/com/forgerock/openbanking/aspsp/rs/api/payment/v3_1_9/vrp/DomesticVrpApiControllerTest.java
@@ -117,7 +117,7 @@ public class DomesticVrpApiControllerTest {
                 new ResponseEntity(domesticVRPResponse, HttpStatus.CREATED);
         given(domesticVrpPaymentsEndpointWrapper.execute(any())).willReturn(validResponse);
         // When
-        ResponseEntity<OBDomesticVRPResponse> response = domesticVrpController.domesticVrpPost("test", "test_sig",
+        ResponseEntity<OBDomesticVRPResponse> response = domesticVrpController.domesticVrpPost("test", "idempotencyKey1", "test_sig",
                 obDomesticVRPRequest,  new DateTime().toString(),
                 "127..0.0.1", "x-fapi-interaction_id", "user-agent", null, request, principal);
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApi.java
@@ -184,6 +184,7 @@ public interface DomesticVrpsApi {
      * @param xFapiCustomerIpAddress The PSU&#39;s IP address if the PSU is currently logged in with the TPP. (optional)
      * @param xFapiInteractionId An RFC4122 UID used as a correlation id. (optional)
      * @param xCustomerUserAgent Indicates the user-agent that the PSU is using. (optional)
+     * @param clientId The PISP ID
      * @return Default response (status code 201)
      *         or Bad request (status code 400)
      *         or Unauthorized (status code 401)
@@ -236,6 +237,9 @@ public interface DomesticVrpsApi {
 
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "The PISP ID" )
+            @RequestHeader(value="x-ob-client-id", required=true) String clientId,
 
             HttpServletRequest request,
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiController.java
@@ -81,7 +81,8 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Domestic VRP payment '" + domesticVRPId + "' " +
                     "can't be found");
         }
-        Optional<FRDomesticVRPConsent> frDomesticVRPConsent = domesticVRPConsentRepository.findById(domesticVRPId);
+        final String consentId = optionalVrpPayment.get().getDomesticVrpPayment().getData().getConsentId();
+        Optional<FRDomesticVRPConsent> frDomesticVRPConsent = domesticVRPConsentRepository.findById(consentId);
         if (!frDomesticVRPConsent.isPresent()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("VRP Payment consent behind payment submission '" + domesticVRPId + "' can't be found");
         }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiController.java
@@ -207,7 +207,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
         OBDomesticVRPResponse response = new OBDomesticVRPResponse()
                 .data(
                         new OBDomesticVRPResponseData()
-                                .consentId(paymentSubmission.getId())
+                                .consentId(frDomesticVRPConsent.getId())
                                 .domesticVRPId(paymentSubmission.getId())
                                 .status(paymentSubmission.getStatus())
                                 .creationDateTime(new DateTime(paymentSubmission.getCreated()))

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApi.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApi.java
@@ -178,12 +178,14 @@ public interface DomesticVrpsApi {
      * Create a domestic VRP
      *
      * @param authorization An Authorisation Token as per https://tools.ietf.org/html/rfc6750 (required)
+     * @param xIdempotencyKey Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours.  (required)
      * @param xJwsSignature A detached JWS signature of the body of the payload. (required)
      * @param obDomesticVRPRequest Default (required)
      * @param xFapiAuthDate The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC (optional)
      * @param xFapiCustomerIpAddress The PSU&#39;s IP address if the PSU is currently logged in with the TPP. (optional)
      * @param xFapiInteractionId An RFC4122 UID used as a correlation id. (optional)
      * @param xCustomerUserAgent Indicates the user-agent that the PSU is using. (optional)
+     * @param clientId The PISP ID
      * @return Default response (status code 201)
      *         or Bad request (status code 400)
      *         or Unauthorized (status code 401)
@@ -218,6 +220,9 @@ public interface DomesticVrpsApi {
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
+            @ApiParam(value = "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours. ", required = true)
+            @RequestHeader(value = "x-idempotency-key", required = true) String xIdempotencyKey,
+
             @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
@@ -236,6 +241,9 @@ public interface DomesticVrpsApi {
 
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "The PISP ID" )
+            @RequestHeader(value="x-ob-client-id", required=true) String clientId,
 
             HttpServletRequest request,
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -85,7 +85,8 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Domestic VRP payment '" + domesticVRPId + "' " +
                     "can't be found");
         }
-        Optional<FRDomesticVRPConsent> frDomesticVRPConsent = domesticVRPConsentRepository.findById(domesticVRPId);
+        final String consentId = optionalVrpPayment.get().getDomesticVrpPayment().getData().getConsentId();
+        Optional<FRDomesticVRPConsent> frDomesticVRPConsent = domesticVRPConsentRepository.findById(consentId);
         if (!frDomesticVRPConsent.isPresent()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("VRP Payment consent behind payment submission '" + domesticVRPId + "' can't be found");
         }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -20,7 +20,6 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1_9.vrp;
 
-import com.forgerock.openbanking.aspsp.rs.store.repository.IdempotentRepositoryAdapter;
 import com.forgerock.openbanking.aspsp.rs.store.repository.vrp.DomesticVRPConsentRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.vrp.FRDomesticVrpPaymentSubmissionRepository;
 import com.forgerock.openbanking.aspsp.rs.store.utils.VersionPathExtractor;
@@ -38,8 +37,6 @@ import com.forgerock.openbanking.model.error.OBRIErrorType;
 import com.forgerock.openbanking.repositories.TppRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
-import org.joda.time.Duration;
-import org.joda.time.ReadableDuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -223,7 +223,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
         OBDomesticVRPResponse response = new OBDomesticVRPResponse()
                 .data(
                         new OBDomesticVRPResponseData()
-                                .consentId(paymentSubmission.getDomesticVrpPayment().getData().getConsentId())
+                                .consentId(frDomesticVRPConsent.getId())
                                 .domesticVRPId(paymentSubmission.getId())
                                 .status(paymentSubmission.getStatus())
                                 .creationDateTime(new DateTime(paymentSubmission.getCreated()))

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/vrp/FRDomesticVrpPaymentSubmissionRepository.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/main/java/com/forgerock/openbanking/aspsp/rs/store/repository/vrp/FRDomesticVrpPaymentSubmissionRepository.java
@@ -20,8 +20,14 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.repository.vrp;
 
+import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVRPConsent;
 import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDomesticVrpPaymentSubmission;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface FRDomesticVrpPaymentSubmissionRepository extends MongoRepository<FRDomesticVrpPaymentSubmission, String> {
+
+    Optional<FRDomesticVrpPaymentSubmission> findByIdempotencyKeyAndPispId(@Param("idempotencyKey") String idempotencyKey, @Param("pispId") String pispId);
 }

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiControllerIT.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiControllerIT.java
@@ -33,6 +33,7 @@ import com.forgerock.openbanking.common.model.openbanking.persistence.vrp.FRDome
 import com.forgerock.openbanking.common.model.version.OBVersion;
 import com.forgerock.openbanking.integration.test.support.SpringSecForTest;
 import com.forgerock.openbanking.model.OBRIRole;
+import com.forgerock.openbanking.repositories.TppRepository;
 import com.github.jsonzou.jmockdata.JMockData;
 import kong.unirest.HttpResponse;
 import kong.unirest.JacksonObjectMapper;
@@ -45,6 +46,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,11 +54,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.org.openbanking.OBHeaders;
 import uk.org.openbanking.datamodel.vrp.*;
 
-import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.PaymentTestHelper.MOCK_CLIENT_ID;
+import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.payment.v3_1.PaymentTestHelper.setupMockTpp;
 import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.testsupport.domain.FRAccountIdentifierTestDataFactory.aValidFRAccountIdentifier;
 import static com.forgerock.openbanking.aspsp.rs.store.api.openbanking.testsupport.domain.FRRiskTestDataFactory.aValidFRRisk;
 import static com.forgerock.openbanking.common.services.openbanking.converter.vrp.FRDomesticVRPConsentConverter.toFRDomesticVRPConsentDetails;
@@ -90,6 +94,9 @@ public class DomesticVrpsApiControllerIT {
     @Autowired
     private SpringSecForTest springSecForTest;
 
+    @MockBean
+    private TppRepository tppRepository;
+
     @Before
     public void setUp() {
         Unirest.config().setObjectMapper(new JacksonObjectMapper(objectMapper)).verifySsl(false);
@@ -97,6 +104,8 @@ public class DomesticVrpsApiControllerIT {
 
     @Test
     public void createVrpPaymentSubmission() throws UnirestException {
+        setupMockTpp(tppRepository);
+
         // Given
         springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
         OBDomesticVRPRequest request = aValidOBDomesticVRPRequest();
@@ -108,7 +117,6 @@ public class DomesticVrpsApiControllerIT {
         HttpResponse<OBDomesticVRPResponse> response = Unirest.post(RS_STORE_URL + port + CONTEXT_PATH)
                 .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                 .header(OBHeaders.AUTHORIZATION, "token")
-                .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                 .header(OBHeaders.X_JWS_SIGNATURE, "x-jws-signature")
                 .header("x-ob-client-id", MOCK_CLIENT_ID)
                 .header(OBHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
@@ -126,10 +134,54 @@ public class DomesticVrpsApiControllerIT {
         FRDomesticVrpPaymentSubmission paymentSubmission = paymentSubmissionRepository.findById(
                 vrpResponse.getData().getConsentId()
         ).get();
-        assertThat(paymentSubmission.getId()).isEqualTo(consent.getId());
-        assertThat(paymentSubmission.getId()).isEqualTo(request.getData().getConsentId());
+        assertThat(paymentSubmission.getId()).isNotNull();
+        assertThat(paymentSubmission.getDomesticVrpPayment().getData().getConsentId()).isEqualTo(request.getData().getConsentId());
         assertThat(vrpResponse.getData().getStatus()).isEqualTo(OBDomesticVRPResponseData.StatusEnum.PENDING);
         assertThat(paymentSubmission.getStatus()).isEqualTo(vrpResponse.getData().getStatus());
+    }
+
+    @Test
+    public void createVrpPaymentSubmissionMultiplePerConsent() throws UnirestException {
+        // Given
+        setupMockTpp(tppRepository);
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        OBDomesticVRPRequest request = aValidOBDomesticVRPRequest();
+        final String consentId = request.getData().getConsentId();
+        saveFRConsent(consentId, FRReadRefundAccount.YES, ConsentStatusCode.AUTHORISED);
+
+        // When
+        final int numPayments = 10;
+        final Set<String> domesticVrpIds = new HashSet<>();
+        for (int i = 0; i < numPayments; i++) {
+            // Submit the same payment multiple times
+            HttpResponse<OBDomesticVRPResponse> response = Unirest.post(RS_STORE_URL + port + CONTEXT_PATH)
+                    .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
+                    .header(OBHeaders.AUTHORIZATION, "token")
+                    .header(OBHeaders.X_JWS_SIGNATURE, "x-jws-signature")
+                    .header("x-ob-client-id", MOCK_CLIENT_ID)
+                    .header(OBHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
+                    .body(request)
+                    .asObject(OBDomesticVRPResponse.class);
+
+            // Then
+            log.debug("Response {}:{}  {}", response.getStatus(), response.getStatusText(), response.getBody());
+            if (response.getParsingError().isPresent()) {
+                log.error("Parsing error", response.getParsingError().get());
+            }
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value());
+            OBDomesticVRPResponse vrpResponse = response.getBody();
+            FRDomesticVrpPaymentSubmission paymentSubmission = paymentSubmissionRepository.findById(
+                    vrpResponse.getData().getConsentId()).get();
+            assertThat(paymentSubmission.getId()).isEqualTo(vrpResponse.getData().getDomesticVRPId());
+            domesticVrpIds.add(vrpResponse.getData().getDomesticVRPId());
+
+            assertThat(paymentSubmission.getDomesticVrpPayment().getData().getConsentId()).isEqualTo(consentId);
+            assertThat(vrpResponse.getData().getStatus()).isEqualTo(OBDomesticVRPResponseData.StatusEnum.PENDING);
+            assertThat(paymentSubmission.getStatus()).isEqualTo(vrpResponse.getData().getStatus());
+        }
+        // Verify all ids were unique
+        assertThat(domesticVrpIds.size()).isEqualTo(numPayments);
     }
 
     @Test

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiControllerIT.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/src/test/java/com/forgerock/openbanking/aspsp/rs/store/api/openbanking/payment/v3_1_8/vrp/DomesticVrpsApiControllerIT.java
@@ -132,7 +132,7 @@ public class DomesticVrpsApiControllerIT {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value());
         OBDomesticVRPResponse vrpResponse = response.getBody();
         FRDomesticVrpPaymentSubmission paymentSubmission = paymentSubmissionRepository.findById(
-                vrpResponse.getData().getConsentId()
+                vrpResponse.getData().getDomesticVRPId()
         ).get();
         assertThat(paymentSubmission.getId()).isNotNull();
         assertThat(paymentSubmission.getDomesticVrpPayment().getData().getConsentId()).isEqualTo(request.getData().getConsentId());
@@ -172,7 +172,7 @@ public class DomesticVrpsApiControllerIT {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value());
             OBDomesticVRPResponse vrpResponse = response.getBody();
             FRDomesticVrpPaymentSubmission paymentSubmission = paymentSubmissionRepository.findById(
-                    vrpResponse.getData().getConsentId()).get();
+                    vrpResponse.getData().getDomesticVRPId()).get();
             assertThat(paymentSubmission.getId()).isEqualTo(vrpResponse.getData().getDomesticVRPId());
             domesticVrpIds.add(vrpResponse.getData().getDomesticVRPId());
 


### PR DESCRIPTION
Bug fix to allow multiple VRP payments to be made for a single consent, the fix is being made to v3.1.8 and v3.1.9 implementations

- Using Mongo to generate the id for the FRDomesticVrpPaymentSubmission (rather than using the consentId), and returning this value as domesticVRPId
- v3.1.9 - add missing x-idempotency-key header to the API calls in order to implement idempotency
- v3.1.8 - no idempotency support as the header is not in the OBIE spec, for consistency with v3.1.9 logic we generate a unique idempotencyKey value internally for this version

Issue: https://github.com/ForgeCloud/ob-deploy/issues/874