### PR TITLE
985 fix unknown fields in account consent details page

### DIFF
--- a/forgerock-openbanking-ui/projects/bank/src/app/types/api.ts
+++ b/forgerock-openbanking-ui/projects/bank/src/app/types/api.ts
@@ -24,6 +24,7 @@ export module ApiResponses {
     merchantName: string;
     pispName: string;
     aspspName?: string;
+    aispName?: string;
     // optional
     permissions?: OBAccountPermissions[];
     expiredDate?: string;


### PR DESCRIPTION
- Fix api type to map the aispName to interpolate the value with the placeholders 'merchantName' and 'client' defined in the htlm account component template

Issue: https://github.com/ForgeCloud/ob-deploy/issues/985