### PR TITLE
Release 2.1.6

### DIFF
--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-gateway/forgerock-openbanking-uk-aspsp-as-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.7-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6-SNAPSHOT</version>
+		<version>2.1.6</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.7-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-as/forgerock-openbanking-uk-aspsp-as-manual-onboarding/forgerock-openbanking-uk-aspsp-as-manual-onboarding-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6-SNAPSHOT</version>
+		<version>2.1.6</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-uk-aspsp-common/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-common/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-gateway/forgerock-openbanking-uk-aspsp-rs-gateway-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.7-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6-SNAPSHOT</version>
+		<version>2.1.6</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.7-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator/forgerock-openbanking-uk-aspsp-rs-mock-payment-simulator-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6-SNAPSHOT</version>
+		<version>2.1.6</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.7-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-sample/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6-SNAPSHOT</version>
+		<version>2.1.6</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.7-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-portal/forgerock-openbanking-uk-aspsp-rs-mock-portal-server/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp</groupId>
 		<artifactId>forgerock-openbanking-aspsp</artifactId>
-		<version>2.1.6-SNAPSHOT</version>
+		<version>2.1.6</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-mock-store/forgerock-openbanking-uk-aspsp-rs-mock-store-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-sample/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
+++ b/forgerock-openbanking-uk-aspsp-rs/forgerock-openbanking-uk-aspsp-rs-rcs/forgerock-openbanking-uk-aspsp-rs-rcs-server/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/integration-test-support/pom.xml
+++ b/integration-test-support/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-test-support/pom.xml
+++ b/integration-test-support/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>2.1.6</version>
+    <version>2.1.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -156,7 +156,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-aspsp.git</url>
-        <tag>2.1.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.6</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -156,7 +156,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-aspsp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-aspsp.git</url>
-        <tag>HEAD</tag>
+        <tag>2.1.6</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Re-release of 2.1.5 to pick up some github workflow changes. 

Contains a fix for https://github.com/ForgeCloud/ob-deploy/issues/985

Fix to UI.

Also, the latest base image used to run the spring-application java image is now no longer pinned to an old verison. This was necessary as we needed a newer jre with a fix for this jre/cgroup v2 issue;
https://bugs.openjdk.org/browse/JDK-8230305
See https://github.com/ForgeCloud/ob-deploy/issues/982 for further details.