### PR TITLE
889: Enabling VRP validation by default

### DIFF
--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/RSEndpointWrapperService.java
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/main/java/com/forgerock/openbanking/aspsp/rs/wrappper/RSEndpointWrapperService.java
@@ -112,7 +112,7 @@ public class RSEndpointWrapperService {
                                     OBRisk1Validator riskValidator,
                                     DetachedJwsVerifier detachedJwsVerifier,
                                     DetachedJwsGenerator detachedJwsGenerator,
-                                    @Value("${rs.vrp.extended.validation.enable:false}") boolean enabledExtendedVrpValidation
+                                    @Value("${rs.vrp.extended.validation.enable:true}") boolean enabledExtendedVrpValidation
     ) {
         this.obHeaderCheckerService = obHeaderCheckerService;
         this.cryptoApiClient = cryptoApiClient;

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/resources/bootstrap.properties
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/resources/bootstrap.properties
@@ -9,3 +9,6 @@ spring.data.mongodb.uri=mongodb://localhost:57019/test
 
 #disable JWS signature verification here - rely on the functional tests instead
 rs.detached-signature.enable=false
+
+# Enable the extended validations for VRPs for Integration Testing
+rs.vrp.extended.validation.enable=true

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/resources/bootstrap.properties
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/src/test/resources/bootstrap.properties
@@ -9,6 +9,3 @@ spring.data.mongodb.uri=mongodb://localhost:57019/test
 
 #disable JWS signature verification here - rely on the functional tests instead
 rs.detached-signature.enable=false
-
-# Enable the extended validations for VRPs for Integration Testing
-rs.vrp.extended.validation.enable=true


### PR DESCRIPTION
Defaulting property rs.vrp.extended.validation.enable to true

Issue: https://github.com/ForgeCloud/ob-deploy/issues/889